### PR TITLE
Fix `HelpTooltip` rendering for "refund proposal deposits"

### DIFF
--- a/pages/dao/create.tsx
+++ b/pages/dao/create.tsx
@@ -344,7 +344,7 @@ const CreateDao: NextPage = () => {
             fieldErrorMessage={fieldErrorMessage}
           />
 
-          <div className="p-6 card bordered">
+          <div className="p-6 bordered">
             <InputField
               fieldName="refund"
               label="Refund Proposal Deposits"


### PR DESCRIPTION
Resolves #104 