### PR TITLE
Add vote information on proposal view page

### DIFF
--- a/components/ProposalDetails.tsx
+++ b/components/ProposalDetails.tsx
@@ -1,8 +1,13 @@
 import Markdown from 'rich-markdown-editor'
 import VoteButtons from 'components/VoteButtons'
 import { useThemeContext } from 'contexts/theme'
-import { VoteInfo, ProposalResponse } from '@dao-dao/types/contracts/cw3-dao'
+import {
+  VoteInfo,
+  ProposalResponse,
+  ProposalTallyResponse,
+} from '@dao-dao/types/contracts/cw3-dao'
 import ProposalVotes from 'components/ProposalVotes'
+import ProposalTally from 'components/ProposalTally'
 import ProposalStatus from './ProposalStatus'
 
 function ProposalDetails({
@@ -12,6 +17,8 @@ function ProposalDetails({
   vote,
   execute,
   close,
+  tally,
+  multisig, // Needed to determine if denom or microdenom should be shown.
 }: {
   proposal: ProposalResponse
   walletAddress: string
@@ -19,6 +26,8 @@ function ProposalDetails({
   vote: (arg0: string) => Promise<void>
   execute: () => void
   close: () => void
+  tally: ProposalTallyResponse | undefined
+  multisig: boolean
 }) {
   const themeContext = useThemeContext()
 
@@ -31,7 +40,7 @@ function ProposalDetails({
   return (
     <>
       <div className="mt-2 mb-8 flex justify-between items-center">
-        <h1 className="text-3xl font-bold inline align-middle">
+        <h1 className="text-4xl font-bold inline align-middle">
           {proposal.title}
         </h1>
         <ProposalStatus status={proposal.status} />
@@ -53,7 +62,7 @@ function ProposalDetails({
         walletAddress={walletAddress}
         status={proposal.status}
       />
-      {proposal.status !== 'open' && (
+      {proposal.status !== 'open' && proposal.msgs.length > 0 && (
         <div className="flex justify-between items-center content-center my-8">
           {proposal.status === 'passed' && proposal?.msgs?.length > 0 && (
             <button
@@ -73,7 +82,8 @@ function ProposalDetails({
           )}
         </div>
       )}
-      <ProposalVotes votes={votes} />
+      {tally ? <ProposalTally tally={tally} multisig={multisig} /> : null}
+      <ProposalVotes votes={votes} walletAddress={walletAddress} />
     </>
   )
 }

--- a/components/ProposalTally.tsx
+++ b/components/ProposalTally.tsx
@@ -1,0 +1,116 @@
+import {
+  ProposalTallyResponse,
+  ThresholdResponse,
+} from '@dao-dao/types/contracts/cw3-dao'
+import {
+  CheckCircleIcon,
+  UserGroupIcon,
+  XCircleIcon,
+} from '@heroicons/react/outline'
+import { convertMicroDenomToDenom } from 'util/conversion'
+
+function makeStatBody(
+  value: Number,
+  units: string,
+  max: Number,
+  required: Number
+) {
+  return (
+    <>
+      <div className="stat-value">{`${value}${units}`}</div>
+      <div className="stat-desc">
+        <progress
+          value={`${value}`}
+          max={`${max}`}
+          className="progress progress-accent"
+        ></progress>
+      </div>
+      <div className="stat-desc">
+        Required: {required}
+        {units}
+      </div>
+    </>
+  )
+}
+
+function getThresholdStats(tally: ProposalTallyResponse) {
+  const threshold = tally.threshold
+  let body = null
+  if ('absolute_count' in threshold) {
+    body = makeStatBody(
+      parseInt(tally.total_votes),
+      '',
+      parseInt(tally.total_weight),
+      (threshold as any).absolute_count.weight
+    )
+  } else if ('absolute_percentage' in threshold) {
+    body = makeStatBody(
+      parseFloat(tally.quorum) * 100,
+      '%',
+      100,
+      (threshold as any).absolute_percentage.percentage * 100
+    )
+  } else if ('threshold_quorum' in threshold) {
+    // TODO: more info here once the UI supports creating DAOs with this type of threshold.
+    body = makeStatBody(
+      parseFloat(tally.quorum) * 100,
+      '%',
+      100,
+      (threshold as any).threshold_quorum.quorum * 100
+    )
+  } else {
+    console.log('F')
+    return null
+  }
+  return (
+    <div className="w-full stats shadow my-2">
+      <div className="stat">
+        <div className="stat-figure text-info">
+          <UserGroupIcon className="inline-block w-8 h-8 stroke-current" />
+        </div>
+        <div className="stat-title">Turnout</div>
+        {body}
+      </div>
+    </div>
+  )
+}
+
+function ProposalTally({
+  tally,
+  multisig,
+}: {
+  tally: ProposalTallyResponse
+  multisig: boolean
+}) {
+  return (
+    <>
+      <div className="w-full stats shadow mt-2">
+        <div className="stat">
+          <div className="stat-figure text-success">
+            <CheckCircleIcon className="inline-block w-8 h-8 stroke-current" />
+          </div>
+          <div className="stat-title">Yes Votes</div>
+          <div className="stat-value">
+            {multisig
+              ? tally.votes.yes
+              : convertMicroDenomToDenom(tally.votes.yes)}
+          </div>
+        </div>
+        <div className="stat">
+          <div className="stat-figure text-error">
+            <XCircleIcon className="inline-block w-8 h-8 stroke-current" />
+          </div>
+          <div className="stat-title">No Votes</div>
+          <div className="stat-value">
+            {multisig
+              ? tally.votes.no
+              : convertMicroDenomToDenom(tally.votes.no)}
+          </div>
+        </div>
+      </div>
+      {getThresholdStats(tally)}
+    </>
+  )
+}
+
+export default ProposalTally

--- a/components/ProposalVotes.tsx
+++ b/components/ProposalVotes.tsx
@@ -1,31 +1,54 @@
 import { VoteInfo } from '@dao-dao/types/contracts/cw3-dao'
+import { UserIcon } from '@heroicons/react/outline'
 
-function ProposalVotes({ votes }: { votes: VoteInfo[] }) {
+function ProposalVotes({
+  votes,
+  walletAddress,
+}: {
+  votes: VoteInfo[]
+  walletAddress: string
+}) {
   return (
-    <table className="table w-full">
-      <thead>
-        <th>Voter</th>
-        <th>Weight</th>
-        <th>Vote</th>
-      </thead>
-      <tbody>
-        {!votes ||
-          (votes.length < 1 && (
-            <tr>
-              <td className="text-center" colSpan={3}>
-                This proposal currently has no votes
-              </td>
-            </tr>
-          ))}
-        {votes.map(({ voter, weight, vote }) => (
-          <tr key={voter}>
-            <td>{voter}</td>
-            <td>{weight}</td>
-            <td>{vote}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <div className="overflow-x-auto">
+      <table className="table w-full">
+        <thead>
+          <th>Voter</th>
+          <th>Weight</th>
+          <th>Vote</th>
+        </thead>
+        <tbody>
+          {!votes ||
+            (votes.length < 1 && (
+              <tr>
+                <td className="text-center" colSpan={3}>
+                  This proposal currently has no votes
+                </td>
+              </tr>
+            ))}
+          {votes.map(({ voter, weight, vote }) => {
+            if (voter === walletAddress) {
+              return (
+                <tr key={voter}>
+                  <td>
+                    <UserIcon className="h-4 w-4 mb-1 mr-1 inline" />
+                    You
+                  </td>
+                  <td>{weight}</td>
+                  <td>{vote}</td>
+                </tr>
+              )
+            }
+            return (
+              <tr key={voter}>
+                <td>{voter}</td>
+                <td>{weight}</td>
+                <td>{vote}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
   )
 }
 

--- a/hooks/proposals.ts
+++ b/hooks/proposals.ts
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react'
 import {
   ProposalListResponse,
   ProposalResponse,
+  ProposalTallyResponse,
+  ThresholdResponse,
   VoteInfo,
 } from '@dao-dao/types/contracts/cw3-dao'
 import { useSigningClient } from 'contexts/cosmwasm'
@@ -52,6 +54,7 @@ export function useProposal(contractAddress: string, proposalId: string) {
   const { walletAddress, signingClient } = useSigningClient()
   const [loading, setLoading] = useState(false)
   const [votes, setVotes] = useState<VoteInfo[]>([])
+  const [tally, setTally] = useState<ProposalTallyResponse>()
   const [proposal, setProposal] = useState<ProposalResponse | null>(null)
   const [error, setError] = useState('')
   const [timestamp, setTimestamp] = useState(new Date())
@@ -69,11 +72,15 @@ export function useProposal(contractAddress: string, proposalId: string) {
       signingClient.queryContractSmart(contractAddress, {
         list_votes: { proposal_id: parseInt(proposalId) },
       }),
+      signingClient.queryContractSmart(contractAddress, {
+        tally: { proposal_id: parseInt(proposalId) },
+      }),
     ])
       .then((values) => {
-        const [proposal, { votes }] = values
+        const [proposal, { votes }, tally] = values
         setProposal(proposal)
         setVotes(votes)
+        setTally(tally)
         setLoading(false)
       })
       .catch((err) => {
@@ -155,6 +162,7 @@ export function useProposal(contractAddress: string, proposalId: string) {
     vote,
     execute,
     close,
+    tally,
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.27.0-rc2",
     "@cosmjs/stargate": "^0.27.0-rc2",
-    "@dao-dao/types": "^0.0.1",
+    "@dao-dao/types": "^0.0.2",
     "@heroicons/react": "^1.0.5",
     "@types/react-json-editor-ajrm": "^2.5.2",
     "daisyui": "^1.14.0",
@@ -35,7 +35,7 @@
     "react-hot-toast": "^2.1.1",
     "react-json-editor-ajrm": "^2.5.13",
     "recoil": "^0.5.2",
-    "rich-markdown-editor": "^11.20.0",
+    "rich-markdown-editor": "^11.21.3",
     "styled-components": "^5.3.3",
     "theme-change": "^2.0.2"
   },

--- a/pages/dao/[contractAddress]/proposals/[proposalId].tsx
+++ b/pages/dao/[contractAddress]/proposals/[proposalId].tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import LineAlert from 'components/LineAlert'
 import { useProposal } from 'hooks/proposals'
 import ProposalDetails from 'components/ProposalDetails'
+import Link from 'next/link'
 
 const Proposal: NextPage = () => {
   let router = useRouter()
@@ -22,6 +23,7 @@ const Proposal: NextPage = () => {
     vote,
     execute,
     close,
+    tally,
   } = useProposal(contractAddress as string, proposalId)
 
   const initialMessage: string | undefined = router.query.initialMessage as any
@@ -43,17 +45,12 @@ const Proposal: NextPage = () => {
               No proposal with that ID found.
             </div>
           ) : (
-            <div className="container mx-auto w-96 lg:w-6/12 max-w-full text-left">
-              <button
-                className="btn btn-primary float-left"
-                style={{ marginLeft: '-100px' }}
-                onClick={(e) => {
-                  e.preventDefault()
-                  router.push(`/dao/${contractAddress}/proposals`)
-                }}
-              >
-                {'< Back'}
-              </button>
+            <div className="mx-auto max-w-prose w-screen text-left">
+              <div className="justify-left flex">
+                <Link href={`/dao/${contractAddress}/proposals`}>
+                  <a className="link">{'< Back'}</a>
+                </Link>
+              </div>
 
               <ProposalDetails
                 proposal={proposal}
@@ -62,6 +59,8 @@ const Proposal: NextPage = () => {
                 vote={vote}
                 execute={execute}
                 close={close}
+                tally={tally}
+                multisig={false}
               />
 
               {error && (

--- a/pages/dao/[contractAddress]/proposals/create.tsx
+++ b/pages/dao/[contractAddress]/proposals/create.tsx
@@ -25,6 +25,7 @@ const ProposalCreate: NextPage = () => {
     const propose = messageForProposal(proposal, contractAddress)
     const memo = memoForProposal(proposal)
     try {
+      console.log(JSON.stringify(propose))
       const response = await signingClient?.execute(
         walletAddress,
         contractAddress,

--- a/pages/multisig/[contractAddress]/proposals/[proposalId].tsx
+++ b/pages/multisig/[contractAddress]/proposals/[proposalId].tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router'
 import LineAlert from 'components/LineAlert'
 import { useProposal } from 'hooks/proposals'
 import ProposalDetails from 'components/ProposalDetails'
+import Link from 'next/link'
 
 const Proposal: NextPage = () => {
   const router = useRouter()
@@ -21,6 +22,7 @@ const Proposal: NextPage = () => {
     vote,
     execute,
     close,
+    tally,
   } = useProposal(contractAddress, proposalId)
 
   return (
@@ -32,17 +34,13 @@ const Proposal: NextPage = () => {
               No proposal with that ID found.
             </div>
           ) : (
-            <div className="container mx-auto w-96 lg:w-6/12 max-w-full text-left">
-              <button
-                className="btn btn-primary float-left"
-                style={{ marginLeft: '-100px' }}
-                onClick={(e) => {
-                  e.preventDefault()
-                  router.push(`/multisig/${contractAddress}/proposals`)
-                }}
-              >
-                {'< Back'}
-              </button>
+            <div className="mx-auto max-w-prose w-screen text-left">
+              <div className="justify-left flex">
+                <Link href={`/dao/${contractAddress}/proposals`}>
+                  <a className="link">{'< Back'}</a>
+                </Link>
+              </div>
+
               <ProposalDetails
                 proposal={proposal}
                 walletAddress={walletAddress}
@@ -50,6 +48,8 @@ const Proposal: NextPage = () => {
                 vote={vote}
                 execute={execute}
                 close={close}
+                tally={tally}
+                multisig={false}
               />
 
               {error && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,10 +508,10 @@
   resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.27.0-rc2.tgz#58717efdf6e9a6c840c874fd957995498f6f93e9"
   integrity sha512-GphNKb87sfpQI14EFKu062xzitczJvY/6c0ELQnuBo+4geIUGSVeJ7g1uOzQ+ki/nb6JbVMo1sR5Z37N9olVrg==
 
-"@dao-dao/types@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@dao-dao/types/-/types-0.0.1.tgz#458a82ba25225f491f1555da71578718b4e6034b"
-  integrity sha512-YV1J4xy/19RiXjzSWJWkgp2Qasn60mX83xHVbi16cRMaOW5Gn2nE+8pezOYQuEIWRiReF0BwvcJXsJaThiSrjg==
+"@dao-dao/types@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@dao-dao/types/-/types-0.0.2.tgz#2c7017e6bed1fca0ef5c9406bfb16c436ad87dca"
+  integrity sha512-ckMejWYHU5qBBKOVLifPXaWorTn6DelBUujvKNe0HBJkTcfmQerYDcNMN4dd1bKTJ2Q5TXWzkLwBtS4ShB458A==
   dependencies:
     dotenv "^10.0.0"
     json-schema-to-typescript "^10.1.5"
@@ -6038,10 +6038,10 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rich-markdown-editor@^11.20.0:
-  version "11.21.1"
-  resolved "https://registry.yarnpkg.com/rich-markdown-editor/-/rich-markdown-editor-11.21.1.tgz#c96d200377ec0c62607593c4c35830f256229ec3"
-  integrity sha512-rvx2RhMUR804Bdt5gKYnHIblv0VUGR1d1uQ1fr3+C5e7V5VdwGSyp7vpvrc5iFkKe7jGZYj0WOCh42AzfLCW1g==
+rich-markdown-editor@^11.21.3:
+  version "11.21.3"
+  resolved "https://registry.yarnpkg.com/rich-markdown-editor/-/rich-markdown-editor-11.21.3.tgz#9c1fc32d10e75c1adf53e7fda7d4a72be52f3363"
+  integrity sha512-XqVDfwDiGMVVtb+HUY35FQvfo97ECAe+Pgo1veFiYiL5f9Jfp9zuF6fOK5eze9h8rApBsgD9iVHEsA8/gyv5Jg==
   dependencies:
     copy-to-clipboard "^3.0.8"
     fuzzy-search "^3.2.1"


### PR DESCRIPTION
This adds information to the proposal view page which was made
avaliable with the `tally` query on the dao and multisig. Also does
some cleanup on the view page.

Resolves #100 and #89

Modified page looks like this:

<img width="701" alt="image" src="https://user-images.githubusercontent.com/30676292/146664121-34386bec-01d8-45cf-b0b2-a46b215b781d.png">
