### PR TITLE
Fix multisig membership check

### DIFF
--- a/hooks/multisig.ts
+++ b/hooks/multisig.ts
@@ -34,7 +34,7 @@ export function useMultisigsList(codeId: number) {
           if (sigInfo) {
             sigList.push({
               ...sigInfo,
-              member: voterInfo.weight !== '0',
+              member: voterInfo.weight && parseInt(voterInfo.weight, 10) > 0,
             })
           }
         }

--- a/pages/multisig/list.tsx
+++ b/pages/multisig/list.tsx
@@ -67,6 +67,9 @@ const MultisigList: NextPage = () => {
           </Link>
         </>
       )}
+      <h2 className="text-3xl font-bold mt-8 text-left max-w-sm w-full -mb-3">
+        Community Multisigs
+      </h2>
       {nonMemberSigs.length > 0
         ? nonMemberSigs.map((multisig, key) => (
             <MultisigListComponent


### PR DESCRIPTION
Multisigs will return null (not zero) when asked about the voting
power of an address of a non-member.

Member query result:

```
{"weight":1}
```

Non-member query result:

```
{"weght":null}
```