### PR TITLE
Clean errors returned from failed contract executions

### DIFF
--- a/components/Notifications.tsx
+++ b/components/Notifications.tsx
@@ -4,6 +4,10 @@ import { successOptions, errorOptions } from 'util/toast'
 const Notifications = () => (
   <Toaster
     toastOptions={{
+      // https://github.com/timolins/react-hot-toast/issues/110
+      style: {
+        wordBreak: 'break-all',
+      },
       success: successOptions,
       error: errorOptions,
     }}

--- a/components/ProposalEditor.tsx
+++ b/components/ProposalEditor.tsx
@@ -35,6 +35,7 @@ import MessageSelector from './MessageSelector'
 import MintEditor from './MintEditor'
 import RawEditor from './RawEditor'
 import SpendEditor from './SpendEditor'
+import { cleanChainError } from 'util/cleanChainError'
 
 export default function ProposalEditor({
   initialProposal,
@@ -376,7 +377,7 @@ export default function ProposalEditor({
               </button>
               {error && (
                 <div className="mt-8">
-                  <LineAlert variant="error" msg={error} />
+                  <LineAlert variant="error" msg={cleanChainError(error)} />
                 </div>
               )}
             </form>

--- a/pages/dao/[contractAddress]/proposals/[proposalId].tsx
+++ b/pages/dao/[contractAddress]/proposals/[proposalId].tsx
@@ -6,6 +6,7 @@ import LineAlert from 'components/LineAlert'
 import { useProposal } from 'hooks/proposals'
 import ProposalDetails from 'components/ProposalDetails'
 import Link from 'next/link'
+import { cleanChainError } from 'util/cleanChainError'
 
 const Proposal: NextPage = () => {
   let router = useRouter()
@@ -54,7 +55,11 @@ const Proposal: NextPage = () => {
               />
 
               {error && (
-                <LineAlert className="mt-2" variant="error" msg={error} />
+                <LineAlert
+                  className="mt-2"
+                  variant="error"
+                  msg={cleanChainError(error)}
+                />
               )}
 
               {transactionHash.length > 0 && (

--- a/pages/dao/[contractAddress]/proposals/create.tsx
+++ b/pages/dao/[contractAddress]/proposals/create.tsx
@@ -11,6 +11,7 @@ import { defaultExecuteFee } from 'util/fee'
 import { successNotify } from 'util/toast'
 import { useRecoilState } from 'recoil'
 import { proposalsCreatedAtom } from 'atoms/proposals'
+import { cleanChainError } from 'util/cleanChainError'
 
 const ProposalCreate: NextPage = () => {
   const router = useRouter()

--- a/pages/dao/[contractAddress]/staking.tsx
+++ b/pages/dao/[contractAddress]/staking.tsx
@@ -11,6 +11,7 @@ import {
   convertMicroDenomToDenom,
   convertDenomToMicroDenom,
 } from 'util/conversion'
+import { cleanChainError } from 'util/cleanChainError'
 
 export function TokenBalance({
   amount,
@@ -118,12 +119,12 @@ const Staking: NextPage = () => {
       </div>
       {cw20Error && (
         <div className="mt-8">
-          <LineAlert variant="error" msg={cw20Error.message} />
+          <LineAlert variant="error" msg={cleanChainError(cw20Error.message)} />
         </div>
       )}
       {stakingError && (
         <div className="mt-8">
-          <LineAlert variant="error" msg={stakingError} />
+          <LineAlert variant="error" msg={cleanChainError(stakingError)} />
         </div>
       )}
     </WalletLoader>

--- a/pages/dao/create.tsx
+++ b/pages/dao/create.tsx
@@ -19,6 +19,7 @@ import {
 } from 'util/messagehelpers'
 import { errorNotify, successNotify } from 'util/toast'
 import { isValidName, isValidTicker } from 'util/isValidTicker'
+import { cleanChainError } from 'util/cleanChainError'
 
 const DEFAULT_MAX_VOTING_PERIOD_SECONDS = '604800'
 const DEFAULT_UNSTAKING_DURATION_SECONDS = '43200' // 12 hours
@@ -75,7 +76,7 @@ const CreateDao: NextPage = () => {
   } = useForm()
 
   useEffect(() => {
-    if (error) errorNotify(error)
+    if (error) errorNotify(cleanChainError(error))
   }, [error])
 
   function fieldErrorMessage(fieldName: string, msg?: string) {
@@ -166,6 +167,7 @@ const CreateDao: NextPage = () => {
             refund
           )
 
+    console.log('instantiating DAO with message:')
     console.log(msg)
 
     if (!signingClient) {

--- a/pages/multisig/[contractAddress]/proposals/[proposalId].tsx
+++ b/pages/multisig/[contractAddress]/proposals/[proposalId].tsx
@@ -6,6 +6,7 @@ import LineAlert from 'components/LineAlert'
 import { useProposal } from 'hooks/proposals'
 import ProposalDetails from 'components/ProposalDetails'
 import Link from 'next/link'
+import { cleanChainError } from 'util/cleanChainError'
 
 const Proposal: NextPage = () => {
   const router = useRouter()
@@ -53,7 +54,11 @@ const Proposal: NextPage = () => {
               />
 
               {error && (
-                <LineAlert className="mt-2" variant="error" msg={error} />
+                <LineAlert
+                  className="mt-2"
+                  variant="error"
+                  msg={cleanChainError(error)}
+                />
               )}
 
               {transactionHash.length > 0 && (

--- a/pages/multisig/create.tsx
+++ b/pages/multisig/create.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'next/router'
 import { C4_GROUP_CODE_ID, MULTISIG_CODE_ID } from 'util/constants'
 import { defaultExecuteFee } from 'util/fee'
 import { successNotify } from 'util/toast'
+import { cleanChainError } from 'util/cleanChainError'
 
 function validateNonEmpty(msg: InstantiateMsg, label: string) {
   const { threshold, max_voting_period, group } = msg
@@ -301,7 +302,7 @@ const CreateMultisig: NextPage = () => {
           )}
         </form>
 
-        {error && <LineAlert variant="error" msg={error} />}
+        {error && <LineAlert variant="error" msg={cleanChainError(error)} />}
       </div>
     </WalletLoader>
   )

--- a/util/cleanChainError.ts
+++ b/util/cleanChainError.ts
@@ -1,0 +1,9 @@
+// Makes an error returned by a failed smart contract execution more
+// readable.
+export function cleanChainError(error: string): string {
+  // Errors will either have a stack trace followed by the actual
+  // error or just the actual error. In either case the error in
+  // question is just the last line of the returned string.
+  const lines = error.split('\n')
+  return lines[lines.length - 1]
+}


### PR DESCRIPTION
Part of #120

Error traces are the reason for our woes but it turns out that the
format of the errors is reasonably consistent. Instead of trying to
find nodes with traces disabled and hoping they don't turn them back
on we can just take the last line of errors returned from the
chain. If the node has traces disabled this will be a no-op. Otherwise
it'll extract the error message we care about.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/30676292/148450673-f99fa8df-1f4d-4373-b4fa-f53edc3a5fd7.png">
