### PR TITLE
Fix percent selectors and +/- buttons on unstaking UI

### DIFF
--- a/components/StakingModal.tsx
+++ b/components/StakingModal.tsx
@@ -120,8 +120,13 @@ function PercentSelector({
   const getClassName = (p: number) =>
     'btn btn-sm rounded-md bg-base-300 border-none text-primary hover:bg-base-200 font-normal' +
     (active(p) ? '' : ' bg-transparent')
-  const getOnClick = (p: number) => () =>
-    setAmount((p * max).toLocaleString(undefined, { maximumFractionDigits: 6 }))
+  const getOnClick = (p: number) => () => {
+    setAmount(
+      (p * max)
+        .toLocaleString(undefined, { maximumFractionDigits: 6 })
+        .replace(',', '')
+    )
+  }
 
   return (
     <div className="grid grid-cols-5 gap-1">

--- a/pages/dao/[contractAddress]/index.tsx
+++ b/pages/dao/[contractAddress]/index.tsx
@@ -119,11 +119,11 @@ const DaoHome: NextPage = () => {
               denom={tokenInfo?.symbol}
               onPlus={() => {
                 setShowStaking(true)
-                setStakingDefault(StakingMode.Stake)
+                setStakingDefault(StakingMode.Unstake)
               }}
               onMinus={() => {
                 setShowStaking(true)
-                setStakingDefault(StakingMode.Unstake)
+                setStakingDefault(StakingMode.Stake)
               }}
             />
           </li>
@@ -136,11 +136,11 @@ const DaoHome: NextPage = () => {
               denom={tokenInfo?.symbol}
               onPlus={() => {
                 setShowStaking(true)
-                setStakingDefault(StakingMode.Unstake)
+                setStakingDefault(StakingMode.Stake)
               }}
               onMinus={() => {
                 setShowStaking(true)
-                setStakingDefault(StakingMode.Stake)
+                setStakingDefault(StakingMode.Unstake)
               }}
             />
           </li>


### PR DESCRIPTION
`toLocaleString` was inserting commas for unstaking / staking amounts that were over `999` which was causing the percent selectors to fail. This removes said commas and also fixes a little logic error in which staking modal gets displayed when you press +/-.