### PR TITLE
Make homepage work on Firefox

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -57,10 +57,12 @@ function InfoCard({
 function GradientWrapper({ children }: { children: ReactNode }) {
   return (
     <div className="overflow-x-hidden">
-      <div className="fixed top-1/4 left-1/2 -mt-[100px] -ml-[250px] animate-spin-slow">
-        <LogoNoborder width={500} height={500} />
-      </div>
-      <div className="fixed bg-gradient-radial-t-wide from-slate-500/80 via-transparent w-full h-full"></div>
+      {CSS.supports('backdrop-filter', 'blur(5px)') && (
+        <div className="fixed top-1/4 left-1/2 -mt-[100px] -ml-[250px] animate-spin-slow -z-20">
+          <LogoNoborder width={500} height={500} />
+        </div>
+      )}
+      <div className="fixed bg-gradient-radial-t-wide from-slate-500/80 via-transparent w-full h-full -z-10"></div>
       <div className="bg-clip-padding backdrop-filter backdrop-blur-3xl bg-opacity-60 w-screen h-screen flex flex-col justify-between">
         {children}
       </div>


### PR DESCRIPTION
Firefox [does
not](https://bugzilla.mozilla.org/show_bug.cgi?id=1578503) support
background blur. This change removes the spinning logo for browsers
that are also in this camp.

Resolves #186