### PR TITLE
Correctly handle membership updates caused by token staking / unstaking

### DIFF
--- a/components/ContractView.tsx
+++ b/components/ContractView.tsx
@@ -10,7 +10,7 @@ import {
   convertFromMicroDenom,
   convertMicroDenomToDenom,
 } from 'util/conversion'
-import { Logo } from './Logo'
+import { Logo, LogoNoBorder } from './Logo'
 import { ProposalList } from './ProposalList'
 
 export function GradientHero({ children }: { children: ReactNode }) {
@@ -147,19 +147,27 @@ export function BalanceCard({
   amount,
   onPlus,
   onMinus,
+  loading,
 }: {
   denom: string
   title: string
   amount: string
   onPlus: MouseEventHandler<HTMLButtonElement>
   onMinus: MouseEventHandler<HTMLButtonElement>
+  loading: boolean
 }) {
   return (
-    <div className="shadow p-6 rounded-lg w-full border border-base-300 h-28 mt-2">
+    <div className="shadow p-6 rounded-lg w-full border border-base-300 mt-2">
       <h2 className="text-sm font-mono text-secondary">{title}</h2>
-      <p className="mt-2 font-bold">
-        {amount} ${denom}
-      </p>
+      {loading ? (
+        <div className="animate-spin-medium inline-block mt-2">
+          <LogoNoBorder />
+        </div>
+      ) : (
+        <p className="mt-2 font-bold">
+          {amount} ${denom}
+        </p>
+      )}
       <div className="flex justify-end">
         <div className="btn-group">
           <button

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -39,7 +39,7 @@ export function Logo({
   )
 }
 
-export function LogoNoborder({
+export function LogoNoBorder({
   width = 28,
   height = 28,
   alt = '',

--- a/components/StakingModal.tsx
+++ b/components/StakingModal.tsx
@@ -88,7 +88,6 @@ function AmountSelector({
         </button>
         <input
           type="number"
-          defaultValue="0"
           className="appearance-none w-full pr-16 pl-16 input input-primary input-bordered bg-base-300 border-none"
           value={amount}
           onChange={onChange}
@@ -192,7 +191,7 @@ function executeUnstakeAction(
     })
     .finally(() => {
       setLoading(false)
-      toast.success(`Staked ${denomAmount} tokens`)
+      toast.success(`Unstaked ${denomAmount} tokens`)
       onDone()
     })
 }
@@ -230,7 +229,7 @@ function executeStakeAction(
     })
     .finally(() => {
       setLoading(false)
-      toast.success(`Unstaked ${denomAmount} tokens`)
+      toast.success(`Staked ${denomAmount} tokens`)
       onDone()
     })
 }
@@ -240,14 +239,18 @@ export function StakingModal({
   contractAddress,
   tokenSymbol,
   onClose,
+  beforeExecute,
+  afterExecute,
 }: {
   defaultMode: StakingMode
   contractAddress: string
   tokenSymbol: string
   onClose: MouseEventHandler<HTMLButtonElement>
+  beforeExecute: Function
+  afterExecute: Function
 }) {
   const [mode, setMode] = useState(defaultMode)
-  const [amount, setAmount] = useState('')
+  const [amount, setAmount] = useState('0')
 
   const { signingClient, walletAddress } = useSigningClient()
   const [loading, setLoading] = useState(false)
@@ -298,6 +301,7 @@ export function StakingModal({
           (loading ? ' loading' : '')
         }
         onClick={() => {
+          beforeExecute()
           if (mode === StakingMode.Stake) {
             executeStakeAction(
               amount,
@@ -308,7 +312,11 @@ export function StakingModal({
               setLoading,
               () => {
                 setAmount('0')
-                setWalletTokenBalanceUpdateCount((p) => p + 1)
+                // New staking balances will not appear until the next block has been added.
+                setTimeout(() => {
+                  setWalletTokenBalanceUpdateCount((p) => p + 1)
+                  afterExecute()
+                }, 6000)
               }
             )
           } else if (mode === StakingMode.Unstake) {
@@ -320,7 +328,11 @@ export function StakingModal({
               setLoading,
               () => {
                 setAmount('0')
-                setWalletTokenBalanceUpdateCount((p) => p + 1)
+                // New staking balances will not appear until the next block has been added.
+                setTimeout(() => {
+                  setWalletTokenBalanceUpdateCount((p) => p + 1)
+                  afterExecute()
+                }, 6500)
               }
             )
           }

--- a/pages/dao/[contractAddress]/index.tsx
+++ b/pages/dao/[contractAddress]/index.tsx
@@ -8,7 +8,7 @@ import {
 import type { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import React, { useState } from 'react'
-import { useRecoilValue } from 'recoil'
+import { useRecoilState, useRecoilValue } from 'recoil'
 import {
   daoSelector,
   isMemberSelector,
@@ -16,7 +16,12 @@ import {
   tokenConfig,
   totalStaked,
 } from 'selectors/daos'
-import { cw20Balances, nativeBalance } from 'selectors/treasury'
+import {
+  cw20Balances,
+  nativeBalance,
+  walletAddress,
+  walletTokenBalanceLoading,
+} from 'selectors/treasury'
 import { convertMicroDenomToDenom } from 'util/conversion'
 import {
   walletStakedTokenBalance,
@@ -51,6 +56,11 @@ const DaoHome: NextPage = () => {
   const govTokenBalance = useRecoilValue(walletTokenBalance(daoInfo?.gov_token))
   const stakedGovTokenBalance = useRecoilValue(
     walletStakedTokenBalance(daoInfo?.staking_contract)
+  )
+
+  const wallet = useRecoilValue(walletAddress)
+  const [tokenBalanceLoading, setTokenBalancesLoading] = useRecoilState(
+    walletTokenBalanceLoading(wallet)
   )
 
   const [showStaking, setShowStaking] = useState(false)
@@ -125,6 +135,7 @@ const DaoHome: NextPage = () => {
                 setShowStaking(true)
                 setStakingDefault(StakingMode.Stake)
               }}
+              loading={tokenBalanceLoading}
             />
           </li>
           <li>
@@ -142,6 +153,7 @@ const DaoHome: NextPage = () => {
                 setShowStaking(true)
                 setStakingDefault(StakingMode.Unstake)
               }}
+              loading={tokenBalanceLoading}
             />
           </li>
         </ul>
@@ -187,6 +199,8 @@ const DaoHome: NextPage = () => {
             contractAddress={contractAddress}
             tokenSymbol={tokenInfo.symbol}
             onClose={() => setShowStaking(false)}
+            beforeExecute={() => setTokenBalancesLoading(true)}
+            afterExecute={() => setTokenBalancesLoading(false)}
           />
         )}
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import {
   StarIcon,
 } from '@heroicons/react/solid'
 import { ScaleIcon } from '@heroicons/react/outline'
-import { Logo, LogoNoborder } from 'components/Logo'
+import { Logo, LogoNoBorder } from 'components/Logo'
 import ThemeToggle from 'components/ThemeToggle'
 import type { NextPage } from 'next'
 import Link from 'next/link'
@@ -58,8 +58,11 @@ function GradientWrapper({ children }: { children: ReactNode }) {
   return (
     <div className="overflow-x-hidden">
       {CSS.supports('backdrop-filter', 'blur(5px)') && (
-        <div className="fixed top-1/4 left-1/2 -mt-[100px] -ml-[250px] animate-spin-slow -z-20">
-          <LogoNoborder width={500} height={500} />
+        <div
+          className="fixed top-1/4 left-1/2 -mt-[100px] -ml-[250px] animate-spin-slow -z-20"
+          style={{ transform: 'rotate(270)' }}
+        >
+          <LogoNoBorder width={500} height={500} />
         </div>
       )}
       <div className="fixed bg-gradient-radial-t-wide from-slate-500/80 via-transparent w-full h-full -z-10"></div>

--- a/selectors/cosm.ts
+++ b/selectors/cosm.ts
@@ -5,6 +5,7 @@ import {
   SigningCosmWasmClient,
 } from '@cosmjs/cosmwasm-stargate'
 import { connectKeplr } from 'services/keplr'
+import { walletTokenBalanceUpdateCountAtom } from './treasury'
 
 const CHAIN_RPC_ENDPOINT = process.env.NEXT_PUBLIC_CHAIN_RPC_ENDPOINT || ''
 const CHAIN_ID = process.env.NEXT_PUBLIC_CHAIN_ID
@@ -57,15 +58,6 @@ export const cosmWasmSigningClient = selector({
   dangerouslyAllowMutability: true,
 })
 
-export const walletAddressSelector = selector({
-  key: 'walletAddress',
-  get: async ({ get }) => {
-    const client = get(kelprOfflineSigner)
-    const [{ address }] = await client.getAccounts()
-    return address
-  },
-})
-
 export const voterInfoSelector = selectorFamily({
   key: 'voterInfo',
   get:
@@ -77,7 +69,7 @@ export const voterInfoSelector = selectorFamily({
       walletAddress: string
     }) =>
     async ({ get }) => {
-      // const client = get(cosmWasmSigningClient)
+      get(walletTokenBalanceUpdateCountAtom(walletAddress))
       const client = get(cosmWasmClient)
       return client?.queryContractSmart(contractAddress, {
         voter: {

--- a/selectors/daos.ts
+++ b/selectors/daos.ts
@@ -1,14 +1,10 @@
-import {
-  cosmWasmClient,
-  walletAddressSelector,
-  voterInfoSelector,
-} from 'selectors/cosm'
+import { cosmWasmClient, voterInfoSelector } from 'selectors/cosm'
 import { contractsByCodeId } from 'selectors/contracts'
 import { selector, selectorFamily } from 'recoil'
 import { DAO_CODE_ID } from 'util/constants'
 import { ConfigResponse, Duration } from '@dao-dao/types/contracts/cw3-dao'
 import { TokenInfoResponse } from '@dao-dao/types/contracts/cw20-gov'
-import { walletTokenBalanceUpdateCountAtom } from './treasury'
+import { walletAddress } from './treasury'
 
 export interface MemberStatus {
   member: boolean
@@ -26,56 +22,55 @@ export const tokenConfig = selectorFamily<TokenInfoResponse, string>({
   key: 'govTokenConfig',
   get:
     (contractAddress) =>
-      async ({ get }) => {
-        const client = get(cosmWasmClient)
-        const response = await client.queryContractSmart(contractAddress, {
-          token_info: {},
-        })
-        return response
-      },
+    async ({ get }) => {
+      const client = get(cosmWasmClient)
+      const response = await client.queryContractSmart(contractAddress, {
+        token_info: {},
+      })
+      return response
+    },
 })
 
 export const totalStaked = selectorFamily<number, string>({
   key: 'totalStaked',
   get:
     (contractAddress) =>
-      async ({ get }) => {
-        const client = get(cosmWasmClient)
-        const response = await client.queryContractSmart(contractAddress, {
-          total_staked_at_height: {},
-        })
-        return Number(response.total)
-      },
+    async ({ get }) => {
+      const client = get(cosmWasmClient)
+      const response = await client.queryContractSmart(contractAddress, {
+        total_staked_at_height: {},
+      })
+      return Number(response.total)
+    },
 })
 
 export const proposalCount = selectorFamily<number, string>({
   key: 'daoProposalCount',
   get:
     (contractAddress) =>
-      async ({ get }) => {
-        const client = get(cosmWasmClient)
-        const response = await client.queryContractSmart(contractAddress, {
-          proposal_count: {},
-        })
-        return response
-      },
+    async ({ get }) => {
+      const client = get(cosmWasmClient)
+      const response = await client.queryContractSmart(contractAddress, {
+        proposal_count: {},
+      })
+      return response
+    },
 })
 
 export const isMemberSelector = selectorFamily<MemberStatus, string>({
   key: 'isMember',
   get:
     (contractAddress) =>
-      async ({ get }) => {
-        const walletAddress = get(walletAddressSelector)
-        get(walletTokenBalanceUpdateCountAtom(walletAddress))
-        const voterInfo = get(
-          voterInfoSelector({ contractAddress, walletAddress })
-        )
-        return {
-          member: voterInfo.weight && voterInfo.weight !== '0',
-          weight: voterInfo.weight,
-        }
-      },
+    async ({ get }) => {
+      const wallet = get(walletAddress)
+      const voterInfo = get(
+        voterInfoSelector({ contractAddress, walletAddress: wallet })
+      )
+      return {
+        member: voterInfo.weight && voterInfo.weight !== '0',
+        weight: voterInfo.weight,
+      }
+    },
 })
 
 export const daosSelector = selector<DaoListType[]>({
@@ -99,25 +94,25 @@ export const daoSelector = selectorFamily<ConfigResponse, string>({
   key: 'dao',
   get:
     (address: string) =>
-      async ({ get }) => {
-        const client = get(cosmWasmClient)
-        const response = await client.queryContractSmart(address, {
-          get_config: {},
-        })
-        return response
-      },
+    async ({ get }) => {
+      const client = get(cosmWasmClient)
+      const response = await client.queryContractSmart(address, {
+        get_config: {},
+      })
+      return response
+    },
 })
 
 export const unstakingDuration = selectorFamily<Duration, string>({
   key: 'govTokenUnstakingDuration',
   get:
     (address: string) =>
-      async ({ get }) => {
-        const client = get(cosmWasmClient)
-        const response = await client.queryContractSmart(address, {
-          unstaking_duration: {},
-        })
-        // Returns null of there is no unstaking duration.
-        return response.duration || { time: 0 }
-      },
+    async ({ get }) => {
+      const client = get(cosmWasmClient)
+      const response = await client.queryContractSmart(address, {
+        unstaking_duration: {},
+      })
+      // Returns null of there is no unstaking duration.
+      return response.duration || { time: 0 }
+    },
 })

--- a/selectors/treasury.ts
+++ b/selectors/treasury.ts
@@ -67,7 +67,7 @@ export const walletAddress = selector({
   get: async ({ get }) => {
     const client = get(kelprOfflineSigner)
     const [{ address }] = await client.getAccounts()
-    return address
+    return address as string
   },
 })
 
@@ -76,6 +76,13 @@ export const walletAddress = selector({
 export const walletTokenBalanceUpdateCountAtom = atomFamily<number, string>({
   key: 'walletTokenBalanceUpdateCount',
   default: 0,
+})
+
+// Tracks if the token balance for a wallet is loading. This will be
+// true when we are staking / unstaking tokens.
+export const walletTokenBalanceLoading = atomFamily<boolean, string>({
+  key: 'walletTokenBalanceLoading',
+  default: false,
 })
 
 export const walletTokenBalance = selectorFamily({
@@ -87,6 +94,7 @@ export const walletTokenBalance = selectorFamily({
 
       const wallet = get(walletAddress)
       get(walletTokenBalanceUpdateCountAtom(wallet))
+
       const response = (await client.queryContractSmart(tokenAddress, {
         balance: { address: wallet },
       })) as any
@@ -106,9 +114,11 @@ export const walletStakedTokenBalance = selectorFamily({
 
       const wallet = get(walletAddress)
       get(walletTokenBalanceUpdateCountAtom(wallet))
+
       const response = (await client.queryContractSmart(tokenAddress, {
         staked_balance_at_height: { address: wallet },
       })) as any
+
       return {
         amount: response.balance,
         address: tokenAddress,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,8 @@ module.exports = {
           'radial-gradient(80% 40% at top, var(--tw-gradient-stops))',
       },
       animation: {
-        'spin-slow': 'spin 10s linear infinite',
+        'spin-slow': 'spin 10s cubic-bezier(.6,1.15,.89,.81) infinite',
+        'spin-medium': 'spin 3s cubic-bezier(.6,1.15,.89,.81) infinite',
       },
     },
   },


### PR DESCRIPTION
Staked token balances are counted based on token balance at the
beginning of the block. To get the staked token balance after we have
staked or unstaked tokens we need to wait for one block.

This has implications for determining if a user is a member. We now
properly handle the case where a user stakes some tokens and then
attempts to vote on a proposal as we will display a loading indicator
until the we have learned the most up-to-date staking balance.