### PR TITLE
Add UI for DAOs with nonzero unstaking durations

### DIFF
--- a/components/Claims.tsx
+++ b/components/Claims.tsx
@@ -1,0 +1,155 @@
+import { Duration } from '@dao-dao/types/contracts/cw3-dao'
+import { Claim } from '@dao-dao/types/contracts/stake-cw20'
+import { CheckIcon, CurrencyDollarIcon } from '@heroicons/react/outline'
+import { MouseEventHandler } from 'react'
+import { useRecoilValue } from 'recoil'
+import { unstakingDuration } from 'selectors/daos'
+import { getBlockHeight, walletClaims } from 'selectors/treasury'
+import { convertMicroDenomToDenom } from 'util/conversion'
+import { LogoNoBorder } from './Logo'
+import { humanReadableDuration } from './StakingModal'
+
+export function claimAvaliable(claim: Claim, blockHeight: number) {
+  if ('at_height' in claim.release_at) {
+    return blockHeight >= claim.release_at.at_height
+  } else if ('at_time' in claim.release_at) {
+    const currentTimeNs = new Date().getTime() * 1000000
+    return currentTimeNs >= Number(claim.release_at.at_time)
+  }
+
+  // Unreachable.
+  return true
+}
+
+function claimDurationRemaining(claim: Claim, blockHeight: number): Duration {
+  if (claimAvaliable(claim, blockHeight)) {
+    return { time: 0 }
+  }
+  if ('at_height' in claim.release_at) {
+    const releaseBlock = claim.release_at.at_height
+    return { height: releaseBlock - blockHeight }
+  } else if ('at_time' in claim.release_at) {
+    const currentTimeNs = new Date().getTime() * 1000000
+    return {
+      time: (Number(claim.release_at.at_time) - currentTimeNs) / 1000000000, // To seconds.
+    }
+  }
+
+  // Unreachable.
+  return { time: 0 }
+}
+
+function ClaimListItem({
+  claim,
+  unstakingDuration,
+  blockHeight,
+  tokenSymbol,
+}: {
+  claim: Claim
+  unstakingDuration: Duration
+  blockHeight: number
+  tokenSymbol: string
+}) {
+  const avaliable = claimAvaliable(claim, blockHeight)
+  const durationForHumans = humanReadableDuration(unstakingDuration)
+  const durationRemaining = claimDurationRemaining(claim, blockHeight)
+  const durationRemainingForHumans = humanReadableDuration(durationRemaining)
+
+  return (
+    <div className="my-2">
+      {avaliable ? (
+        <p className="text-secondary font-mono text-sm">
+          Avaliable
+          <CheckIcon className="inline h-4 ml-1" />
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2 text-secondary font-mono text-sm">
+          <p>{durationRemainingForHumans} left</p>
+          <p>/ {durationForHumans}</p>
+        </div>
+      )}
+      <p className="mt-1">
+        {convertMicroDenomToDenom(claim.amount)} ${tokenSymbol}
+      </p>
+    </div>
+  )
+}
+
+export function ClaimsPendingList({
+  stakingAddress,
+  tokenSymbol,
+}: {
+  stakingAddress: string
+  tokenSymbol: string
+}) {
+  const unstakeDuration = useRecoilValue(unstakingDuration(stakingAddress))
+  const blockHeight = useRecoilValue(getBlockHeight)
+  const claimsPending = useRecoilValue(
+    walletClaims(stakingAddress)
+  ).claims.filter((c) => !claimAvaliable(c, blockHeight))
+
+  return (
+    <>
+      {claimsPending.length ? (
+        <>
+          <h2 className="mt-4">Currently unstaking</h2>
+          <ul className="ml-1">
+            {claimsPending.map((claim, idx) => {
+              return (
+                <ClaimListItem
+                  key={idx}
+                  claim={claim}
+                  blockHeight={blockHeight}
+                  unstakingDuration={unstakeDuration}
+                  tokenSymbol={tokenSymbol}
+                />
+              )
+            })}
+          </ul>
+        </>
+      ) : null}
+    </>
+  )
+}
+
+export function ClaimAvaliableCard({
+  stakingAddress,
+  tokenSymbol,
+  onClaim,
+  loading,
+}: {
+  stakingAddress: string
+  tokenSymbol: string
+  onClaim: MouseEventHandler<HTMLButtonElement>
+  loading: boolean
+}) {
+  const blockHeight = useRecoilValue(getBlockHeight)
+  const claimsAvaliable = useRecoilValue(walletClaims(stakingAddress))
+    .claims.filter((c) => claimAvaliable(c, blockHeight))
+    .reduce((p, n) => p + Number(n.amount), 0)
+
+  return (
+    <div className="shadow p-6 rounded-lg w-full border border-base-300 mt-2">
+      <h2 className="text-sm font-mono text-secondary">
+        Unclaimed (unstaked ${tokenSymbol})
+      </h2>
+      {loading ? (
+        <div className="animate-spin-medium inline-block mt-2">
+          <LogoNoBorder />
+        </div>
+      ) : (
+        <p className="mt-2 font-bold">
+          {convertMicroDenomToDenom(claimsAvaliable)} ${tokenSymbol}
+        </p>
+      )}
+      <div className="flex justify-end">
+        <button
+          className="btn-outline btn btn-xs border-secondary normal-case"
+          onClick={onClaim}
+        >
+          Claim
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/ContractView.tsx
+++ b/components/ContractView.tsx
@@ -262,15 +262,13 @@ export function BalanceCard({
   denom,
   title,
   amount,
-  onPlus,
-  onMinus,
+  onManage,
   loading,
 }: {
   denom: string
   title: string
   amount: string
-  onPlus: MouseEventHandler<HTMLButtonElement>
-  onMinus: MouseEventHandler<HTMLButtonElement>
+  onManage: MouseEventHandler<HTMLButtonElement>
   loading: boolean
 }) {
   return (
@@ -286,20 +284,12 @@ export function BalanceCard({
         </p>
       )}
       <div className="flex justify-end">
-        <div className="btn-group">
-          <button
-            className="btn-outline btn btn-xs btn-square border-secondary"
-            onClick={onPlus}
-          >
-            +
-          </button>
-          <button
-            className="btn-outline btn btn-xs btn-square border-secondary"
-            onClick={onMinus}
-          >
-            -
-          </button>
-        </div>
+        <button
+          className="btn btn-xs normal-case font-normal rounded-md"
+          onClick={onManage}
+        >
+          Manage
+        </button>
       </div>
     </div>
   )

--- a/components/StakingModal.tsx
+++ b/components/StakingModal.tsx
@@ -33,10 +33,20 @@ import { defaultExecuteFee } from 'util/fee'
 export enum StakingMode {
   Stake,
   Unstake,
+  Claim,
 }
 
 function stakingModeString(mode: StakingMode) {
-  return mode === StakingMode.Stake ? 'stake' : 'unstake'
+  switch (mode) {
+    case StakingMode.Stake:
+      return 'stake'
+    case StakingMode.Unstake:
+      return 'unstake'
+    case StakingMode.Claim:
+      return 'claim'
+    default:
+      return 'internal error'
+  }
 }
 
 function ModeButton({
@@ -155,7 +165,7 @@ function durationIsNonZero(d: Duration) {
   return d.time !== 0
 }
 
-function humanReadableDuration(d: Duration) {
+export function humanReadableDuration(d: Duration) {
   if ('height' in d) {
     return `${d.height} blocks`
   }
@@ -234,10 +244,42 @@ function executeStakeAction(
     })
 }
 
+function executeClaimAction(
+  denomAmount: number,
+  stakingAddress: string,
+  signingClient: SigningCosmWasmClient | null,
+  walletAddress: string,
+  setLoading: SetterOrUpdater<boolean>,
+  onDone: Function
+) {
+  if (!signingClient) {
+    toast.error('Please connect your wallet')
+  }
+  setLoading(true)
+  signingClient
+    ?.execute(
+      walletAddress,
+      stakingAddress,
+      {
+        claim: {},
+      },
+      defaultExecuteFee
+    )
+    .catch((err) => {
+      toast.error(cleanChainError(err.message))
+    })
+    .finally(() => {
+      setLoading(false)
+      toast.success(`Claimed ${denomAmount} tokens`)
+      onDone()
+    })
+}
+
 export function StakingModal({
   defaultMode,
   contractAddress,
   tokenSymbol,
+  claimAmount,
   onClose,
   beforeExecute,
   afterExecute,
@@ -245,6 +287,7 @@ export function StakingModal({
   defaultMode: StakingMode
   contractAddress: string
   tokenSymbol: string
+  claimAmount: number
   onClose: MouseEventHandler<HTMLButtonElement>
   beforeExecute: Function
   afterExecute: Function
@@ -272,6 +315,7 @@ export function StakingModal({
   const maxTx = Number(
     mode === StakingMode.Stake ? govTokenBalance : stakedGovTokenBalance
   )
+  const canClaim = claimAmount !== 0
 
   const invalidAmount = (): string => {
     if (amount === '') {
@@ -292,7 +336,7 @@ export function StakingModal({
   const error = invalidAmount() || walletDisconnected()
   const ready = !error
 
-  const ActionButton = () => {
+  const ActionButton = ({ ready }: { ready: boolean }) => {
     return (
       <button
         className={
@@ -335,6 +379,20 @@ export function StakingModal({
                 }, 6500)
               }
             )
+          } else if (mode === StakingMode.Claim) {
+            executeClaimAction(
+              convertMicroDenomToDenom(claimAmount),
+              daoInfo.staking_contract,
+              signingClient,
+              walletAddress,
+              setLoading,
+              () => {
+                setTimeout(() => {
+                  setWalletTokenBalanceUpdateCount((p) => p + 1)
+                  afterExecute()
+                }, 6500)
+              }
+            )
           }
         }}
       >
@@ -369,54 +427,90 @@ export function StakingModal({
           >
             Unstaking
           </ModeButton>
+          {canClaim && (
+            <ModeButton
+              onClick={() => setMode(StakingMode.Claim)}
+              active={mode === StakingMode.Claim}
+            >
+              Claiming
+            </ModeButton>
+          )}
         </div>
       </div>
       <hr />
-      <div className="py-3 px-6 flex flex-col mt-3">
-        <h2 className="font-medium mb-3">Choose your token amount</h2>
-        <AmountSelector
-          amount={amount}
-          onIncrease={() => setAmount((a) => (Number(a) + 1).toString())}
-          onDecrease={() => setAmount((a) => (Number(a) - 1).toString())}
-          onChange={(e) => setAmount(e?.target?.value)}
-          max={maxTx}
-        />
-        {Number(amount) > maxTx && (
-          <span className="text-xs text-error mt-1 ml-1">
-            Can{"'"}t {stakingModeString(mode)} more ${tokenSymbol} than you own
-          </span>
-        )}
-        <span className="text-xs text-secondary font-mono mt-2">
-          Max available {maxTx} ${tokenSymbol}
-        </span>
-        <div className="mt-3">
-          <PercentSelector
-            amount={Number(amount)}
-            setAmount={setAmount}
-            max={maxTx}
-          />
-        </div>
-      </div>
-      {mode === StakingMode.Unstake && durationIsNonZero(unstakeDuration) && (
+      {mode !== StakingMode.Claim && (
         <>
-          <hr />
-          <div className="py-3 px-6 mt-3">
-            <h2 className="font-medium text-md">
-              Unstaking period: {humanReadableDuration(unstakeDuration)}
-            </h2>
-            <p className="text-sm mt-3">
-              There will be {humanReadableDuration(unstakeDuration)} between the
-              time you decide to unstake your tokens and the time you can redeem
-              them.
-            </p>
+          <div className="py-3 px-6 flex flex-col mt-3">
+            <h2 className="font-medium mb-3">Choose your token amount</h2>
+            <AmountSelector
+              amount={amount}
+              onIncrease={() => setAmount((a) => (Number(a) + 1).toString())}
+              onDecrease={() => setAmount((a) => (Number(a) - 1).toString())}
+              onChange={(e) => setAmount(e?.target?.value)}
+              max={maxTx}
+            />
+            {Number(amount) > maxTx && (
+              <span className="text-xs text-error mt-1 ml-1">
+                Can{"'"}t {stakingModeString(mode)} more ${tokenSymbol} than you
+                own
+              </span>
+            )}
+            <span className="text-xs text-secondary font-mono mt-2">
+              Max available {maxTx} ${tokenSymbol}
+            </span>
+            <div className="mt-3">
+              <PercentSelector
+                amount={Number(amount)}
+                setAmount={setAmount}
+                max={maxTx}
+              />
+            </div>
+          </div>
+          {mode === StakingMode.Unstake && durationIsNonZero(unstakeDuration) && (
+            <>
+              <hr className="mt-3" />
+              <div className="py-3 px-6 mt-3">
+                <h2 className="font-medium text-md">
+                  Unstaking period: {humanReadableDuration(unstakeDuration)}
+                </h2>
+                <p className="text-sm mt-3">
+                  There will be {humanReadableDuration(unstakeDuration)} between
+                  the time you decide to unstake your tokens and the time you
+                  can redeem them.
+                </p>
+              </div>
+            </>
+          )}
+          <div className="px-3 py-6 text-right">
+            <div
+              className={!ready ? 'tooltip tooltip-left' : ''}
+              data-tip={error}
+            >
+              <ActionButton ready={ready} />
+            </div>
           </div>
         </>
       )}
-      <div className="px-3 py-6 text-right">
-        <div className={!ready ? 'tooltip tooltip-left' : ''} data-tip={error}>
-          <ActionButton />
-        </div>
-      </div>
+      {mode === StakingMode.Claim && (
+        <>
+          <div className="py-3 px-6 flex flex-col mt-3">
+            <h2 className="font-medium">
+              {convertMicroDenomToDenom(claimAmount)} ${tokenSymbol} avaliable
+            </h2>
+            <p className="text-sm mt-3 mb-3">
+              Claim them to increase your voting power.
+            </p>
+            <div className="px-3 py-6 text-right">
+              <div
+                className={walletDisconnected() ? 'tooltip tooltip-left' : ''}
+                data-tip={walletDisconnected()}
+              >
+                <ActionButton ready={!walletDisconnected()} />
+              </div>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/selectors/treasury.ts
+++ b/selectors/treasury.ts
@@ -11,6 +11,7 @@ import {
   kelprOfflineSigner,
 } from 'selectors/cosm'
 import { TokenInfoResponse } from '@dao-dao/types/contracts/cw20-gov'
+import { ClaimsResponse } from '@dao-dao/types/contracts/stake-cw20'
 
 export const nativeBalance = selectorFamily({
   key: 'NativeBalance',
@@ -124,4 +125,32 @@ export const walletStakedTokenBalance = selectorFamily({
         address: tokenAddress,
       }
     },
+})
+
+export const walletClaims = selectorFamily({
+  key: 'WalletClaims',
+  get:
+    (stakingAddress: string) =>
+    async ({ get }) => {
+      const client = get(cosmWasmClient)
+      const wallet = get(walletAddress)
+      get(walletTokenBalanceUpdateCountAtom(wallet))
+
+      const response = (await client.queryContractSmart(stakingAddress, {
+        claims: { address: wallet },
+      })) as ClaimsResponse
+
+      return response
+    },
+})
+
+export const getBlockHeight = selector({
+  key: 'ChainBlockHeight',
+  get: async ({ get }) => {
+    const wallet = get(walletAddress)
+    get(walletTokenBalanceUpdateCountAtom(wallet))
+
+    const client = get(cosmWasmClient)
+    return await client.getHeight()
+  },
 })


### PR DESCRIPTION
Resolves #249, #179

Shows all claims that are pending in a list on the DAO contract view
and shows the amount of tokens avaliable to claim. Also changes the
+/- buttons on balance cards to "manage" as discussed in #179.

View showing pending and claimable balances
![image](https://user-images.githubusercontent.com/30676292/150469510-a2cf985e-7028-486c-89d8-e8efb233bf32.png)
 
Claiming modal open (would love some visual guidance on this):
![image](https://user-images.githubusercontent.com/30676292/150469533-619fa295-5f1a-43b7-b1c1-b9f89c468874.png)
