### PR TITLE
Multisig not found error for invalid contract address

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,12 +1,11 @@
-import { NextRouter, Router, useRouter } from 'next/router'
+import { NextRouter, useRouter } from 'next/router'
 import { Component, ErrorInfo, ReactNode } from 'react'
 import Link from 'next/link'
-import Layout from 'components/Layout'
-import Notifications from 'components/Notifications'
 
 type ErrorBoundaryProps = {
   children: ReactNode
   router: NextRouter
+  title: string
 }
 
 type ErrorBoundaryState = {
@@ -33,36 +32,33 @@ class ErrorBoundaryHelper extends Component<
   }
 
   render() {
-    const router = this.props.router
-    if (
-      this.state.hasError &&
-      router.pathname == '/multisig/[contractAddress]'
-    ) {
+    const { router, title, children } = this.props
+    if (this.state.hasError) {
       return (
-        <Layout>
-          <div className="max-w-prose break-words p-6">
-            <h1 className="text-3xl font-bold">Multisig Not Found</h1>
-            <p className="mt-3">
-              We couldn{"'"}t find the multisig with address
-              <br />
-              <code>{router.query.contractAddress}</code>.
-              <br />
-              Consider returning{' '}
-              <Link href="/">
-                <a className="link">home</a>
-              </Link>
-            </p>
-          </div>
-          <Notifications />
-        </Layout>
+        <div className="max-w-prose break-words p-6">
+          <h1 className="text-3xl font-bold">{title}</h1>
+          <p className="mt-3">
+            We couldn{"'"}t find the contract with address
+            <br />
+            <code>{router.query.contractAddress}</code>.
+            <br />
+            Consider returning{' '}
+            <Link href="/">
+              <a className="link">home</a>
+            </Link>
+          </p>
+        </div>
       )
     }
     // Can add more errors with different paths here
 
-    return this.props.children
+    return children
   }
 }
 
-export default function ErrorBoundary(props: { children: ReactNode }) {
+export default function ErrorBoundary(props: {
+  children: ReactNode
+  title: string
+}) {
   return <ErrorBoundaryHelper {...props} router={useRouter()} />
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,6 @@ import { Suspense } from 'react'
 import LoadingScreen from 'components/LoadingScreen'
 import { useRouter } from 'next/router'
 import { HomepageLayout } from 'components/HomepageLayout'
-import ErrorBoundary from 'components/ErrorBoundary'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
@@ -46,20 +45,18 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <RecoilRoot>
-      <ErrorBoundary>
-        <Suspense fallback={<LoadingScreen />}>
-          <SigningCosmWasmProvider>
-            <ThemeProvider updateTheme={updateTheme} theme={theme}>
-              {loaded && (
-                <Layout>
-                  <Component {...pageProps} />
-                  <Notifications />
-                </Layout>
-              )}
-            </ThemeProvider>
-          </SigningCosmWasmProvider>
-        </Suspense>
-      </ErrorBoundary>
+      <Suspense fallback={<LoadingScreen />}>
+        <SigningCosmWasmProvider>
+          <ThemeProvider updateTheme={updateTheme} theme={theme}>
+            {loaded && (
+              <Layout>
+                <Component {...pageProps} />
+                <Notifications />
+              </Layout>
+            )}
+          </ThemeProvider>
+        </SigningCosmWasmProvider>
+      </Suspense>
     </RecoilRoot>
   )
 }

--- a/pages/dao/[contractAddress]/index.tsx
+++ b/pages/dao/[contractAddress]/index.tsx
@@ -45,8 +45,9 @@ import {
   ClaimAvaliableCard,
   ClaimsPendingList,
 } from '@components/Claims'
+import ErrorBoundary from 'components/ErrorBoundary'
 
-const DaoHome: NextPage = () => {
+function DaoHome() {
   const router = useRouter()
   const contractAddress = router.query.contractAddress as string
 
@@ -250,4 +251,10 @@ const DaoHome: NextPage = () => {
   )
 }
 
-export default DaoHome
+const DaoHomePage: NextPage = () => (
+  <ErrorBoundary title="DAO Not Found">
+    <DaoHome />
+  </ErrorBoundary>
+)
+
+export default DaoHomePage

--- a/pages/multisig/[contractAddress]/index.tsx
+++ b/pages/multisig/[contractAddress]/index.tsx
@@ -14,6 +14,7 @@ import {
   HeroContractHeader,
   StarButton,
 } from 'components/ContractView'
+import ErrorBoundary from 'components/ErrorBoundary'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { useRecoilState, useRecoilValue } from 'recoil'
@@ -70,7 +71,7 @@ function VoteBalanceCard({
   )
 }
 
-const Home: NextPage = () => {
+function MultisigHome() {
   const router = useRouter()
   const contractAddress = router.query.contractAddress as string
 
@@ -181,4 +182,10 @@ const Home: NextPage = () => {
   )
 }
 
-export default Home
+const MultisigHomePage: NextPage = () => (
+  <ErrorBoundary title="Multisig Not Found">
+    <MultisigHome />
+  </ErrorBoundary>
+)
+
+export default MultisigHomePage


### PR DESCRIPTION
This is my first PR so don't feel bad to criticize!

Closes #260. Uses a React ErrorBoundary and Next's router path to catch bad requests coming from `/multisig/[contractAddress]`. 

This pattern is recommended by Recoil @ https://recoiljs.org/docs/guides/asynchronous-data-queries#error-handling. Displays this page when contract address is not found: 
<img width="1552" alt="multisig not found" src="https://user-images.githubusercontent.com/16130434/150662644-0a94d94f-2b21-4e4d-9869-2a292e508b5d.png">
