### PR TITLE
Fix address validation

### DIFF
--- a/util/isValidAddress.ts
+++ b/util/isValidAddress.ts
@@ -1,13 +1,12 @@
 const CHAIN_PREFIX = process.env.NEXT_PUBLIC_CHAIN_BECH32_PREFIX as string
 
 // We need to remove the chain prefix in these functions because otherwise it is
-// impossible to tell when addresses are the right length. For example, how do
-// you determine if junoabd...1ef belongs to a chain called junoa, or junoab, or
-// jun?
+// impossible to tell when addresses are the right length. For example:
+// determine if junoabd...1ef belongs to a chain called junoa, or junoab, or
+// jun.
 
-// Validates a bech32 address.
-export function isValidAddress(address: string): boolean {
-  const bech32Regex = /^[a-km-zA-HJ-NP-Z0-9]{39,59}$/im
+export function isValidWalletAddress(address: string): boolean {
+  const bech32Regex = /^[a-km-zA-HJ-NP-Z0-9]{39}$/im
   if (!address?.length) {
     return false
   }
@@ -20,7 +19,11 @@ export function isValidContractAddress(address: string): boolean {
   if (!address?.length) {
     return false
   }
-  // Need to remove the chain prefix as otherwise the
   const unprefixed = address.replace(CHAIN_PREFIX, '')
   return !!unprefixed.match(bech32Regex)
+}
+
+// Validates a bech32 address.
+export function isValidAddress(address: string): boolean {
+  return isValidWalletAddress(address) || isValidContractAddress(address)
 }


### PR DESCRIPTION
More clearly names address validation functions and fixes a bug in our
old regex where any length address between wallet and smart contract
size was considered valid.

Pointed out by Maxjuno here: https://discord.com/channels/816256689078403103/896193922244681799/935195213499072542