### PR TITLE
Specify 'en' as the locale in staking modal

### DIFF
--- a/components/StakingModal.tsx
+++ b/components/StakingModal.tsx
@@ -132,7 +132,10 @@ function PercentSelector({
   const getOnClick = (p: number) => () => {
     setAmount(
       (p * max)
-        .toLocaleString(undefined, { maximumFractionDigits: 6 })
+        // Need to specify 'en' here or otherwise different langauges
+        // (ex german) will insert '.' as seperators which will mess
+        // with our replace logic :)
+        .toLocaleString('en', { maximumFractionDigits: 6 })
         .replace(',', '')
     )
   }


### PR DESCRIPTION
Resolves #264 

Otherwise visitors from elsewhere will have their commas replaced
incorrectly (ex in german you write `123.456,789`).

This is a fun one :)