### PR TITLE
 Fix issues with regex

### DIFF
--- a/util/isValidUrl.spec.ts
+++ b/util/isValidUrl.spec.ts
@@ -6,7 +6,7 @@ const goodInputs: string[] = [
   'https://static.fandomspot.com/images/06/7215/20-kaya-ghost-stories-anime-screenshot.jpg',
   'https://archives.bulbagarden.net/media/upload/thumb/0/0d/025Pikachu.png/375px-025Pikachu.png',
   'https://i.imgur.com/k3s7IUL.jpeg',
-  'https://i.imgur.com/F7gBQLy.jpeg',
+  'https://mirrors.creativecommons.org/presskit/icons/cc.svg',
 ]
 const badInputs: string[] = [
   'http://unsafehttpsite.com/bad.exe',

--- a/util/isValidUrl.ts
+++ b/util/isValidUrl.ts
@@ -2,12 +2,7 @@ export function isValidUrl(url: string): boolean {
   if (url === '') {
     return true
   } else {
-    return (
-      url.startsWith('https://') &&
-      (url.endsWith('.gif') ||
-        url.endsWith('.png') ||
-        url.endsWith('.jpg') ||
-        url.endsWith('.jpeg'))
-    )
+    const regex = /^https:\/\/[^\s]*\.(?:gif|png|jpg|jpeg|svg)$/
+    return regex.test(url)
   }
 }


### PR DESCRIPTION
We ignore using regex as some of the test cases didn't work with multiple regexes.

```
(https:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+(?:png|jpg|jpeg|gif|svg)+
``` would match with

```
https://somethingbad.com/good.png/bad.exe
http://test.com/https://im-pretending-to-be-good.com/img.png
```

Instead we use startsWith and endsWith. Tho I can keep iterating on the regex.