### PR TITLE
Add an update config template to the DAO proposal templates

### DIFF
--- a/components/ProposalForm.tsx
+++ b/components/ProposalForm.tsx
@@ -1,10 +1,9 @@
 import { PlusIcon, XIcon } from '@heroicons/react/outline'
-import { useEffect } from 'react'
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form'
 import { useRecoilValue } from 'recoil'
 import { walletAddress } from 'selectors/treasury'
-import { spendDefaults } from 'templates/spend'
 import { MessageTemplate, messageTemplates } from 'templates/templateList'
+import { contractConfigSelector } from 'util/contractConfigWrapper'
 import { validateRequired } from 'util/formValidation'
 import SvgAirplane from './icons/Airplane'
 import { InputErrorMessage } from './input/InputErrorMessage'
@@ -20,16 +19,19 @@ export interface ProposalData {
 
 export function ProposalForm({
   onSubmit,
-  govTokenDenom,
+  contractAddress,
   loading,
   multisig,
 }: {
   onSubmit: (data: ProposalData) => void
-  govTokenDenom?: string
+  contractAddress: string
   loading: boolean
   multisig?: boolean
 }) {
   const wallet = useRecoilValue(walletAddress)
+  const contractConfig = useRecoilValue(
+    contractConfigSelector({ contractAddress, multisig: !!multisig })
+  )
 
   const formMethods = useForm()
 
@@ -98,10 +100,11 @@ export function ProposalForm({
             return (
               <li key={index}>
                 <Component
-                  govTokenDenom={govTokenDenom}
+                  contractAddress={contractAddress}
                   onRemove={() => remove(index)}
                   getLabel={(fieldName) => `messages.${index}.${fieldName}`}
                   errors={(errors.messages && errors.messages[index]) || {}}
+                  multisig={multisig}
                 />
               </li>
             )
@@ -116,7 +119,7 @@ export function ProposalForm({
           </div>
           <ul
             tabIndex={0}
-            className="p-2 shadow menu dropdown-content rounded-md bg-base-300 border border-secondary w-40"
+            className="p-2 shadow menu dropdown-content rounded-md bg-base-300 border border-secondary w-max"
           >
             {messageTemplates
               .filter(({ multisigSupport }) => multisigSupport || !multisig)
@@ -127,7 +130,9 @@ export function ProposalForm({
                 >
                   <button
                     className="text-left"
-                    onClick={() => append({ ...getDefaults(wallet), label })}
+                    onClick={() =>
+                      append({ ...getDefaults(wallet, contractConfig), label })
+                    }
                     type="button"
                   >
                     {label}

--- a/pages/dao/[contractAddress]/proposals/create.tsx
+++ b/pages/dao/[contractAddress]/proposals/create.tsx
@@ -112,7 +112,7 @@ const ProposalCreate: NextPage = () => {
         />
         <ProposalForm
           onSubmit={onProposalSubmit}
-          govTokenDenom={tokenInfo.symbol}
+          contractAddress={contractAddress}
           loading={proposalLoading}
         />
       </div>

--- a/pages/dao/create.tsx
+++ b/pages/dao/create.tsx
@@ -39,7 +39,7 @@ import { InputErrorMessage } from '@components/input/InputErrorMessage'
 import { NumberInput } from '@components/input/NumberInput'
 import { ToggleInput } from '@components/input/ToggleInput'
 import { TokenInfoResponse } from '@dao-dao/types/contracts/cw20-gov'
-import { addToken } from 'util/addToken'
+
 interface DaoCreateData {
   deposit: string
   description: string
@@ -65,8 +65,8 @@ interface DaoCreateData {
   [key: string]: string | boolean
 }
 
-const DEFAULT_MAX_VOTING_PERIOD_SECONDS = '604800'
-const DEFAULT_UNSTAKING_DURATION_SECONDS = '0' // 12 hours
+export const DEFAULT_MAX_VOTING_PERIOD_SECONDS = '604800'
+export const DEFAULT_UNSTAKING_DURATION_SECONDS = '0' // 12 hours
 
 enum TokenMode {
   UseExisting,

--- a/pages/multisig/[contractAddress]/proposals/create.tsx
+++ b/pages/multisig/[contractAddress]/proposals/create.tsx
@@ -85,6 +85,7 @@ const MultisigProposalCreate: NextPage = () => {
           ]}
         />
         <ProposalForm
+          contractAddress={contractAddress}
           onSubmit={onProposalSubmit}
           loading={proposalLoading}
           multisig

--- a/templates/configUpdate.tsx
+++ b/templates/configUpdate.tsx
@@ -1,0 +1,257 @@
+import { InputErrorMessage } from '@components/input/InputErrorMessage'
+import { InputLabel } from '@components/input/InputLabel'
+import { NumberInput } from '@components/input/NumberInput'
+import { TextInput } from '@components/input/TextInput'
+import { ToggleInput } from '@components/input/ToggleInput'
+import {
+  CosmosMsgFor_Empty,
+  Config as DAOConfig,
+} from '@dao-dao/types/contracts/cw3-dao'
+import { InformationCircleIcon, XIcon } from '@heroicons/react/outline'
+import {
+  DEFAULT_MAX_VOTING_PERIOD_SECONDS,
+  DEFAULT_UNSTAKING_DURATION_SECONDS,
+  secondsToHms,
+} from 'pages/dao/create'
+import { useState } from 'react'
+import { FieldErrors, useFormContext } from 'react-hook-form'
+import { Config } from 'util/contractConfigWrapper'
+import {
+  validatePercent,
+  validatePositive,
+  validateRequired,
+  validateUrl,
+} from 'util/formValidation'
+import { makeWasmMessage } from 'util/messagehelpers'
+import { ToCosmosMsgProps } from './templateList'
+
+export interface DAOConfigUpdateData {
+  name: string
+  description: string
+  image_url: string
+  // The proposal voting duration in seconds. Technically we also support a
+  // duration in blocks but this isn't supported anywhere in the UI.
+  max_voting_period: number
+  proposal_deposit: number
+  refund_failed_proposals: boolean
+  // The threshold in terms of `absolute_percentage` which is all we
+  // support in the UI.
+  threshold: number
+}
+
+export const DAOConfigUpdateDefaults = (
+  _walletAddress: string,
+  contractConfig: Config
+): DAOConfigUpdateData => {
+  const config = contractConfig.config as DAOConfig
+
+  let max_voting_period = Number(DEFAULT_MAX_VOTING_PERIOD_SECONDS)
+  if ('time' in config.max_voting_period) {
+    max_voting_period = config.max_voting_period.time
+  }
+  let threshold = 75
+  if ('absolute_percentage' in config.threshold) {
+    threshold = Number(config.threshold.absolute_percentage.percentage) * 100
+  }
+
+  return {
+    name: config.name,
+    description: config.description,
+    image_url: config.image_url as string,
+    max_voting_period,
+    proposal_deposit: Number(config.proposal_deposit),
+    threshold,
+    refund_failed_proposals: !!config.refund_failed_proposals,
+  }
+}
+
+export const DAOUpdateConfigComponent = ({
+  contractAddress,
+  getLabel,
+  onRemove,
+  errors,
+  multisig,
+}: {
+  contractAddress: string
+  getLabel: (field: string) => string
+  onRemove: () => void
+  errors: FieldErrors
+  multisig?: boolean
+}) => {
+  const { register } = useFormContext()
+
+  const [votingPeriodSeconds, setVotingPeriodSeconds] = useState(
+    DEFAULT_MAX_VOTING_PERIOD_SECONDS
+  )
+  const [unstakingDurationSeconds, setUnstakingDurationSeconds] = useState(
+    DEFAULT_UNSTAKING_DURATION_SECONDS
+  )
+
+  return (
+    <div className="flex flex flex-col py-2 px-3 rounded-lg my-2 bg-base-300">
+      <div className="flex items-center gap-2 justify-between">
+        <div className="flex items-center gap-2">
+          <h2 className="text-4xl">🎭</h2>
+          <h2>Update Config</h2>
+        </div>
+        <button onClick={() => onRemove()} type="button">
+          <XIcon className="h-4" />
+        </button>
+      </div>
+      <div className="px-3">
+        <div className="form-control">
+          <InputLabel name="Name" />
+          <TextInput
+            label={getLabel('name')}
+            register={register}
+            error={errors.name}
+            validation={[validateRequired]}
+          />
+          <InputErrorMessage error={errors.name} />
+        </div>
+
+        <div className="form-control">
+          <InputLabel name="Description" />
+          <TextInput
+            label={getLabel('description')}
+            register={register}
+            error={errors.description}
+            validation={[validateRequired]}
+          />
+          <InputErrorMessage error={errors.description} />
+        </div>
+
+        <div className="form-control">
+          <InputLabel name="Image URL (optional)" />
+          <TextInput
+            label={getLabel('image_url')}
+            register={register}
+            error={errors.imageUrl}
+            validation={[validateUrl]}
+          />
+          <InputErrorMessage error={errors.imageUrl} />
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-3 mt-1">
+          <div className="form-control">
+            <InputLabel name="Passing Threshold (%)" />
+            <NumberInput
+              label={getLabel('threshold')}
+              register={register}
+              error={errors.threshold}
+              validation={[validateRequired, validatePercent]}
+              defaultValue="75"
+              step="any"
+            />
+            <InputErrorMessage error={errors.threshold} />
+          </div>
+
+          <div className="form-control">
+            <InputLabel name="Voting Duration (seconds)" />
+            <NumberInput
+              label={getLabel('duration')}
+              register={register}
+              error={errors.duration}
+              validation={[validateRequired, validatePositive]}
+              onChange={(e) => setVotingPeriodSeconds(e?.target?.value)}
+              defaultValue={DEFAULT_MAX_VOTING_PERIOD_SECONDS}
+            />
+            <InputErrorMessage error={errors.duration} />
+            <div
+              style={{
+                textAlign: 'end',
+                padding: '5px 0 0 17px',
+                fontSize: ' 12px',
+                color: 'grey',
+              }}
+            >
+              {secondsToHms(votingPeriodSeconds)}
+            </div>
+          </div>
+
+          <div className="form-control">
+            <InputLabel name="Proposal Deposit" />
+            <NumberInput
+              label={getLabel('proposal_deposit')}
+              register={register}
+              error={errors.deposit}
+              validation={[validateRequired]}
+              step={0.000001}
+              defaultValue="0"
+            />
+            <InputErrorMessage error={errors.deposit} />
+          </div>
+
+          <div className="form-control">
+            <InputLabel name="Unstaking Duration (seconds)" />
+            <NumberInput
+              label={getLabel('unstaking_duration')}
+              register={register}
+              error={errors.unstakingDuration}
+              validation={[validateRequired]}
+              onChange={(e) => setUnstakingDurationSeconds(e?.target?.value)}
+              defaultValue={DEFAULT_UNSTAKING_DURATION_SECONDS}
+            />
+            <InputErrorMessage error={errors.unstakingDuration} />
+            <div
+              style={{
+                textAlign: 'end',
+                padding: '5px 0 0 17px',
+                fontSize: ' 12px',
+                color: 'grey',
+              }}
+            >
+              {secondsToHms(unstakingDurationSeconds)}
+            </div>
+          </div>
+
+          <div className="form-control">
+            <InputLabel name="Refund Failed Proposal Deposits" />
+            <ToggleInput
+              label={getLabel('refund_failed_proposals')}
+              register={register}
+            />
+            <InputErrorMessage error={errors.refund} />
+          </div>
+        </div>
+      </div>
+      <div className="p-2 rounded-lg my-3 flex items-center gap-2 bg-base-200">
+        <InformationCircleIcon className="h-4" />
+        <p>
+          This message will change the configuration of your DAO. Take Care.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export const transformDAOToConfigUpdateCosmos = (
+  self: DAOConfigUpdateData,
+  props: ToCosmosMsgProps
+) => {
+  const config: DAOConfig = {
+    name: self.name,
+    description: self.description,
+    ...(self.image_url && { image_url: self.image_url }),
+    max_voting_period: { time: self.max_voting_period },
+    proposal_deposit: self.proposal_deposit.toString(),
+    ...(self.refund_failed_proposals && {
+      refund_failed_proposals: self.refund_failed_proposals,
+    }),
+    threshold: {
+      absolute_percentage: { percentage: (self.threshold / 100).toString() },
+    },
+  }
+  const message = makeWasmMessage({
+    wasm: {
+      execute: {
+        contract_addr: props.sigAddress,
+        funds: [],
+        msg: {
+          update_config: config,
+        },
+      },
+    },
+  })
+  return message
+}

--- a/templates/custom.tsx
+++ b/templates/custom.tsx
@@ -6,27 +6,33 @@ import { validateCosmosMsg } from 'util/validateWasmMsg'
 import { CodeMirrorInput } from '@components/input/CodeMirrorInput'
 import { FieldErrors, useFormContext } from 'react-hook-form'
 import { ToCosmosMsgProps } from './templateList'
+import { Config } from 'util/contractConfigWrapper'
 
 export interface CustomData {
   message: string
 }
 
-export const customDefaults = (_walletAddress: string) => {
+export const customDefaults = (
+  _walletAddress: string,
+  _contractConfig: Config
+) => {
   return {
     message: '{}',
   }
 }
 
 export const CustomComponent = ({
-  govTokenDenom,
+  contractAddress,
   getLabel,
   onRemove,
   errors,
+  multisig,
 }: {
-  govTokenDenom?: string
+  contractAddress: string
   getLabel: (field: string) => string
   onRemove: () => void
   errors: FieldErrors
+  multisig?: boolean
 }) => {
   const { control } = useFormContext()
 

--- a/templates/mint.tsx
+++ b/templates/mint.tsx
@@ -3,6 +3,12 @@ import { InputErrorMessage } from '@components/input/InputErrorMessage'
 import { NumberInput } from '@components/input/NumberInput'
 import { ArrowRightIcon, XIcon } from '@heroicons/react/outline'
 import { FieldErrors, useFormContext } from 'react-hook-form'
+import { useRecoilValue } from 'recoil'
+import {
+  Config,
+  contractConfigSelector,
+  ContractConfigWrapper,
+} from 'util/contractConfigWrapper'
 import { convertDenomToMicroDenomWithDecimals } from 'util/conversion'
 import {
   validateAddress,
@@ -17,7 +23,10 @@ export interface MintData {
   amount: number
 }
 
-export const mintDefaults = (walletAddress: string) => {
+export const mintDefaults = (
+  walletAddress: string,
+  _contractConfig: Config
+) => {
   return {
     to: walletAddress,
     amount: 1,
@@ -25,17 +34,25 @@ export const mintDefaults = (walletAddress: string) => {
 }
 
 export const MintComponent = ({
-  govTokenDenom,
+  contractAddress,
   getLabel,
   onRemove,
   errors,
+  multisig,
 }: {
-  govTokenDenom?: string
+  contractAddress: string
   getLabel: (field: string) => string
   onRemove: () => void
   errors: FieldErrors
+  multisig?: boolean
 }) => {
   const { register } = useFormContext()
+
+  const info = useRecoilValue(
+    contractConfigSelector({ contractAddress, multisig: !!multisig })
+  )
+  const config = new ContractConfigWrapper(info)
+  const govTokenDenom = config.gov_token_symbol
 
   return (
     <div className="flex justify-between items-center bg-base-300 py-2 px-3 rounded-lg my-2">

--- a/templates/spend.tsx
+++ b/templates/spend.tsx
@@ -4,7 +4,13 @@ import { NumberInput } from '@components/input/NumberInput'
 import { SelectInput } from '@components/input/SelectInput'
 import { ArrowRightIcon, XIcon } from '@heroicons/react/outline'
 import { FieldErrors, useFormContext } from 'react-hook-form'
+import { useRecoilValue } from 'recoil'
 import { NATIVE_DECIMALS } from 'util/constants'
+import {
+  Config,
+  contractConfigSelector,
+  ContractConfigWrapper,
+} from 'util/contractConfigWrapper'
 import { convertDenomToMicroDenomWithDecimals } from 'util/conversion'
 import {
   validateAddress,
@@ -20,7 +26,10 @@ export interface SpendData {
   denom: string
 }
 
-export const spendDefaults = (walletAddress: string) => {
+export const spendDefaults = (
+  walletAddress: string,
+  _contractConfig: Config
+) => {
   return {
     to: walletAddress,
     amount: 1,
@@ -29,17 +38,25 @@ export const spendDefaults = (walletAddress: string) => {
 }
 
 export const SpendComponent = ({
-  govTokenDenom,
+  contractAddress,
   getLabel,
   onRemove,
   errors,
+  multisig,
 }: {
-  govTokenDenom?: string
+  contractAddress: string
   getLabel: (field: string) => string
   onRemove: () => void
   errors: FieldErrors
+  multisig?: boolean
 }) => {
   const { register } = useFormContext()
+
+  const info = useRecoilValue(
+    contractConfigSelector({ contractAddress, multisig: !!multisig })
+  )
+  const config = new ContractConfigWrapper(info)
+  const govTokenDenom = config.gov_token_symbol
 
   return (
     <div className="flex justify-between items-center bg-base-300 py-2 px-3 rounded-lg my-2">

--- a/templates/templateList.tsx
+++ b/templates/templateList.tsx
@@ -1,5 +1,11 @@
 import { CosmosMsgFor_Empty } from '@dao-dao/types/contracts/cw3-dao'
 import { FieldErrors } from 'react-hook-form'
+import { Config } from 'util/contractConfigWrapper'
+import {
+  DAOConfigUpdateDefaults,
+  DAOUpdateConfigComponent,
+  transformDAOToConfigUpdateCosmos,
+} from './configUpdate'
 import {
   CustomComponent,
   customDefaults,
@@ -32,14 +38,22 @@ export const messageTemplates: MessageTemplate[] = [
     getDefaults: customDefaults,
     toCosmosMsg: transformCustomToCosmos,
   },
+  {
+    label: '🎭 Update Config',
+    component: DAOUpdateConfigComponent,
+    multisigSupport: false,
+    getDefaults: DAOConfigUpdateDefaults,
+    toCosmosMsg: transformDAOToConfigUpdateCosmos,
+  },
 ]
 
 // A component which will render a template's input form.
 export type TemplateComponent = React.FunctionComponent<{
-  govTokenDenom?: string
+  contractAddress: string
   getLabel: (field: string) => string
   onRemove: () => void
   errors: FieldErrors
+  multisig?: boolean
 }>
 
 // Defines a new template.
@@ -47,7 +61,7 @@ export interface MessageTemplate {
   label: string
   component: TemplateComponent
   multisigSupport: boolean
-  getDefaults: (walletAddress: string) => any
+  getDefaults: (walletAddress: string, contractConfig: Config) => any
   toCosmosMsg: (self: any, props: ToCosmosMsgProps) => CosmosMsgFor_Empty
 }
 

--- a/util/contractConfigWrapper.ts
+++ b/util/contractConfigWrapper.ts
@@ -4,7 +4,7 @@ import { selectorFamily, useRecoilValue, waitForAll } from 'recoil'
 import { daoSelector, tokenConfig } from 'selectors/daos'
 import { sigSelector } from 'selectors/multisigs'
 
-type Config = SigConfig | DaoConfig
+export type Config = SigConfig | DaoConfig
 
 /*
  * Wrapper class for unifying some behavior between Dao and Multisig


### PR DESCRIPTION
This adds an update config message template to the DAO message templates. The template automatically fills in the current config values for the DAO to make folks lives easier.

This commit also includes some improvements to the proposal templates design to make them more flexible. I'm sure more of this will come along as we continue to add more templates and learn.

![image](https://user-images.githubusercontent.com/30676292/152467824-4a748105-f3b3-4f94-993d-60273ebd75cf.png)
