### PR TITLE
Improve responsive layout of close navigation button

### DIFF
--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -84,7 +84,7 @@ function Nav({ onMenuClick }: NavProps) {
   return (
     <nav className="p-6 text-lg sticky top-0 h-screen flex flex-col justify-between border-r border-base-300">
       <div>
-        <div className="flex items-center">
+        <div className="flex justify-between lg:justify-start items-center">
           <Link href="/starred">
             <a>
               <Logo height={38} width={38} alt={`${SITE_TITLE} Logo`} />


### PR DESCRIPTION
This adds space between the DAO DAO logo, `Beta` text, and navigation menu button to match the layout when the nav is closed (on mobile).

Current closed behavior:
![image](https://user-images.githubusercontent.com/6721426/152592754-4edd6c76-e09b-4ca0-b858-d2a467540986.png)
Current open behavior:
![image](https://user-images.githubusercontent.com/6721426/152592772-1337afd2-dbff-4531-b550-f39d55261a72.png)

Open behavior after this PR:
![image](https://user-images.githubusercontent.com/6721426/152592793-dfe5a060-b700-4f4d-8688-1f59276e7fe8.png)
