### PR TITLE
Modify import incantation to appease tests

### DIFF
--- a/selectors/treasury.ts
+++ b/selectors/treasury.ts
@@ -12,7 +12,7 @@ import {
 } from '../selectors/cosm'
 import { TokenInfoResponse } from '@dao-dao/types/contracts/cw20-gov'
 import { ClaimsResponse } from '@dao-dao/types/contracts/stake-cw20'
-import { treasuryTokenListUpdates } from 'atoms/treasury'
+import { treasuryTokenListUpdates } from '../atoms/treasury'
 
 export { walletAddress }
 


### PR DESCRIPTION
Tests are [failing](https://github.com/DA0-DA0/dao-ui/runs/5130883098?check_suite_focus=true) when we try and merge development with main. Just need to change `atoms/treasury` to `../atoms/treasury`.