### PR TITLE
Allow copying text from JSON message display.

### DIFF
--- a/components/CosmosMessageDisplay.tsx
+++ b/components/CosmosMessageDisplay.tsx
@@ -19,7 +19,7 @@ export const CosmosMessageDisplay = ({ value }: { value: string }) => {
             name: 'javascript',
             json: true,
           },
-          readOnly: 'nocursor',
+          readOnly: true,
           lineNumbers: true,
           lineWrapping: false,
           tabSize: 2,


### PR DESCRIPTION
Some discussion about why this doesn't work with `readonly: 'nocursor'` and why `readonly: true` is the way [here](https://discuss.codemirror.net/t/copy-text-to-clipboard-when-readonly-is-set-to-cursor/764/2).