### PR TITLE
Fix Percentage button bug on large stake amounts

### DIFF
--- a/components/StakingModal.tsx
+++ b/components/StakingModal.tsx
@@ -143,7 +143,7 @@ function PercentSelector({
         // (ex german) will insert '.' as seperators which will mess
         // with our replace logic :)
         .toLocaleString('en', { maximumFractionDigits: 6 })
-        .replace(',', '')
+        .replaceAll(',', '')
     )
   }
 


### PR DESCRIPTION
Issue: https://github.com/DA0-DA0/dao-ui/issues/375

Fixes replacing the last comma with an empty space in the string that is passed through when clicking the percentage buttons.

![percentBug](https://user-images.githubusercontent.com/7235902/155240848-0ed000f0-8c22-415f-b835-d943486f7166.gif)
375

