### PR TITLE
Help tooltips about current field for create forms.

### DIFF
--- a/components/TooltipsDisplay/TooltipsDisplay.tsx
+++ b/components/TooltipsDisplay/TooltipsDisplay.tsx
@@ -1,5 +1,5 @@
+import { TooltipResponse } from 'components/TooltipsDisplay'
 import { useThemeContext } from 'contexts/theme'
-import { TooltipResponse } from 'tooltips/useTooltipsReguster'
 
 export function TooltipsDisplay({ selected }: { selected: TooltipResponse }) {
   const withSpaces = selected.label.replace(/([A-Z])/g, ' $1')

--- a/components/TooltipsDisplay/daoCreate.tsx
+++ b/components/TooltipsDisplay/daoCreate.tsx
@@ -1,6 +1,7 @@
-import { DaoCreateData } from 'pages/dao/create'
 import { ReactNode } from 'react'
-import { TooltipResponse } from './useTooltipsReguster'
+
+import { TooltipResponse } from 'components/TooltipsDisplay'
+import { DaoCreateData } from 'pages/dao/create'
 
 // A type which maps each key of DaoCreateData to a react node. Updating a field
 // name in DaoCreateData will cause type checking to fail until that field is
@@ -35,8 +36,9 @@ const daoCreateTooltips: daoCreateTooltipsType = {
   daoInitialBalance: (
     <>
       <p>
-        The number of governance to allocate to your DAO's treasury. Allocating
-        more tokens to your DAO makes it easier to onboard future members.
+        The number of governance to allocate to your DAO{"'"}s treasury.
+        Allocating more tokens to your DAO makes it easier to onboard future
+        members.
       </p>
       <p>We suggest allocating 90% of the initial token supply to your DAO.</p>
     </>

--- a/components/TooltipsDisplay/index.ts
+++ b/components/TooltipsDisplay/index.ts
@@ -1,10 +1,13 @@
 import { ReactNode, useState } from 'react'
+
 import {
   FieldPath,
   FieldValues,
   RegisterOptions,
   UseFormRegister,
 } from 'react-hook-form'
+
+import { TooltipsDisplay } from './TooltipsDisplay'
 
 export interface TooltipResponse {
   label: string
@@ -33,3 +36,5 @@ export function useTooltipsRegister<
 
   return [selected, newRegister as UseFormRegister<TFieldValues>]
 }
+
+export default TooltipsDisplay

--- a/components/TooltipsDisplay/multisigCreate.tsx
+++ b/components/TooltipsDisplay/multisigCreate.tsx
@@ -1,6 +1,7 @@
-import { MultisigCreateData } from 'pages/multisig/create'
 import { ReactNode } from 'react'
-import { TooltipResponse } from './useTooltipsReguster'
+
+import { TooltipResponse } from 'components/TooltipsDisplay'
+import { MultisigCreateData } from 'pages/multisig/create'
 
 type multisigCreateDataType = { [key in keyof MultisigCreateData]: ReactNode }
 

--- a/pages/dao/create.tsx
+++ b/pages/dao/create.tsx
@@ -23,18 +23,19 @@ import { InputLabel } from '@components/input/InputLabel'
 import { NumberInput } from '@components/input/NumberInput'
 import { TextInput } from '@components/input/TextInput'
 import { ToggleInput } from '@components/input/ToggleInput'
-import { TooltipsDisplay } from '@components/TooltipsDisplay'
+import TooltipsDisplay, {
+  useTooltipsRegister,
+} from '@components/TooltipsDisplay'
 import { pinnedDaosAtom } from 'atoms/pinned'
 import { Breadcrumbs } from 'components/Breadcrumbs'
+import {
+  daoCreateTooltipsGetter,
+  daoCreateTooltipsDefault,
+} from 'components/TooltipsDisplay/daoCreate'
 import {
   cosmWasmSigningClient,
   walletAddress as walletAddressSelector,
 } from 'selectors/cosm'
-import {
-  daoCreateTooltipsGetter,
-  daoCreateTooltipsDefault,
-} from 'tooltips/daoCreate'
-import { useTooltipsRegister } from 'tooltips/useTooltipsReguster'
 import { cleanChainError } from 'util/cleanChainError'
 import { DAO_CODE_ID, NATIVE_DECIMALS } from 'util/constants'
 import { convertDenomToMicroDenomWithDecimals } from 'util/conversion'

--- a/pages/multisig/create.tsx
+++ b/pages/multisig/create.tsx
@@ -13,19 +13,20 @@ import { InputErrorMessage } from '@components/input/InputErrorMessage'
 import { InputLabel } from '@components/input/InputLabel'
 import { NumberInput } from '@components/input/NumberInput'
 import { TextInput } from '@components/input/TextInput'
-import { TooltipsDisplay } from '@components/TooltipsDisplay'
+import TooltipsDisplay, {
+  useTooltipsRegister,
+} from '@components/TooltipsDisplay'
 import { pinnedMultisigsAtom } from 'atoms/pinned'
 import { Breadcrumbs } from 'components/Breadcrumbs'
+import {
+  multisigCreateTooltipsDefault,
+  multisigCreateTooltipsGetter,
+} from 'components/TooltipsDisplay/multisigCreate'
 import { secondsToHms } from 'pages/dao/create'
 import {
   cosmWasmSigningClient,
   walletAddress as walletAddressSelector,
 } from 'selectors/cosm'
-import {
-  multisigCreateTooltipsDefault,
-  multisigCreateTooltipsGetter,
-} from 'tooltips/multisigCreate'
-import { useTooltipsRegister } from 'tooltips/useTooltipsReguster'
 import { cleanChainError } from 'util/cleanChainError'
 import { MULTISIG_CODE_ID } from 'util/constants'
 import {


### PR DESCRIPTION
Shows a help tooltip for the currently selected field as the DAO and Multisig create forms are filled out. For example, with the DAO initial balance field selected:
<img width="1794" alt="image" src="https://user-images.githubusercontent.com/30676292/155260194-bdf0ab3e-8118-4ecc-b428-c2e0f20253d3.png">

Adding new fields to the DAO / Multisig creation process and not updating the tooltip will cause the build to fail. Done as follows:
```tsx
type multisigCreateDataType = { [key in keyof MultisigCreateData]: ReactNode }
```