### PR TITLE
Properly determine if an address has voted in a proposal.

### DIFF
--- a/apps/dapp/components/ProposalVoteStatus.tsx
+++ b/apps/dapp/components/ProposalVoteStatus.tsx
@@ -1,0 +1,68 @@
+import { Suspense } from 'react'
+
+import { useRecoilValue } from 'recoil'
+
+import { CheckIcon, XIcon } from '@heroicons/react/outline'
+
+import { walletVotedSelector } from 'selectors/proposals'
+
+import { LogoNoBorder } from './Logo'
+
+const VoteStatusLoading = () => {
+  return (
+    <div className="flex flex-row flex-wrap items-center gap-1">
+      <div className="animate-spin-medium inline-block">
+        <LogoNoBorder />
+      </div>
+      <p className="text-secondary text-sm">Loading vote status.</p>
+    </div>
+  )
+}
+
+const VoteStatusLoaded = ({
+  contractAddress,
+  proposalId,
+}: {
+  contractAddress: string
+  proposalId: number
+}) => {
+  const voted = useRecoilValue(
+    walletVotedSelector({
+      contractAddress,
+      proposalId,
+    })
+  )
+  if (voted) {
+    return (
+      <div className="flex items-center flex-row flex-wrap gap-1">
+        <CheckIcon className="text-success w-4" />
+        <p className="text-secondary text-sm">You have voted.</p>
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center flex-row flex-wrap gap-1">
+      <XIcon className="w-4" />
+      <p className="text-secondary text-sm">You have not voted.</p>
+    </div>
+  )
+}
+
+const ProposalVoteStatus = ({
+  contractAddress,
+  proposalId,
+}: {
+  contractAddress: string
+  proposalId: number
+}) => {
+  return (
+    <Suspense fallback={<VoteStatusLoading />}>
+      <VoteStatusLoaded
+        contractAddress={contractAddress}
+        proposalId={proposalId}
+      />
+    </Suspense>
+  )
+}
+
+export default ProposalVoteStatus

--- a/apps/dapp/selectors/proposals.ts
+++ b/apps/dapp/selectors/proposals.ts
@@ -145,6 +145,33 @@ export const proposalStartBlockSelector = selectorFamily<
     },
 })
 
+export const walletVotedSelector = selectorFamily<
+  boolean,
+  { contractAddress: string; proposalId: number }
+>({
+  key: 'walletHasVotedOnProposalStatusSelector',
+  get:
+    ({ contractAddress, proposalId }) =>
+    async ({ get }) => {
+      const client = get(cosmWasmClient)
+      const wallet = get(walletAddress)
+      if (!client || !wallet) {
+        return false
+      }
+
+      const events = await client.searchTx({
+        tags: [
+          { key: 'wasm._contract_address', value: contractAddress },
+          { key: 'wasm.proposal_id', value: proposalId.toString() },
+          { key: 'wasm.action', value: 'vote' },
+          { key: 'wasm.sender', value: wallet },
+        ],
+      })
+
+      return events.length != 0
+    },
+})
+
 export const proposalVotesSelector = selectorFamily<
   VoteInfo[],
   { contractAddress: string; proposalId: number; startAfter?: string }


### PR DESCRIPTION
Previously we were searching the vote listing to determine this. For
proposals with over 30 votes pagination kicks in there and this is no
longer sustainable. This adds a selector to determine if a user has
voted and displays that information as appropriate.