### PR TITLE
Add global error boundary to prevent cascading RPC failures.

### DIFF
--- a/apps/dapp/components/ErrorBoundary.tsx
+++ b/apps/dapp/components/ErrorBoundary.tsx
@@ -35,23 +35,38 @@ class ErrorBoundaryHelper extends Component<
   render() {
     const { router, title, children } = this.props
     if (this.state.hasError) {
-      return (
-        <div className="max-w-prose break-words p-6">
-          <h1 className="text-3xl font-bold">{title}</h1>
-          <p className="mt-3">
-            We couldn{"'"}t find the contract with address
-            <br />
-            <code>{router.query.contractAddress}</code>.
-            <br />
-            Consider returning{' '}
-            <Link href="/">
-              <a className="link">home</a>
-            </Link>
-          </p>
-        </div>
-      )
+      if (
+        router.pathname.startsWith('/dao') ||
+        router.pathname.startsWith('/multisig')
+      ) {
+        return (
+          <div className="max-w-prose break-words p-6">
+            <h1 className="text-3xl font-bold">{title}</h1>
+            <p className="mt-3">
+              We couldn{"'"}t find the contract with address
+              <br />
+              <code>{router.query.contractAddress}</code>.
+              <br />
+              Consider returning{' '}
+              <Link href="/">
+                <a className="link">home</a>
+              </Link>
+            </p>
+          </div>
+        )
+      } else {
+        return (
+          <div className="max-w-prose break-words p-6 mx-auto">
+            <h1 className="text-3xl font-bold">{title}</h1>
+            <p className="mt-3">
+              This could happen because the RPC node DAO DAO uses is down.
+              Please try again later.
+            </p>
+          </div>
+        )
+      }
+      // Can add more errors with different paths here
     }
-    // Can add more errors with different paths here
 
     return children
   }

--- a/apps/dapp/pages/_app.tsx
+++ b/apps/dapp/pages/_app.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router'
 
 import { RecoilRoot } from 'recoil'
 
+import ErrorBoundary from 'components/ErrorBoundary'
 import { HomepageLayout } from 'components/HomepageLayout'
 import SidebarLayout from 'components/Layout'
 import LoadingScreen from 'components/LoadingScreen'
@@ -40,16 +41,18 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <RecoilRoot>
-      <Suspense fallback={<LoadingScreen />}>
-        <ThemeProvider updateTheme={updateTheme} theme={theme}>
-          {loaded && (
-            <Layout>
-              <Component {...pageProps} />
-              <Notifications />
-            </Layout>
-          )}
-        </ThemeProvider>
-      </Suspense>
+      <ErrorBoundary title="An unexpected error occured.">
+        <Suspense fallback={<LoadingScreen />}>
+          <ThemeProvider updateTheme={updateTheme} theme={theme}>
+            {loaded && (
+              <Layout>
+                <Component {...pageProps} />
+                <Notifications />
+              </Layout>
+            )}
+          </ThemeProvider>
+        </Suspense>
+      </ErrorBoundary>
     </RecoilRoot>
   )
 }


### PR DESCRIPTION
Lacking a global error boundary a failure to fetch information from a
RPC node would throw an error and cause a reflow with new
requests (see: flickering DAO DAO logo on RPC failure). This adds a
global error boundary which ought to help prevent those cascading
errors.