### PR TITLE
Correctly use getLabel in absolute threshold form component.

### DIFF
--- a/apps/dapp/templates/configUpdate.tsx
+++ b/apps/dapp/templates/configUpdate.tsx
@@ -216,7 +216,7 @@ export const DAOUpdateConfigComponent = ({
               <div className="form-control">
                 <InputLabel name="Passing Threshold (%)" />
                 <NumberInput
-                  label="threshold"
+                  label={getLabel('threshold')}
                   register={register}
                   error={errors.threshold}
                   validation={[validateRequired, validatePercent]}


### PR DESCRIPTION
Little bug we caught in testing.