### PR TITLE
Fix: Fixed Onboarding Issue with New Wallet

### DIFF
--- a/apps/dapp/selectors/cosm.ts
+++ b/apps/dapp/selectors/cosm.ts
@@ -120,6 +120,10 @@ export const keplrAccountNameSelector = selector<string | undefined>({
   get: async ({ get }) => {
     // Invalidate state when the keplr instance changes.
     get(kelprOfflineSigner)
+    const connectedWallet = get(connectedWalletAtom)
+    if (connectedWallet !== 'keplr') {
+      return ''
+    }
     const info = await window.keplr?.getKey(CHAIN_ID as string)
     return info?.name
   },


### PR DESCRIPTION
## Issue

When gathering a Keplr account name, an error is thrown for all new wallet addresses since the wallet has not been registered first. The webpage is then unable to load:

<img width="1904" alt="Screen Shot 2022-03-26 at 2 21 04 PM" src="https://user-images.githubusercontent.com/22926257/160257591-5052e840-ad1a-4f2d-9514-dd0170318bc4.png">

## Fix

Add a check for an existing connected wallet before gathering the Keplr account name.