### PR TITLE
Persist description newlines on ContractView

### DIFF
--- a/apps/dapp/components/ContractView.tsx
+++ b/apps/dapp/components/ContractView.tsx
@@ -123,7 +123,7 @@ export function HeroContractHeader({
         <EstablishedDate address={address} />
       </div>
       <div className="mb-4 mt-2">
-        <p className="body-text">{description}</p>
+        <p className="body-text whitespace-pre-wrap">{description}</p>
       </div>
     </div>
   )


### PR DESCRIPTION
The newlines and spaces need to be persisted from the creation page to the ContractView page.

Creation with newlines and spaces:
<img width="690" alt="Screen Shot 2022-04-09 at 4 53 50 PM" src="https://user-images.githubusercontent.com/7235902/162595453-a9d3af68-473c-439a-92d9-eda9be66a33e.png">

Before on ContractView:
<img width="352" alt="Screen Shot 2022-04-09 at 4 55 12 PM" src="https://user-images.githubusercontent.com/7235902/162595462-c7232035-4c8e-4921-b901-697de49c1284.png">

After on ContractView:
<img width="334" alt="Screen Shot 2022-04-09 at 4 54 40 PM" src="https://user-images.githubusercontent.com/7235902/162595464-f031f684-1300-4c95-8446-ec4588144ba6.png">

