### PR TITLE
Fixes for abstain indicator clarity

### DIFF
--- a/apps/dapp/components/ProposalDetailsSidebar.tsx
+++ b/apps/dapp/components/ProposalDetailsSidebar.tsx
@@ -292,7 +292,8 @@ export const ProposalDetailsVoteStatus = ({
       : undefined
 
   // When only abstain votes have been cast and there is no quorum,
-  // position abstain to the left of Yes and No above the progress bar.
+  // align the abstain progress bar to the right to line up with Abstain
+  // text.
   const onlyAbstain = yesVotes === 0 && noVotes === 0 && abstainVotes > 0
 
   return (


### PR DESCRIPTION
This fixes a few oversights in the previously deployed proposal status UI:
- The all abstain clarification was correctly displaying that a proposal will pass when all abstain, but the passing threshold was still indicating that it was `Not met`. Change the passing threshold calculation from `(quorum ? turnoutYesPercent : totalYesPercent) >= thresholdPercent` to `yesVotes >= ((quorum ? turnoutTotal : totalWeight) - abstainVotes) * thresholdPercent` to match the contracts. This new formula takes into account the entire turnout abstaining (when a quorum is present) or the entire voting body abstaining (when a quorum is NOT present).
![image](https://user-images.githubusercontent.com/6721426/163728249-bd06f280-7cb0-49fe-987d-15f3f98402af.png)
![image](https://user-images.githubusercontent.com/6721426/163728253-288b37f2-2099-4ee9-81a3-3ed41264cdfa.png)

- Align the Abstain progress bar to the right when no quorum is showing and only abstain votes have been cast, since the progress bar is left aligned but the Abstain text is always pushed to the right. When a quorum is present, this doesn't matter as all abstain will fill up the entire bar. But without a quorum, the vote progress bar can be empty and thus look weird. Left aligning the Abstain text here would be weird, since the line may look like it crosses the passing threshold, but abstain only passes when *all* vote to abstain.
![image](https://user-images.githubusercontent.com/6721426/163728519-4803a5ca-bf83-4c20-b0a1-8ea7fdb685c7.png)

- Only display tie clarification if yes/no are nonzero.