### PR TITLE
Deploy abstain clarification display fix

### DIFF
--- a/apps/dapp/components/ProposalDetailsSidebar.tsx
+++ b/apps/dapp/components/ProposalDetailsSidebar.tsx
@@ -661,7 +661,7 @@ export const ProposalDetailsVoteStatus = ({
         </div>
       )}
 
-      {abstainVotes === turnoutTotal && (
+      {turnoutTotal > 0 && abstainVotes === turnoutTotal && (
         <div className="mt-4 text-sm">
           <p className="font-mono text-tertiary">All abstain clarification</p>
 


### PR DESCRIPTION
Abstain clarification was displaying when no votes had been cast, so this ensures votes have been cast before checking if all votes are abstain. Unfortunately, the programmer (me) forgot that `0 == 0`.