### PR TITLE
Line wrap in markdown preview to improve mobile view.

### DIFF
--- a/packages/ui/components/MarkdownPreview.tsx
+++ b/packages/ui/components/MarkdownPreview.tsx
@@ -6,7 +6,7 @@ export interface MarkdownPreviewProps {
 }
 
 export const MarkdownPreview: FC<MarkdownPreviewProps> = ({ markdown }) => (
-  <ReactMarkdown className="prose prose-sm dark:prose-invert">
+  <ReactMarkdown className="prose prose-sm dark:prose-invert break-all">
     {markdown}
   </ReactMarkdown>
 )


### PR DESCRIPTION
Previously if you had a really long word (for example, a transaction hash) it would cause the page to render too wide on small screens. This is just a small change to force that sort of thing to wrap.