### PR TITLE
Responsive "Your Shares" section on DAO page

### DIFF
--- a/apps/dapp/pages/dao/[contractAddress]/index.tsx
+++ b/apps/dapp/pages/dao/[contractAddress]/index.tsx
@@ -272,7 +272,7 @@ function DaoHome() {
               </HorizontalInfoSection>
             </HorizontalInfo>
           </div>
-          <div className="block mt-4 md:hidden">
+          <div className="block mt-4 lg:hidden">
             <YourShares />
           </div>
           <DaoContractInfo address={contractAddress} />
@@ -284,7 +284,7 @@ function DaoHome() {
           />
         </div>
       </div>
-      <div className="hidden p-6 max-w-sm h-full min-h-screen md:block">
+      <div className="hidden p-6 max-w-sm h-full min-h-screen lg:block">
         <YourShares />
       </div>
     </div>


### PR DESCRIPTION
Closes #521. Move "Your Shares" section to main DAO column in screens less than `lg`. 

https://user-images.githubusercontent.com/16130434/166590839-f0c50eb7-a14a-4dc7-9dc8-fec62737cea5.mov

 