### PR TITLE
Convert from micro denom when ibc asset lookup fails.

### DIFF
--- a/packages/utils/ibc.ts
+++ b/packages/utils/ibc.ts
@@ -1,4 +1,5 @@
 import { NATIVE_DENOM, NATIVE_DECIMALS } from './constants'
+import { convertDenomToHumanReadableDenom } from './conversion'
 import ibcAssets from './ibc_assets.json'
 
 export function nativeTokenLabel(denom: string): string {
@@ -8,7 +9,7 @@ export function nativeTokenLabel(denom: string): string {
     ? ibcAssets.tokens.find(({ junoDenom }) => junoDenom === denom)
     : ibcAssets.tokens.find(({ denom: d }) => d === denom)
   // If no asset, assume it's already a microdenom.
-  return asset?.symbol || denom
+  return asset?.symbol || convertDenomToHumanReadableDenom(denom).toUpperCase()
 }
 
 export function nativeTokenLogoURI(denom: string): string | undefined {


### PR DESCRIPTION
If the IBC asset lookup fails we are dealing with a micro denom and we need to convert it to a human readable denom. This fixes an issue where treasury balances and spend template denoms were showing `ujuno` instead of `juno`.