### PR TITLE
Wrap addToken in try/catch to prevent mobile error.

### DIFF
--- a/apps/dapp/components/DaoTreasury.tsx
+++ b/apps/dapp/components/DaoTreasury.tsx
@@ -12,7 +12,13 @@ import { addToken } from 'util/addToken'
 import { TreasuryBalances } from './ContractView'
 import { SuspenseLoader } from './SuspenseLoader'
 
-export function DaoTreasury({ address }: { address: string }) {
+export function DaoTreasury({
+  address,
+  multisig,
+}: {
+  address: string
+  multisig?: boolean
+}) {
   const router = useRouter()
   const contractAddress = router.query.contractAddress as string
 
@@ -26,9 +32,11 @@ export function DaoTreasury({ address }: { address: string }) {
     <div>
       <div className="flex gap-1 justify-between">
         <h2 className="primary-text">Treasury</h2>
-        <Button onClick={addTokenCallback} variant="ghost">
-          Add Token <PlusSmIcon className="w-4 h-4" />
-        </Button>
+        {!multisig && (
+          <Button onClick={addTokenCallback} variant="ghost">
+            Add Token <PlusSmIcon className="w-4 h-4" />
+          </Button>
+        )}
       </div>
       <SuspenseLoader fallback={<Loader />}>
         <TreasuryBalances address={address} />

--- a/apps/dapp/pages/dao/[contractAddress]/index.tsx
+++ b/apps/dapp/pages/dao/[contractAddress]/index.tsx
@@ -107,8 +107,12 @@ const InnerDaoHome: FC = () => {
 
   const shouldAddToken = router.query.add_token
   useEffect(() => {
-    if (shouldAddToken && daoInfo.state === 'hasValue') {
-      addToken(daoInfo.getValue().gov_token)
+    try {
+      if (shouldAddToken && daoInfo.state === 'hasValue') {
+        addToken(daoInfo.getValue().gov_token)
+      }
+    } catch (e) {
+      console.error('Error adding token:', e)
     }
   }, [shouldAddToken, daoInfo])
 

--- a/apps/dapp/pages/multisig/[contractAddress]/index.tsx
+++ b/apps/dapp/pages/multisig/[contractAddress]/index.tsx
@@ -109,7 +109,7 @@ const InnerMobileMultisigHome = () => {
           <MultisigMemberList contractAddress={contractAddress} />
         )}
         {tab === MobileMenuTabSelection.Treasury && (
-          <DaoTreasury address={contractAddress} />
+          <DaoTreasury address={contractAddress} multisig />
         )}
         {tab === MobileMenuTabSelection.Info && (
           <MultisigContractInfo address={contractAddress} hideTreasury />


### PR DESCRIPTION
Adding a token on mobile will cause the page to crash. This fixes that issue and hides the add token button when viewing a Multisig.