### PR TITLE
Fail elegantly when proposal execution hash is not present.

### DIFF
--- a/packages/state/recoil/selectors/proposal.ts
+++ b/packages/state/recoil/selectors/proposal.ts
@@ -32,6 +32,6 @@ export const proposalExecutionTXHashSelector = selectorFamily<
         console.error('More than one execution', events)
       }
 
-      return events?.[0].hash
+      return events?.[0]?.hash
     },
 })


### PR DESCRIPTION
This fixes an issue where we would cause the proposal list to fail to load in the SDA if no hash was returned by the RPC node.