### PR TITLE
Add chain explorer for DAO DAO testnet.

### DIFF
--- a/apps/dapp/.env.development
+++ b/apps/dapp/.env.development
@@ -16,6 +16,7 @@ NEXT_PUBLIC_DAO_DAO_VERSION=$npm_package_version
 # The prefix added to keys for favorited DAOs in local storage.
 NEXT_PUBLIC_FAVORITES_NAMESPACE=19
 NEXT_PUBLIC_GAS_PRICE=0.0025ujunox
+NEXT_PUBLIC_CHAIN_TXN_URL_PREFIX=https://explorer.uni.chaintools.tech/uni/tx/
 
 # cw-plus Contracts / Codes
 # See: https://github.com/CosmWasm/cw-plus/releases/
@@ -31,4 +32,4 @@ NEXT_PUBLIC_STAKE_CW20_CODE_ID=54 # stake_cw20.wasm
 NEXT_PUBLIC_SEARCH_URL=https://dao-search.withoutdoing.com
 NEXT_PUBLIC_SEARCH_API_KEY=geDQZEly47de425b96a1ae8ee53917e75fc8ea27b09afb4dbaec202b91e6ac59f341c568
 NEXT_PUBLIC_MULTISIG_INDEX=testnet-multisigs
-NEXT_PUBLIC_DAO_INDEX=testnet-daos 
+NEXT_PUBLIC_DAO_INDEX=testnet-daos


### PR DESCRIPTION
Adds chain explorer so that proposal TX hashes can link to it on the testnet. Credit to @Callum-A for finding this explorer. :)