### PR TITLE
🤑  I like big bucks and I cannot lie - canonical $USDC IBC asset for DAO DAO 🦅🇺🇸

### DIFF
--- a/packages/utils/ibc_assets.json
+++ b/packages/utils/ibc_assets.json
@@ -27,6 +27,19 @@
       "junoChannel": "channel-27"
     },
     {
+      "id": "terrausd",
+      "name": "UST",
+      "symbol": "UST",
+      "chain_id": "columbus-5",
+      "rpc": "https://rpc-columbus.keplr.app:443",
+      "denom": "uusd",
+      "decimals": 6,
+      "channel": "channel-20",
+      "logoURI": "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/images/ust.png",
+      "junoDenom": "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27",
+      "junoChannel": "channel-27"
+    },
+    {
       "id": "bitsong",
       "name": "BTSG",
       "symbol": "BTSG",
@@ -194,6 +207,6 @@
       "logoURI": "https://sz56ino2efvrofw5wgw6iafudpi6br6xny6u6o6xilynddmf64.arweave.net/lnvkNdohaxcW3bGt5AC0G9Hgx9duPU_8710Lw0Y2F90",
       "junoDenom": "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034",
       "junoChannel": "channel-71"
-    },
+    }
   ]
 }


### PR DESCRIPTION
![bug](https://user-images.githubusercontent.com/1236584/169671169-3c01162a-630a-41fb-a0ac-1244d336ba7b.png)
# Display treasury `$USDC` nicely 💵
gm gm!

Apologies in advance for maximum reviewer reach -- this sort of decision should be subject to governance, but since `€DAO` is on its way and governance does not need to be on-chain for us to do the right thing, think of this as a soft consensus mechanism - approve if you agree and are alive, voice your objection in comments if you do disagree, propose alternatives etc.

Supporting or not supporting a particular fiat peg stable is a big deal, as we lend credibility to it with our community's reputation, and we need to be thoughtful about it.

This PR introduces `$axlUSDC` as the canonical `$USD` asset for DAO DAO treasuries, as displayed in the UI;

## Context
- https://www.rawdao.zone/vote/2
- https://www.rawdao.zone/vote/3
- https://twitter.com/ben2x4/status/1528078136633851904?s=20&t=463ZLWFEUBiqxzmKIgFdsw

## Changes proposed and notable decision points 💰
- adds `$USDC` IBC asset
  - logo is Permaweb'ed on Arweave
  - to follow the Osmosis lead, the `$USDC` does not have a small Axelar logo next to it and is just a regular USDC logo (pros: does not promote a company, cons: obscures the fact that if the bridge is pwned, it is not _actually_ `ERC-20 $USDC`) -- expecting this to be the most contentious one and can follow the JunoSwap lead and adjust with axl if that's the preference

Would love your feedback (even if it's just an emoji reaction / review), and would say let's merge this whenever we are in alignment, but not until the UI folks had a chance to review (thank you for all you do!) and the [IBC stuff](https://github.com/bmorphism/shitcoin) is verified correct.

Ce La Faremo! 👏👏👏