### PR TITLE
Fixed create DAO token amount input not working.

### DIFF
--- a/apps/dapp/pages/dao/create.tsx
+++ b/apps/dapp/pages/dao/create.tsx
@@ -496,7 +496,7 @@ const InnerCreateDao: FC = () => {
                     ]}
                     onRemove={() => remove(index)}
                     register={register}
-                    title={`Recepient ${index}`}
+                    title={`Recipient ${index}`}
                     tokenImage={tokenImage}
                     tokenSymbol={tokenSymbol}
                   />

--- a/packages/ui/components/input/AddressInput.tsx
+++ b/packages/ui/components/input/AddressInput.tsx
@@ -30,7 +30,7 @@ export function AddressInput<FieldValues, FieldName extends Path<FieldValues>>({
   )
   return (
     <div
-      className={`flex items-center gap-1 bg-transparent rounded-lg px-3 py-2 transition focus-within:ring-1 focus-within:outline-none ring-brand ring-offset-0 border-default border border-default text-sm font-mono
+      className={`flex items-center gap-1 bg-transparent rounded-lg px-3 py-2 transition focus-within:ring-1 focus-within:outline-none ring-brand ring-offset-0 border border-default text-sm font-mono
         ${error ? ' ring-error ring-1' : ''}`}
     >
       <Wallet color="currentColor" width="24px" />

--- a/packages/ui/components/input/NumberInput.tsx
+++ b/packages/ui/components/input/NumberInput.tsx
@@ -26,6 +26,7 @@ export function NumberInput<FieldValues, FieldName extends Path<FieldValues>>({
   disabled = false,
   onPlusMinus,
   small = false,
+  className,
 }: {
   label: FieldName
   register: UseFormRegister<FieldValues>
@@ -36,6 +37,7 @@ export function NumberInput<FieldValues, FieldName extends Path<FieldValues>>({
   disabled?: boolean
   onPlusMinus?: [() => void, () => void]
   small?: boolean
+  className?: string
 }) {
   const validate = validation?.reduce(
     (a, v) => ({ ...a, [v.toString()]: v }),
@@ -45,10 +47,10 @@ export function NumberInput<FieldValues, FieldName extends Path<FieldValues>>({
   if (onPlusMinus) {
     return (
       <div
-        className={`flex items-center gap-1 bg-transparent rounded-lg px-3 py-2 transition focus-within:ring-1 focus-within:outline-none ring-brand ring-offset-0 border-default border border-default text-sm ${
+        className={`flex items-center gap-1 bg-transparent rounded-lg px-3 py-2 transition focus-within:ring-1 focus-within:outline-none ring-brand ring-offset-0 border border-default text-sm ${
           small ? 'w-40' : ''
         }
-        ${error ? ' ring-error ring-1' : ''}`}
+        ${error ? ' ring-error ring-1' : ''} ${className}`}
       >
         <button
           className="transition secondary-text hover:body-text"
@@ -82,8 +84,8 @@ export function NumberInput<FieldValues, FieldName extends Path<FieldValues>>({
 
   return (
     <input
-      className={`bg-transparent rounded-lg px-3 py-2 transition focus:ring-1 focus:outline-none ring-brand ring-offset-0 border-default border border-default body-text
-        ${error ? ' ring-error ring-1' : ''}`}
+      className={`bg-transparent rounded-lg px-3 py-2 transition focus:ring-1 focus:outline-none ring-brand ring-offset-0 border border-default body-text
+        ${error ? ' ring-error ring-1' : ''} ${className}`}
       defaultValue={defaultValue}
       disabled={disabled}
       step={step}

--- a/packages/ui/components/input/TokenAmountInput.tsx
+++ b/packages/ui/components/input/TokenAmountInput.tsx
@@ -19,6 +19,26 @@ import { AddressInput } from './AddressInput'
 import { InputErrorMessage } from './InputErrorMessage'
 import { NumberInput } from './NumberInput'
 
+interface TokenAmountInputProps<
+  FieldValues,
+  AmountFieldName extends Path<FieldValues>,
+  AddrFieldName extends Path<FieldValues>
+> {
+  amountLabel: AmountFieldName
+  addrLabel: AddrFieldName
+  onRemove: () => void
+  tokenSymbol?: string
+  tokenImage?: string
+  hideRemove: boolean
+  icon?: ReactNode
+  title: string
+  register: UseFormRegister<FieldValues>
+  onPlusMinus?: [() => void, () => void]
+  amountError?: FieldError
+  addrError?: FieldError
+  readOnly?: boolean
+}
+
 /**
  * @param label      - the label for the value that this will contain.
  * @param register   - the register function returned by `useForm`.
@@ -28,7 +48,7 @@ import { NumberInput } from './NumberInput'
  *                     of this field, return true if the value is valid and an
  *                     error message otherwise.
  */
-export function TokenAmountInput<
+export const TokenAmountInput = <
   FieldValues,
   AmountFieldName extends Path<FieldValues>,
   AddrFieldName extends Path<FieldValues>
@@ -46,36 +66,8 @@ export function TokenAmountInput<
   amountError,
   addrError,
   readOnly,
-}: {
-  amountLabel: AmountFieldName
-  addrLabel: AddrFieldName
-  onRemove: () => void
-  tokenSymbol?: string
-  tokenImage?: string
-  hideRemove: boolean
-  icon?: ReactNode
-  title: string
-  register: UseFormRegister<FieldValues>
-  onPlusMinus?: [() => void, () => void]
-  amountError?: FieldError
-  addrError?: FieldError
-  readOnly?: boolean
-}) {
+}: TokenAmountInputProps<FieldValues, AmountFieldName, AddrFieldName>) => {
   type ValidateFn = Validate<FieldPathValue<FieldValues, AddrFieldName>>
-
-  const numberInputParams = {
-    defaultValue: '0',
-    disabled: readOnly,
-    error: amountError,
-    label: amountLabel as any,
-    onPlusMinus: onPlusMinus,
-    register: register,
-    step: 0.000001,
-    validation: [
-      validateRequired as ValidateFn,
-      validatePositive as ValidateFn,
-    ],
-  }
 
   return (
     <FormCard>
@@ -93,12 +85,20 @@ export function TokenAmountInput<
         </div>
         <div className="flex gap-2 items-center">
           <div className="flex flex-col gap-1">
-            <div className="hidden md:block">
-              <NumberInput {...numberInputParams} small />
-            </div>
-            <div className="md:hidden">
-              <NumberInput {...numberInputParams} />
-            </div>
+            <NumberInput
+              className="md:w-40"
+              defaultValue="0"
+              disabled={readOnly}
+              error={amountError}
+              label={amountLabel as any}
+              onPlusMinus={onPlusMinus}
+              register={register}
+              step={0.000001}
+              validation={[
+                validateRequired as ValidateFn,
+                validatePositive as ValidateFn,
+              ]}
+            />
             <InputErrorMessage error={amountError} />
           </div>
           {tokenSymbol && (


### PR DESCRIPTION
Bug report from a user:
```
Hello, there is an issue with https://testnet.daodao.zone/dao/create 

i'm not able to set the amount of tokens per address... i can only with the + and - button.

EDIT: on mainnet frontend too
```

Responsive changes revealed an issue with registering the same label on two different form input elements using react-hook-form. Fixed by making the responsiveness a single class.