### PR TITLE
Add paginated vote list to proposal display.

### DIFF
--- a/apps/dapp/components/ProposalVotes.tsx
+++ b/apps/dapp/components/ProposalVotes.tsx
@@ -1,0 +1,76 @@
+import { FC, useState } from 'react'
+import { useRecoilCallback, useRecoilValue } from 'recoil'
+
+import { ProposalVotes as StatelessProposalVotes } from '@dao-dao/ui'
+
+import { proposalVotesSelector, proposalSelector } from '@/selectors/proposals'
+
+export interface ProposalVotesProps {
+  contractAddress: string
+  proposalId: number
+}
+
+export const ProposalVotes: FC<ProposalVotesProps> = ({
+  contractAddress,
+  proposalId,
+}) => {
+  const proposal = useRecoilValue(
+    proposalSelector({ contractAddress, proposalId })
+  )!
+
+  // All the threshold variants have a total_weight key so we just index into
+  // whatever this is and get that.
+  const totalPower = Number(
+    (
+      (proposal.threshold as any)[
+        Object.keys(proposal.threshold)[0] as string
+      ] as any
+    ).total_weight
+  )
+
+  const initalVotes = useRecoilValue(
+    proposalVotesSelector({ contractAddress, proposalId })
+  ).map(({ vote, voter, weight }) => ({
+    vote,
+    voter,
+    weight: (Number(weight) / totalPower) * 100,
+  }))
+
+  const [votes, setVotes] = useState(initalVotes)
+  const [votesLoading, setVotesLoading] = useState(false)
+  // We ask for 30 votes when we query. If we get that many back it
+  // suggests we can attempt anoher load.
+  const [canLoadMore, setCanLoadMore] = useState(votes.length === 30)
+
+  const loadMoreVotes = useRecoilCallback(
+    ({ snapshot }) =>
+      async () => {
+        setVotesLoading(true)
+        const startAfter = votes[votes.length - 1].voter
+        const newVotes = (
+          await snapshot.getPromise(
+            proposalVotesSelector({ contractAddress, proposalId, startAfter })
+          )
+        ).map(({ vote, voter, weight }) => ({
+          vote,
+          voter,
+          weight: (Number(weight) / totalPower) * 100,
+        }))
+        setCanLoadMore(newVotes.length === 30)
+        setVotes((votes) => [...votes, ...newVotes])
+        setVotesLoading(false)
+      },
+    [votes, setVotes, proposalId, contractAddress, setVotesLoading]
+  )
+
+  return (
+    <div className="mx-6 mt-11">
+      <StatelessProposalVotes
+        canLoadMore={canLoadMore}
+        loadingMore={votesLoading}
+        onLoadMore={() => loadMoreVotes()}
+        votes={votes}
+      />
+    </div>
+  )
+}

--- a/apps/dapp/pages/dao/[contractAddress]/proposals/[proposalId].tsx
+++ b/apps/dapp/pages/dao/[contractAddress]/proposals/[proposalId].tsx
@@ -12,6 +12,7 @@ import {
   ProposalDetailsSidebar,
   ProposalDetailsVoteStatus,
 } from '@/components/ProposalDetailsSidebar'
+import { ProposalVotes } from '@/components/ProposalVotes'
 import { SmallScreenNav } from '@/components/SmallScreenNav'
 import { SuspenseLoader } from '@/components/SuspenseLoader'
 import { daoSelector } from '@/selectors/daos'
@@ -60,6 +61,7 @@ const InnerProposal: FC = () => {
 
           <ProposalDetailsVoteStatus {...proposalDetailsProps} />
         </div>
+        <ProposalVotes {...proposalDetailsProps} />
       </div>
       <div className="hidden col-span-2 p-4 min-h-screen md:p-6 lg:block bg-base-200">
         <ProposalDetailsSidebar {...proposalDetailsProps} />

--- a/apps/dapp/pages/multisig/[contractAddress]/proposals/[proposalId].tsx
+++ b/apps/dapp/pages/multisig/[contractAddress]/proposals/[proposalId].tsx
@@ -12,6 +12,7 @@ import {
   ProposalDetailsCard,
   ProposalDetailsVoteStatus,
 } from '@/components/ProposalDetailsSidebar'
+import { ProposalVotes } from '@/components/ProposalVotes'
 import { SmallScreenNav } from '@/components/SmallScreenNav'
 import { SuspenseLoader } from '@/components/SuspenseLoader'
 import { sigSelector } from '@/selectors/multisigs'
@@ -59,6 +60,7 @@ const InnerMultisigProposal: FC = () => {
 
           <ProposalDetailsVoteStatus {...proposalDetailsProps} />
         </div>
+        <ProposalVotes {...proposalDetailsProps} />
       </div>
       <div className="hidden col-span-2 p-6 min-h-screen lg:block bg-base-200">
         <ProposalDetailsSidebar {...proposalDetailsProps} />

--- a/packages/ui/components/MarkdownPreview.tsx
+++ b/packages/ui/components/MarkdownPreview.tsx
@@ -12,7 +12,7 @@ export const MarkdownPreview: FC<MarkdownPreviewProps> = ({
   className,
 }) => (
   <ReactMarkdown
-    className={clsx('break-all prose prose-sm dark:prose-invert', className)}
+    className={clsx('prose prose-sm dark:prose-invert break-word', className)}
     linkTarget="_blank"
   >
     {markdown}

--- a/packages/ui/components/ProposalDetails/v0/ProposalDetails.tsx
+++ b/packages/ui/components/ProposalDetails/v0/ProposalDetails.tsx
@@ -99,16 +99,16 @@ export const ProposalDetails: FC<ProposalDetailsProps> = ({
           />
         </>
       )}
-      <p className="mt-[30px] mb-[12px] font-mono caption-text">Vote</p>
-      {proposal.status === 'open' &&
-        !walletVote &&
-        walletWeightPercent !== 0 && (
+      <p className="mt-6 mb-4 link-text">Your vote</p>
+      {proposal.status === 'open' && !walletVote && walletWeightPercent !== 0 && (
+        <div className="max-w-prose">
           <Vote
             loading={loading}
             onVote={onVote}
             voterWeight={walletWeightPercent}
           />
-        )}
+        </div>
+      )}
       {walletVote && (
         <p className="body-text">You voted {walletVote} on this proposal.</p>
       )}

--- a/packages/ui/components/ProposalDetails/v0/ProposalVotes.tsx
+++ b/packages/ui/components/ProposalDetails/v0/ProposalVotes.tsx
@@ -1,0 +1,101 @@
+import { CheckIcon, DownloadIcon, XIcon } from '@heroicons/react/outline'
+import { FC, useState } from 'react'
+import toast from 'react-hot-toast'
+
+import { Abstain } from '@dao-dao/icons'
+import { Button } from '@dao-dao/ui'
+
+type Vote = 'yes' | 'no' | 'abstain' | 'veto'
+
+export interface VoteInfo {
+  vote: Vote
+  voter: string
+  weight: number
+}
+
+export interface ProposalVotesProps {
+  votes: VoteInfo[]
+  canLoadMore: boolean
+  loadingMore: boolean
+  onLoadMore: () => void
+}
+
+const zeroPad = (number: string, length: number) =>
+  number.length >= length
+    ? number
+    : new Array(length - number.length + 1).join(' ') + number
+
+const VoteDisplay: FC<{ vote: Vote }> = ({ vote }) =>
+  vote === 'yes' ? (
+    <p className="flex gap-1 items-center font-mono text-sm text-valid">
+      <CheckIcon className="inline w-4" /> Yes
+    </p>
+  ) : vote === 'no' || vote === 'veto' ? (
+    <p className="flex gap-1 items-center font-mono text-sm text-error">
+      <XIcon className="inline w-4" /> No
+    </p>
+  ) : (
+    <p className="flex gap-1 items-center font-mono text-sm text-secondary">
+      <Abstain fill="currentColor" /> Abstain
+    </p>
+  )
+
+export const VoteRow: FC<VoteInfo> = ({ vote, voter, weight }) => {
+  const [copied, setCopied] = useState(false)
+  return (
+    <div className="flex flex-wrap gap-4 justify-between items-center py-3 px-4 mb-1 bg-card rounded md:px-0 md:my-0 md:bg-transparent md:rounded-none">
+      <button
+        className="overflow-auto font-mono whitespace-nowrap caption-text no-scrollbar"
+        onClick={() => {
+          navigator.clipboard.writeText(voter)
+          setCopied(true)
+          toast.success('Copied to clipboard!')
+          setTimeout(() => setCopied(false), 3000)
+        }}
+        type="button"
+      >
+        {copied ? '*' : '#'} <span className="underline">{voter}</span>
+      </button>
+      <VoteDisplay vote={vote} />
+      <p className="font-mono text-primary caption-text">
+        %
+        {zeroPad(
+          weight.toLocaleString(undefined, {
+            minimumFractionDigits: 6,
+            maximumFractionDigits: 6,
+          }),
+          10
+        )}
+      </p>
+    </div>
+  )
+}
+
+export const ProposalVotes: FC<ProposalVotesProps> = ({
+  votes,
+  canLoadMore,
+  loadingMore,
+  onLoadMore,
+}) => (
+  <>
+    <hr className="border-default" />
+    <h3 className="mt-9 mb-5 link-text">All votes</h3>
+    <div className="flex flex-col divide-y divide-inactive">
+      {votes.map((vote, index) => (
+        <VoteRow {...vote} key={index} />
+      ))}
+    </div>
+    {canLoadMore && (
+      <div className="mt-2">
+        <Button
+          loading={loadingMore}
+          onClick={onLoadMore}
+          size="sm"
+          variant="secondary"
+        >
+          Load more <DownloadIcon className="w-4" />
+        </Button>
+      </div>
+    )}
+  </>
+)

--- a/packages/ui/components/ProposalDetails/v0/index.tsx
+++ b/packages/ui/components/ProposalDetails/v0/index.tsx
@@ -1,3 +1,4 @@
 export * from './ProposalDetails'
 export * from './ProposalDetailsSidebar'
 export * from './ProposalMessageTemplateList'
+export * from './ProposalVotes'


### PR DESCRIPTION
This adds a paginated listing of all the votes for a proposal to the proposal display. Addresses in the listing can be copied by clicking on them.

Mobile:
<img width="160" alt="image" src="https://user-images.githubusercontent.com/30676292/171289074-35bfc80b-00d8-4c48-9631-4f8e7e5bd0a7.png">

Desktop:
<img width="286" alt="image" src="https://user-images.githubusercontent.com/30676292/171289120-1632c419-a768-4095-9dbc-b30571317533.png">
