### PR TITLE
Don't prompt to stake tokens for multisig voting.

### DIFF
--- a/apps/dapp/components/ProposalDetails.tsx
+++ b/apps/dapp/components/ProposalDetails.tsx
@@ -245,14 +245,16 @@ export function ProposalDetails({
       setShowStaking={(s) => setShowStaking(s)}
       showStaking={showStaking}
       stakingModal={
-        <StakingModal
-          afterExecute={() => setTokenBalancesLoading(false)}
-          beforeExecute={() => setTokenBalancesLoading(true)}
-          claimableTokens={0}
-          contractAddress={contractAddress}
-          defaultMode={StakingMode.Stake}
-          onClose={() => setShowStaking(false)}
-        />
+        !multisig ? (
+          <StakingModal
+            afterExecute={() => setTokenBalancesLoading(false)}
+            beforeExecute={() => setTokenBalancesLoading(true)}
+            claimableTokens={0}
+            contractAddress={contractAddress}
+            defaultMode={StakingMode.Stake}
+            onClose={() => setShowStaking(false)}
+          />
+        ) : undefined
       }
       walletVote={walletVote}
       walletWeightPercent={weightPercent}

--- a/packages/ui/components/ProposalDetails/v0/ProposalDetails.tsx
+++ b/packages/ui/components/ProposalDetails/v0/ProposalDetails.tsx
@@ -115,14 +115,12 @@ export const ProposalDetails: FC<ProposalDetailsProps> = ({
       {proposal.status !== 'open' && !walletVote && (
         <p className="body-text">You did not vote on this proposal.</p>
       )}
-      {walletWeightPercent === 0 && (
+      {walletWeightPercent === 0 && stakingModal && (
         <p className="max-w-prose body-text">
           You must have voting power at the time of proposal creation to vote.{' '}
-          {stakingModal && (
-            <button className="underline" onClick={() => setShowStaking(true)}>
-              Stake some tokens so you can vote next time?
-            </button>
-          )}
+          <button className="underline" onClick={() => setShowStaking(true)}>
+            Stake some tokens so you can vote next time?
+          </button>
           {showStaking && stakingModal}
         </p>
       )}


### PR DESCRIPTION
We were previously prompting folks to stake tokens if they did not have voting power when viewing a multisig. This isn't terribly sensible.