### PR TITLE
Fixed majority threshold incorrectly failing

### DIFF
--- a/packages/ui/components/ProposalDetails/v1/V1ProposalInfoCards.tsx
+++ b/packages/ui/components/ProposalDetails/v1/V1ProposalInfoCards.tsx
@@ -209,7 +209,7 @@ export const V1ProposalInfoVoteStatus: FC<V1ProposalInfoVoteStatusProps> = ({
   // If there are no abstain votes, this should be 50.
   // If there are 4% abstain votes, this should be 48, since 48%+1 of the 96% non-abstain votes need to be in favor.
   const majorityThresholdMarker =
-    Math.round(50 - (abstainVotes / 2 / ((quorum ? turnoutTotal : totalWeight) || 1)) * 100)
+    50 - (abstainVotes / 2 / ((quorum ? turnoutTotal : totalWeight) || 1)) * 100
 
   const helpfulStatusText =
     proposal.status === Status.Open && threshold && quorum


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6721426/173443739-9e2d776b-742a-4bfb-9d9b-f2891670a136.png)

This displays the proposal as erroneously failing, even though the majority of non-abstain votes are in favor.