### PR TITLE
Fix straggling percent symbols

### DIFF
--- a/apps/dapp/components/Cw20StakedBalanceVotingPowerDisplay.tsx
+++ b/apps/dapp/components/Cw20StakedBalanceVotingPowerDisplay.tsx
@@ -123,7 +123,6 @@ const InnerCw20StakedBalanceVotingPowerDisplay: FC = () => {
                       ? (walletStakedValue / totalStakedValue) * 100
                       : 0
                   )}
-                  %
                 </p>
               </div>
 

--- a/apps/sda/components/stake/BalanceCards.tsx
+++ b/apps/sda/components/stake/BalanceCards.tsx
@@ -126,8 +126,8 @@ export const StakedBalanceCard: FunctionComponent<CardProps> = ({
                   ? 0
                   : ((walletStakedValue ?? 0) / totalStakedValue) * 100
               ),
-            }}
-            % <span className="text-xs text-tertiary">of all voting power</span>
+            }}{' '}
+            <span className="text-xs text-tertiary">of all voting power</span>
           </Trans>
         </p>
       </div>


### PR DESCRIPTION
I noticed _another_ double percent that I missed, so I scoured the codebase for remaining percents hardcoded directly into pages/components, and removed them! Down with hardcoded percent symbols!