### PR TITLE
Fix mobile multisig proposals linking to /dao/proposals/.

### DIFF
--- a/apps/dapp/pages/multisig/[contractAddress]/index.tsx
+++ b/apps/dapp/pages/multisig/[contractAddress]/index.tsx
@@ -103,6 +103,7 @@ const InnerMobileMultisigHome = () => {
           <ContractProposalsDisplay
             contractAddress={contractAddress}
             proposalCreateLink={`/multisig/${contractAddress}/proposals/create`}
+            multisig
           />
         )}
         {tab === MobileMenuTabSelection.Members && (


### PR DESCRIPTION
This fixes a bug reported by @maxjuno where on mobile we are linking to `/dao/proposals` when clicking a proposal in the proposal list for a multisig.