### PR TITLE
Add template for updating CosmWasm contract admins.

### DIFF
--- a/apps/dapp/components/ContractCard.tsx
+++ b/apps/dapp/components/ContractCard.tsx
@@ -62,7 +62,7 @@ function ContractCardBase({
             <h3 className="mt-3 max-w-full font-semibold truncate text-md">
               {title}
             </h3>
-            <p className="mt-1 font-mono text-xs text-center text-secondary break-words line-clamp-3">
+            <p className="mt-1 max-w-full font-mono text-xs text-center text-secondary break-words line-clamp-3">
               {body}
             </p>
           </div>

--- a/apps/dapp/templates/migrateContract.tsx
+++ b/apps/dapp/templates/migrateContract.tsx
@@ -56,7 +56,7 @@ const IsAdminWarningInner = ({
   return null
 }
 
-const IsAdminWarning = ({
+export const IsAdminWarning = ({
   contract,
   maybeAdmin,
 }: {

--- a/apps/dapp/templates/migrateDao.tsx
+++ b/apps/dapp/templates/migrateDao.tsx
@@ -140,7 +140,7 @@ export const MigrateDaoComponent: TemplateComponent = ({
 
   useEffect(
     () => setValue(getLabel('unstakingDuration'), unstakingDuration),
-    [setValue, unstakingDuration]
+    [setValue, getLabel, unstakingDuration]
   )
 
   const instantiateV1Dao = () => {
@@ -474,6 +474,18 @@ export const transformMigrateDaoToCosmos = (
     })
   )
 
+  // Update contract level admin of staking contract.
+  messages.push(
+    makeWasmMessage({
+      wasm: {
+        update_admin: {
+          contract_addr: self.stakingAddress,
+          admin: self.newDao,
+        },
+      },
+    })
+  )
+
   // Upgrade the token contract.
   messages.push(
     makeWasmMessage({
@@ -482,6 +494,18 @@ export const transformMigrateDaoToCosmos = (
           contract_addr: self.govToken,
           new_code_id: V1_CW20_ID,
           msg: {},
+        },
+      },
+    })
+  )
+
+  // Update the contract level admin of the token contract.
+  messages.push(
+    makeWasmMessage({
+      wasm: {
+        update_admin: {
+          contract_addr: self.govToken,
+          admin: self.newDao,
         },
       },
     })
@@ -558,5 +582,6 @@ export const transformMigrateDaoToCosmos = (
     })
   )
 
+  console.log(messages)
   return messages
 }

--- a/apps/dapp/templates/templateList.tsx
+++ b/apps/dapp/templates/templateList.tsx
@@ -83,6 +83,12 @@ import {
   transformStakingUpdateToCosmos,
 } from './stakingUpdate'
 import {
+  transformCosmosToUpdateAdmin,
+  transformUpdateAdminToCosmos,
+  UpdateAdminComponent,
+  updateAdminDefaults,
+} from './updateAdmin'
+import {
   transformCosmosToUpdateMinter,
   transformUpdateMinterToCosmos,
   UpdateMinterComponent,
@@ -160,6 +166,15 @@ export const messageTemplates: MessageTemplate[] = [
     getDefaults: migrateContractDefaults,
     toCosmosMsg: transformMigrateContractToCosmos,
     fromCosmosMsg: transformCosmosToMigrateContract,
+  },
+  {
+    label: '🍄 Update Contract Admin',
+    description: 'Update the admin of a CosmWasm contract.',
+    component: UpdateAdminComponent,
+    contractSupport: ContractSupport.Both,
+    getDefaults: updateAdminDefaults,
+    toCosmosMsg: transformUpdateAdminToCosmos,
+    fromCosmosMsg: transformCosmosToUpdateAdmin,
   },
   {
     label: '🌳 Update Staking Config',

--- a/apps/dapp/templates/updateAdmin.tsx
+++ b/apps/dapp/templates/updateAdmin.tsx
@@ -1,0 +1,101 @@
+import { XIcon } from '@heroicons/react/outline'
+import { useFormContext } from 'react-hook-form'
+
+import { AddressInput, InputErrorMessage, InputLabel } from '@dao-dao/ui'
+import {
+  validateAddress,
+  validateContractAddress,
+  validateRequired,
+} from '@dao-dao/utils'
+
+import { IsAdminWarning } from './migrateContract'
+import { TemplateComponent } from './templateList'
+import { makeWasmMessage } from '@/util/messagehelpers'
+
+interface UpdateAdminData {
+  contract: string
+  newAdmin: string
+}
+
+export const updateAdminDefaults = () => ({
+  contract: '',
+  newAdmin: '',
+})
+
+export const UpdateAdminComponent: TemplateComponent = ({
+  getLabel,
+  onRemove,
+  errors,
+  readOnly,
+  contractAddress,
+}) => {
+  const { register, watch } = useFormContext()
+
+  const contract = watch(getLabel('contract'))
+
+  return (
+    <div className="flex flex-col p-3 my-2 bg-primary rounded-lg">
+      <div className="flex justify-between items-center">
+        <div className="flex gap-2 items-center mb-2">
+          <h2 className="text-3xl">🍄</h2>
+          <h2>Update Contract Admin</h2>
+        </div>
+        {onRemove && (
+          <button onClick={onRemove} type="button">
+            <XIcon className="h-4" />
+          </button>
+        )}
+      </div>
+      <p className="mb-4 max-w-prose secondary-text">
+        This will update the admin for the selected contract. The new admin will
+        have complete control over the contract. Take care.
+      </p>
+      <div className="flex flex-row flex-wrap gap-2">
+        <div className="flex flex-col grow gap-1">
+          <InputLabel name="Contract Address" />
+          <AddressInput
+            disabled={readOnly}
+            error={errors?.contract}
+            label={getLabel('contract')}
+            register={register}
+            validation={[validateRequired, validateContractAddress]}
+          />
+          <InputErrorMessage error={errors?.tokenAddress} />
+        </div>
+        <div className="flex flex-col grow gap-1">
+          <InputLabel name="New Admin" />
+          <AddressInput
+            disabled={readOnly}
+            error={errors?.newAdmin}
+            label={getLabel('newAdmin')}
+            register={register}
+            validation={[validateRequired, validateAddress]}
+          />
+          <InputErrorMessage error={errors?.tokenAddress} />
+        </div>
+      </div>
+      <div className="my-2">
+        <IsAdminWarning contract={contract} maybeAdmin={contractAddress} />
+      </div>
+    </div>
+  )
+}
+export const transformUpdateAdminToCosmos = (self: UpdateAdminData) =>
+  makeWasmMessage({
+    wasm: {
+      update_admin: {
+        contract_addr: self.contract,
+        admin: self.newAdmin,
+      },
+    },
+  })
+
+export const transformCosmosToUpdateAdmin = (
+  msg: Record<string, any>
+): UpdateAdminData | null =>
+  'wasm' in msg && 'update_admin' in msg.wasm
+    ? {
+        contract: msg.wasm.update_admin.contract_addr,
+        newAdmin: msg.wasm.update_admin.admin,
+      }
+    : null

--- a/packages/ui/components/CosmosMessageDisplay.tsx
+++ b/packages/ui/components/CosmosMessageDisplay.tsx
@@ -20,6 +20,7 @@ export interface CosmosMessageDisplayProps {
 export const CosmosMessageDisplay: FC<CosmosMessageDisplayProps> = ({
   value,
 }) => {
+  console.log(value)
   const themeCtx = useThemeContext()
   const editorTheme = themeCtx.theme !== 'dark' ? 'default' : 'material-ocean'
   return (


### PR DESCRIPTION
This adds a template for updating the CosmWasm level admin of a smart contract. It then adds that template to the DAO migration template's generated output so that the staking and token contracts have their admin changed.

<img width="699" alt="image" src="https://user-images.githubusercontent.com/30676292/176572912-95b50717-a3b6-4895-8a30-7c0b21b89a7c.png">
