### PR TITLE
Redirect to v1 URL from legacy

### DIFF
--- a/apps/dapp/.env.development
+++ b/apps/dapp/.env.development
@@ -17,7 +17,6 @@ NEXT_PUBLIC_DAO_DAO_VERSION=$npm_package_version
 NEXT_PUBLIC_FAVORITES_NAMESPACE=19
 NEXT_PUBLIC_GAS_PRICE=0.0025ujunox
 NEXT_PUBLIC_CHAIN_TXN_URL_PREFIX=https://explorer.uni.chaintools.tech/uni/tx/
-NEXT_PUBLIC_V1_URL_PREFIX=https://v1.daodao.zone
 
 # cw-plus Contracts / Codes
 # See: https://github.com/CosmWasm/cw-plus/releases/

--- a/apps/dapp/.env.mainnet
+++ b/apps/dapp/.env.mainnet
@@ -17,7 +17,6 @@ NEXT_PUBLIC_DAO_DAO_VERSION=$npm_package_version
 NEXT_PUBLIC_FAVORITES_NAMESPACE=43
 NEXT_PUBLIC_GAS_PRICE=0.0025ujuno
 NEXT_PUBLIC_CHAIN_TXN_URL_PREFIX=https://mintscan.io/juno/txs/
-NEXT_PUBLIC_V1_URL_PREFIX=https://v1.daodao.zone
 
 # Contracts / Codes
 NEXT_PUBLIC_CW20_CODE_ID=37
@@ -33,3 +32,5 @@ NEXT_PUBLIC_SEARCH_URL=https://dao-search.withoutdoing.com
 NEXT_PUBLIC_SEARCH_API_KEY=geDQZEly47de425b96a1ae8ee53917e75fc8ea27b09afb4dbaec202b91e6ac59f341c568
 NEXT_PUBLIC_MULTISIG_INDEX=mainnet-multisigs
 NEXT_PUBLIC_DAO_INDEX=mainnet-daos
+
+NEXT_PUBLIC_V1_URL=https://v1.daodao.zone 

--- a/apps/dapp/pages/dao/[contractAddress]/index.tsx
+++ b/apps/dapp/pages/dao/[contractAddress]/index.tsx
@@ -11,7 +11,11 @@ import {
   Breadcrumbs,
   MobileMenuTab,
 } from '@dao-dao/ui'
-import { CHAIN_RPC_ENDPOINT, cosmWasmClientRouter } from '@dao-dao/utils'
+import {
+  CHAIN_RPC_ENDPOINT,
+  cosmWasmClientRouter,
+  V1_URL,
+} from '@dao-dao/utils'
 
 import { pinnedDaosAtom } from '@/atoms/pinned'
 import { ContractHeader } from '@/components/ContractHeader'
@@ -280,8 +284,7 @@ export const getStaticProps: GetStaticProps<StaticProps> = async ({
     ) {
       return {
         redirect: {
-          destination:
-            process.env.NEXT_PUBLIC_V1_URL_PREFIX + `/dao/${contractAddress}`,
+          destination: V1_URL + `/dao/${contractAddress}`,
           permanent: false,
         },
       }

--- a/apps/dapp/pages/dao/[contractAddress]/proposals/[proposalId].tsx
+++ b/apps/dapp/pages/dao/[contractAddress]/proposals/[proposalId].tsx
@@ -4,7 +4,7 @@ import { FC } from 'react'
 import { useRecoilValue } from 'recoil'
 
 import { Breadcrumbs, LoadingScreen } from '@dao-dao/ui'
-import { CHAIN_RPC_ENDPOINT } from '@dao-dao/utils'
+import { CHAIN_RPC_ENDPOINT, V1_URL } from '@dao-dao/utils'
 
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { ProposalDetails } from '@/components/ProposalDetails'
@@ -112,8 +112,7 @@ export const getStaticProps: GetStaticProps = async ({
       return {
         redirect: {
           destination:
-            process.env.NEXT_PUBLIC_V1_URL_PREFIX +
-            `/dao/${contractAddress}/proposals/${proposalId}`,
+            V1_URL + `/dao/${contractAddress}/proposals/${proposalId}`,
           permanent: false,
         },
       }

--- a/apps/dapp/pages/dao/[contractAddress]/proposals/create.tsx
+++ b/apps/dapp/pages/dao/[contractAddress]/proposals/create.tsx
@@ -8,7 +8,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil'
 
 import { useWallet } from '@dao-dao/state'
 import { CopyToClipboard, Breadcrumbs, LoadingScreen } from '@dao-dao/ui'
-import { CHAIN_RPC_ENDPOINT } from '@dao-dao/utils'
+import { CHAIN_RPC_ENDPOINT, V1_URL } from '@dao-dao/utils'
 
 import { proposalsCreatedAtom } from '@/atoms/proposals'
 import { ProposalData, ProposalForm } from '@/components/ProposalForm'
@@ -198,9 +198,7 @@ export const getStaticProps: GetStaticProps = async ({
     ) {
       return {
         redirect: {
-          destination:
-            process.env.NEXT_PUBLIC_V1_URL_PREFIX +
-            `/dao/${contractAddress}/proposals/create`,
+          destination: V1_URL + `/dao/${contractAddress}/proposals/create`,
           permanent: false,
         },
       }


### PR DESCRIPTION
Part of #633 

Redirects to https://v1.daodao.zone/* if trying to access a v1 DAO on the legacy site.

_Environment variables have already been added to Vercel (`dao-dao` project)._

Example v1 DOG DAO:
https://dao-f0hwrz93k-da0da0.vercel.app/dao/juno1czh5dy2kxwwt5hlw6rr2q25clj96sheftsdccswg9qe34m3wzgdswmw8ju redirects to `https://v1.daodao.zone/dao/juno1czh5dy2kxwwt5hlw6rr2q25clj96sheftsdccswg9qe34m3wzgdswmw8ju`