### PR TITLE
Fixed spacing class name on home page

### DIFF
--- a/apps/dapp/pages/home.tsx
+++ b/apps/dapp/pages/home.tsx
@@ -13,7 +13,7 @@ const HomePage: NextPage = () => (
   <>
     <SmallScreenNav />
 
-    <div className="gap-y-6 px-4 md:p-6">
+    <div className="px-4 space-y-6 md:p-6">
       <PinnedProposalsList />
       <PinnedDAOsList />
       <FeaturedDAOsList />


### PR DESCRIPTION
Changed `gap-y-6` to `space-y-6`