### PR TITLE
Render markdown for DAO descriptions.

### DIFF
--- a/packages/ui/components/ContractView/ContractHeader.tsx
+++ b/packages/ui/components/ContractView/ContractHeader.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 
+import { MarkdownPreview } from '@dao-dao/ui'
 import { HEADER_IMAGES_ENABLED } from '@dao-dao/utils'
 
 import { Logo } from '../Logo'
@@ -36,7 +37,10 @@ export const ContractHeader: FC<ContractHeaderProps> = ({
       {established && <EstablishedDate date={established} />}
     </div>
     <div className="mt-2 mb-4">
-      <p className="whitespace-pre-wrap body-text">{description}</p>
+      <MarkdownPreview
+        className="whitespace-pre-wrap body-text"
+        markdown={description}
+      />
     </div>
   </div>
 )


### PR DESCRIPTION
This renders DAO descriptions as markdown. This helps when we want to link to v1 DAOs from beta DAOs.
<img width="550" alt="image" src="https://user-images.githubusercontent.com/30676292/176980471-11406edf-8c1e-41a1-80c9-29a7af13d0c0.png">
