### PR TITLE
Proposal page anchor links

### DIFF
--- a/packages/actions/components/ActionsRenderer.tsx
+++ b/packages/actions/components/ActionsRenderer.tsx
@@ -1,4 +1,5 @@
-import { FC, FunctionComponent } from 'react'
+import { CheckCircleIcon, LinkIcon } from '@heroicons/react/outline'
+import { FC, FunctionComponent, useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { SuspenseLoader } from '@dao-dao/ui'
@@ -33,22 +34,50 @@ const InnerActionsRenderer: FunctionComponent<ActionsRendererProps> = ({
     ),
   })
 
+  const [copied, setCopied] = useState<number>()
+  // Unset copied after 2 seconds.
+  useEffect(() => {
+    const timeout = setTimeout(() => setCopied(undefined), 2000)
+    // Cleanup on unmount.
+    return () => clearTimeout(timeout)
+  }, [copied])
+
   return (
     <FormProvider {...formMethods}>
       <form>
         {actionData.map(({ action: { Component } }, index) => (
-          <Component
-            key={index}
-            allActionsWithData={actionData.map(({ action: { key }, data }) => ({
-              key,
-              data,
-            }))}
-            coreAddress={coreAddress}
-            getFieldName={(field: string) => `${index}.${field}`}
-            index={index}
-            proposalId={proposalId}
-            readOnly
-          />
+          <div key={index} className="group relative" id={`A${index + 1}`}>
+            <Component
+              allActionsWithData={actionData.map(
+                ({ action: { key }, data }) => ({
+                  key,
+                  data,
+                })
+              )}
+              coreAddress={coreAddress}
+              getFieldName={(field: string) => `${index}.${field}`}
+              index={index}
+              proposalId={proposalId}
+              readOnly
+            />
+
+            <button
+              className="absolute top-1 -right-5 opacity-0 group-hover:opacity-100 transition-opacity"
+              onClick={() => {
+                const url = new URL(window.location.href)
+                url.hash = '#' + `A${index + 1}`
+                navigator.clipboard.writeText(url.href)
+                setCopied(index)
+              }}
+              type="button"
+            >
+              {copied === index ? (
+                <CheckCircleIcon className="w-4" />
+              ) : (
+                <LinkIcon className="w-4" />
+              )}
+            </button>
+          </div>
         ))}
       </form>
     </FormProvider>

--- a/packages/ui/components/MarkdownPreview.tsx
+++ b/packages/ui/components/MarkdownPreview.tsx
@@ -44,7 +44,7 @@ const HeadingRenderer: HeadingComponent = ({
     return () => clearTimeout(timeout)
   }, [copied])
 
-  const id = `l${sourcePosition!.start.line}`
+  const id = `L${sourcePosition!.start.line}`
 
   return createElement(
     'h' + level,

--- a/packages/ui/components/ProposalDetails/ProposalDetails.tsx
+++ b/packages/ui/components/ProposalDetails/ProposalDetails.tsx
@@ -99,10 +99,18 @@ export const ProposalDetails: FC<ProposalDetailsProps> = ({
   // renders.
   useEffect(() => {
     if (typeof window !== 'undefined' && window.location.hash) {
-      document
-        // Ignore the '#' character at the beginning.
-        .getElementById(window.location.hash.slice(1))
-        ?.scrollIntoView({ behavior: 'smooth' })
+      // Ignore the '#' character at the beginning.
+      const element = document.getElementById(window.location.hash.slice(1))
+      if (!element) {
+        return
+      }
+
+      // 24px offset so the element isn't touching the edge of the browser.
+      const top = element.getBoundingClientRect().top + window.scrollY - 24
+      window.scrollTo({
+        top,
+        behavior: 'smooth',
+      })
     }
   }, [])
 


### PR DESCRIPTION
Resolves #547 

Added Github-style markdown heading anchor linking that becomes visible on hover.
<img width="976" alt="Screen Shot 2022-07-05 at 7 16 04 PM" src="https://user-images.githubusercontent.com/6721426/177453390-64f392c1-26f1-4ef3-8c62-743d0e423e76.png">

Also actions.
<img width="779" alt="Screen Shot 2022-07-06 at 12 07 51 PM" src="https://user-images.githubusercontent.com/6721426/177624689-ded6a2be-b449-49ce-b7e8-3a67bdaffb87.png">
