### PR TITLE
Prevent voting duration shorter than 60 seconds.

### DIFF
--- a/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
@@ -275,12 +275,12 @@ export const CreateDAOVotingDurationCard: FC<
             validation={[
               validatePositive,
               validateRequired,
-              // Prevent < 30 second voting duration since DAOs will brick
+              // Prevent < 60 second voting duration since DAOs will brick
               // if the voting duration is shorter tahn 1 block.
               (value) =>
                 votingDuration.units !== DurationUnits.Seconds ||
-                value >= 30 ||
-                'Cannot be shorter than 30 seconds.',
+                value >= 60 ||
+                'Cannot be shorter than 60 seconds.',
             ]}
           />
 

--- a/packages/actions/components/UpdateProposalConfig.tsx
+++ b/packages/actions/components/UpdateProposalConfig.tsx
@@ -283,12 +283,12 @@ export const UpdateProposalConfigComponent: ActionComponent<
               validation={[
                 validatePositive,
                 validateRequired,
-                // Prevent < 30 second voting duration since DAOs will
+                // Prevent < 60 second voting duration since DAOs will
                 // brick if the voting duration is shorter tahn 1 block.
                 (value) =>
                   proposalDurationUnits !== 'seconds' ||
-                  value >= 30 ||
-                  'Cannot be shorter than 30 seconds.',
+                  value >= 60 ||
+                  'Cannot be shorter than 60 seconds.',
               ]}
             />
             <InputErrorMessage error={errors?.proposalDuration} />


### PR DESCRIPTION
Resolves #499 

Prevent bricking DAOs because someone puts a voting duration shorter than block time. Why someone would use a 6 second voting duration I do not know. But let's disallow it anyway.