### PR TITLE
Set default values for deposit info.

### DIFF
--- a/packages/actions/actions/UpdateProposalConfig.tsx
+++ b/packages/actions/actions/UpdateProposalConfig.tsx
@@ -87,7 +87,10 @@ const useDefaults: UseDefaults<UpdateProposalConfigData> = (
         refundFailedProposals:
           proposalModuleConfig.deposit_info.refund_failed_proposals,
       }
-    : undefined
+    : {
+        deposit: '0',
+        refundFailedProposals: false,
+      }
   const proposalDuration =
     'time' in proposalModuleConfig.max_voting_period
       ? proposalModuleConfig.max_voting_period.time


### PR DESCRIPTION
This fixes a bug where this was being set to undefined meaning that the field would not be filled correctly causing an error. Reported in the discord.