### PR TITLE
Encode duplicate data in URI

### DIFF
--- a/apps/dapp/pages/dao/[address]/proposals/[proposalId].tsx
+++ b/apps/dapp/pages/dao/[address]/proposals/[proposalId].tsx
@@ -167,8 +167,8 @@ const InnerProposal: FC = () => {
       }
 
       router.push(
-        `/dao/${coreAddress}/proposals/create?prefill=${JSON.stringify(
-          duplicateFormData
+        `/dao/${coreAddress}/proposals/create?prefill=${encodeURIComponent(
+          JSON.stringify(duplicateFormData)
         )}`
       )
     },

--- a/apps/raw-sda/pages/vote/[proposalId].tsx
+++ b/apps/raw-sda/pages/vote/[proposalId].tsx
@@ -173,7 +173,11 @@ const InnerProposal: FC = () => {
         })),
       }
 
-      router.push(`/propose?prefill=${JSON.stringify(duplicateFormData)}`)
+      router.push(
+        `/propose?prefill=${encodeURIComponent(
+          JSON.stringify(duplicateFormData)
+        )}`
+      )
     },
     [
       proposalResponse.proposal.description,

--- a/apps/sda-base/pages/vote/[proposalId].tsx
+++ b/apps/sda-base/pages/vote/[proposalId].tsx
@@ -166,7 +166,11 @@ const InnerProposal: FC = () => {
         })),
       }
 
-      router.push(`/propose?prefill=${JSON.stringify(duplicateFormData)}`)
+      router.push(
+        `/propose?prefill=${encodeURIComponent(
+          JSON.stringify(duplicateFormData)
+        )}`
+      )
     },
     [
       proposalResponse.proposal.description,


### PR DESCRIPTION
We were not using `encodeURIComponent` with encoded prefill data on duplicating a proposal. This caused issues when certain symbols were present.