### PR TITLE
Expand initial page loader to fill screen

### DIFF
--- a/apps/dapp/components/DAOPageWrapper.tsx
+++ b/apps/dapp/components/DAOPageWrapper.tsx
@@ -7,10 +7,11 @@ import {
   useContext,
 } from 'react'
 
-import { Loader, SuspenseLoader } from '@dao-dao/ui'
+import { SuspenseLoader } from '@dao-dao/ui'
 import { VotingModuleType } from '@dao-dao/utils'
 
 import { DAONotFound } from './dao/NotFound'
+import { PageLoader } from './Loader'
 
 interface DAOInfo {
   coreAddress: string
@@ -76,7 +77,7 @@ export const DAOPageWrapper: FunctionComponent<DAOPageWrapperProps> = ({
         title={title}
       />
 
-      <SuspenseLoader fallback={<Loader />}>
+      <SuspenseLoader fallback={<PageLoader />}>
         {/* We only know a DAO is not found if info is still empty when
          * when the page is ready and not a fallback page.
          */}


### PR DESCRIPTION
Current first loader displays small and at the top edge of the page, which looks weird. We should be using the larger, centered `PageLoader` component in our suspending page wrapper.