### PR TITLE
Don't spam git with vercel deploys on main

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
This prevents Vercel commenting on PRs and commits with preview deploys of the Vercel `dao-dao` legacy project since it wastes time on Vercel building preview branches. `main` is running legacy, basically completely detached from our current development flow.