### PR TITLE
Don't prevent DAO page rendering if image fails to load in static props

### DIFF
--- a/apps/dapp/pages/dao/[address]/index.tsx
+++ b/apps/dapp/pages/dao/[address]/index.tsx
@@ -266,13 +266,18 @@ export const getStaticProps: GetStaticProps<DaoHomePageProps> =
       return
     }
 
-    const response = await axios.get(image_url, {
-      responseType: 'arraybuffer',
-    })
-    const buffer = Buffer.from(response.data, 'binary')
-    const result = await getAverageColor(buffer)
+    try {
+      const response = await axios.get(image_url, {
+        responseType: 'arraybuffer',
+      })
+      const buffer = Buffer.from(response.data, 'binary')
+      const result = await getAverageColor(buffer)
 
-    return {
-      additionalProps: { accentColor: result.rgb },
+      return {
+        additionalProps: { accentColor: result.rgb },
+      }
+    } catch (error) {
+      // If fail to load image or get color, don't prevent page render.
+      console.error(error)
     }
   })


### PR DESCRIPTION
The [Core 1](https://daodao.zone/dao/juno1gpwekludv6vu8pkpnp2hwwf7f84a7mcvgm9t2cvp92hvpxk07kdq8z4xj2) multisig is failing to render because the image URL no longer exists, and so an error is thrown in `getStaticProps`.

This PR logs the error to the console but continues to render the page anyway, as we should have done.