### PR TITLE
Only fetch stats on homepage once on mount.

### DIFF
--- a/apps/dapp/pages/index.tsx
+++ b/apps/dapp/pages/index.tsx
@@ -1,7 +1,7 @@
 import { ArrowNarrowRightIcon } from '@heroicons/react/solid'
 import type { GetStaticProps, NextPage } from 'next'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { serverSideTranslations } from '@dao-dao/i18n/serverSideTranslations'
@@ -31,15 +31,17 @@ const Home: NextPage = () => {
   const [daos, setDaos] = useState<string | undefined>(undefined)
   const [proposals, setProposals] = useState<string | undefined>(undefined)
 
-  fetch('https://dao-stats.withoutdoing.com/mainnet/balances.json')
-    .then((response) => response.json())
-    .then((data) => setTVL(data[data.length - 1].value))
-  fetch('https://dao-stats.withoutdoing.com/mainnet/count.json')
-    .then((response) => response.json())
-    .then((data) => setDaos(data[data.length - 1].value))
-  fetch('https://dao-stats.withoutdoing.com/mainnet/proposals.json')
-    .then((response) => response.json())
-    .then((data) => setProposals(data[data.length - 1].value))
+  useEffect(() => {
+    fetch('https://dao-stats.withoutdoing.com/mainnet/balances.json')
+      .then((response) => response.json())
+      .then((data) => setTVL(data[data.length - 1].value))
+    fetch('https://dao-stats.withoutdoing.com/mainnet/count.json')
+      .then((response) => response.json())
+      .then((data) => setDaos(data[data.length - 1].value))
+    fetch('https://dao-stats.withoutdoing.com/mainnet/proposals.json')
+      .then((response) => response.json())
+      .then((data) => setProposals(data[data.length - 1].value))
+  }, [])
 
   return (
     <SuspenseLoader fallback={<LoadingScreen />}>


### PR DESCRIPTION
Resolves #743 

Stop querying data on every render!