### PR TITLE
Removed typo-ful copy from frontpage

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -308,7 +308,7 @@
     "daosCreated": "DAOs Created",
     "documentation": "Documentation",
     "easyToUse": "Easy-to-use interface",
-    "easyToUseExplanation": "No more command line wrangling just to vote on a proposal. DAO DAO'ss visual UI makes collective ownership accessible to everyone.",
+    "easyToUseExplanation": "DAO DAO's visual interface makes governance accessible to everyone.",
     "joinTheCommunity": "Join the community",
     "longTagline": "Simple, capable, and free DAO tooling. Built with love, by DAO DAO, on Juno.",
     "poweredByJuno": "Powered by Juno",


### PR DESCRIPTION
Removed a typoful piece of copy, and replaced it with a simpler suggestion from @caseorganic 