### PR TITLE
Fixed spend action and refactored getFieldName

### DIFF
--- a/packages/actions/actions/AddToken.tsx
+++ b/packages/actions/actions/AddToken.tsx
@@ -27,11 +27,11 @@ const useDefaults: UseDefaults<AddTokenData> = () => ({
 })
 
 const Component: ActionComponent = (props) => {
-  const { getFieldName, errors, Loader } = props
+  const { fieldNamePrefix, errors, Loader } = props
 
   const { watch, setError, clearErrors } = useFormContext()
 
-  const tokenAddress = watch(getFieldName('address'))
+  const tokenAddress = watch(fieldNamePrefix + 'address')
   const tokenInfoLoadable = useRecoilValueLoadable(
     tokenAddress
       ? Cw20BaseSelectors.tokenInfoSelector({
@@ -44,13 +44,13 @@ const Component: ActionComponent = (props) => {
   useEffect(() => {
     if (tokenInfoLoadable.state !== 'hasError') {
       if (errors?.address) {
-        clearErrors(getFieldName('address'))
+        clearErrors(fieldNamePrefix + 'address')
       }
       return
     }
 
     if (!errors?.address) {
-      setError(getFieldName('address'), {
+      setError(fieldNamePrefix + 'address', {
         type: 'manual',
         message: 'Failed to get token info.',
       })
@@ -60,7 +60,7 @@ const Component: ActionComponent = (props) => {
     errors?.address,
     setError,
     clearErrors,
-    getFieldName,
+    fieldNamePrefix,
   ])
 
   return (

--- a/packages/actions/actions/Instantiate.tsx
+++ b/packages/actions/actions/Instantiate.tsx
@@ -120,7 +120,7 @@ const Component: ActionComponent = (props) => {
   )
 
   const { watch } = useFormContext()
-  const codeId: number = watch(props.getFieldName('codeId'))
+  const codeId: number = watch(props.fieldNamePrefix + 'codeId')
   // This gets all instantiation actions that instantiate the same codeId
   // and all addresses actually instantiated in the transaction on-chain.
   // If these two lists are not the same length, then another instantiation

--- a/packages/actions/actions/RemoveToken.tsx
+++ b/packages/actions/actions/RemoveToken.tsx
@@ -35,11 +35,11 @@ const useDefaults: UseDefaults<RemoveTokenData> = () => ({
 })
 
 const InnerComponent: ActionComponent = (props) => {
-  const { getFieldName, errors, Loader } = props
+  const { fieldNamePrefix, errors, Loader } = props
 
   const { watch, setError, clearErrors } = useFormContext()
 
-  const tokenAddress = watch(getFieldName('address'))
+  const tokenAddress = watch(fieldNamePrefix + 'address')
   const tokenInfoLoadable = useRecoilValueLoadable(
     tokenAddress
       ? Cw20BaseSelectors.tokenInfoSelector({
@@ -80,13 +80,13 @@ const InnerComponent: ActionComponent = (props) => {
   useEffect(() => {
     if (tokenInfoLoadable.state !== 'hasError' && existingTokens.length > 0) {
       if (errors?.address) {
-        clearErrors(getFieldName('address'))
+        clearErrors(fieldNamePrefix + 'address')
       }
       return
     }
 
     if (!errors?.address) {
-      setError(getFieldName('address'), {
+      setError(fieldNamePrefix + 'address', {
         type: 'manual',
         message:
           tokenInfoLoadable.state === 'hasError'
@@ -101,7 +101,7 @@ const InnerComponent: ActionComponent = (props) => {
     errors?.address,
     setError,
     clearErrors,
-    getFieldName,
+    fieldNamePrefix,
     existingTokens.length,
   ])
 

--- a/packages/actions/components/ActionsRenderer.tsx
+++ b/packages/actions/components/ActionsRenderer.tsx
@@ -63,7 +63,7 @@ const InnerActionsRenderer = ({
               )}
               coreAddress={coreAddress}
               data={actionData[index].data}
-              getFieldName={(field: string) => `${index}.${field}`}
+              fieldNamePrefix={`${index}.`}
               index={index}
               proposalModule={proposalModule}
               readOnly

--- a/packages/actions/components/AddToken.tsx
+++ b/packages/actions/components/AddToken.tsx
@@ -17,7 +17,7 @@ import {
 import { ActionCard, ActionComponent } from '..'
 
 export const AddTokenComponent: ActionComponent<TokenInfoDisplayProps> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -37,7 +37,7 @@ export const AddTokenComponent: ActionComponent<TokenInfoDisplayProps> = ({
         <AddressInput
           disabled={readOnly}
           error={errors?.address}
-          fieldName={getFieldName('address')}
+          fieldName={fieldNamePrefix + 'address'}
           register={register}
           validation={[validateRequired, validateContractAddress]}
         />

--- a/packages/actions/components/Custom.tsx
+++ b/packages/actions/components/Custom.tsx
@@ -12,7 +12,7 @@ import { ActionCard, ActionComponent } from '..'
 const INVALID_COSMOS_MSG = 'INVALID_COSMOS_MSG'
 
 export const CustomComponent: ActionComponent = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -26,7 +26,7 @@ export const CustomComponent: ActionComponent = ({
       <CodeMirrorInput
         control={control}
         error={errors?.message}
-        fieldName={getFieldName('message')}
+        fieldName={fieldNamePrefix + 'message'}
         readOnly={readOnly}
         validation={[
           (v: string) => {

--- a/packages/actions/components/Execute.tsx
+++ b/packages/actions/components/Execute.tsx
@@ -30,7 +30,7 @@ export interface ExecuteOptions {
 
 export const ExecuteComponent: ActionComponent<ExecuteOptions> = (props) => {
   const { t } = useTranslation()
-  const { getFieldName, onRemove, errors, readOnly } = props
+  const { fieldNamePrefix, onRemove, errors, readOnly } = props
   const { register, control } = useFormContext()
   const {
     fields: coins,
@@ -38,7 +38,7 @@ export const ExecuteComponent: ActionComponent<ExecuteOptions> = (props) => {
     remove: removeCoin,
   } = useFieldArray({
     control,
-    name: getFieldName('funds'),
+    name: fieldNamePrefix + 'funds',
   })
 
   return (
@@ -52,7 +52,7 @@ export const ExecuteComponent: ActionComponent<ExecuteOptions> = (props) => {
         <TextInput
           disabled={readOnly}
           error={errors?.address}
-          fieldName={getFieldName('address')}
+          fieldName={fieldNamePrefix + 'address'}
           placeholder="juno..."
           register={register}
           validation={[validateRequired, validateContractAddress]}
@@ -64,7 +64,7 @@ export const ExecuteComponent: ActionComponent<ExecuteOptions> = (props) => {
       <CodeMirrorInput
         control={control}
         error={errors?.message}
-        fieldName={getFieldName('message')}
+        fieldName={fieldNamePrefix + 'message'}
         readOnly={readOnly}
         validation={[
           (v: string) => {
@@ -107,9 +107,7 @@ export const ExecuteComponent: ActionComponent<ExecuteOptions> = (props) => {
             key={id}
             {...props}
             errors={errors?.funds?.[index]}
-            getFieldName={(field: string) =>
-              getFieldName(`funds.${index}.${field}`)
-            }
+            fieldNamePrefix={fieldNamePrefix + `funds.${index}.`}
             onRemove={() => removeCoin(index)}
           />
         ))}

--- a/packages/actions/components/Instantiate.tsx
+++ b/packages/actions/components/Instantiate.tsx
@@ -36,7 +36,7 @@ export const InstantiateComponent: ActionComponent<InstantiateOptions> = (
 ) => {
   const { t } = useTranslation()
   const {
-    getFieldName,
+    fieldNamePrefix,
     onRemove,
     errors,
     readOnly,
@@ -49,7 +49,7 @@ export const InstantiateComponent: ActionComponent<InstantiateOptions> = (
     remove: removeCoin,
   } = useFieldArray({
     control,
-    name: getFieldName('funds'),
+    name: fieldNamePrefix + 'funds',
   })
 
   return (
@@ -74,7 +74,7 @@ export const InstantiateComponent: ActionComponent<InstantiateOptions> = (
           <NumberInput
             disabled={readOnly}
             error={errors?.codeId}
-            fieldName={getFieldName('codeId')}
+            fieldName={fieldNamePrefix + 'codeId'}
             register={register}
             sizing="sm"
             step={1}
@@ -88,7 +88,7 @@ export const InstantiateComponent: ActionComponent<InstantiateOptions> = (
           <TextInput
             disabled={readOnly}
             error={errors?.label}
-            fieldName={getFieldName('label')}
+            fieldName={fieldNamePrefix + 'label'}
             register={register}
             validation={[validateRequired]}
           />
@@ -100,7 +100,7 @@ export const InstantiateComponent: ActionComponent<InstantiateOptions> = (
       <CodeMirrorInput
         control={control}
         error={errors?.message}
-        fieldName={getFieldName('message')}
+        fieldName={fieldNamePrefix + 'message'}
         readOnly={readOnly}
         validation={[
           (v: string) => {
@@ -143,9 +143,7 @@ export const InstantiateComponent: ActionComponent<InstantiateOptions> = (
             key={id}
             {...props}
             errors={errors?.funds?.[index]}
-            getFieldName={(field: string) =>
-              getFieldName(`funds.${index}.${field}`)
-            }
+            fieldNamePrefix={fieldNamePrefix + `funds.${index}.`}
             onRemove={() => removeCoin(index)}
           />
         ))}
@@ -170,7 +168,7 @@ export const InstantiateComponent: ActionComponent<InstantiateOptions> = (
         <TextInput
           disabled={readOnly}
           error={errors?.admin}
-          fieldName={getFieldName('admin')}
+          fieldName={fieldNamePrefix + 'admin'}
           placeholder={readOnly ? t('info.none') : 'juno...'}
           register={register}
           validation={[(v: string) => validateContractAddress(v, false)]}

--- a/packages/actions/components/MigrateContract.tsx
+++ b/packages/actions/components/MigrateContract.tsx
@@ -26,7 +26,7 @@ export interface MigrateOptions {
 }
 
 export const MigrateContractComponent: ActionComponent<MigrateOptions> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -63,7 +63,7 @@ export const MigrateContractComponent: ActionComponent<MigrateOptions> = ({
           <AddressInput
             disabled={readOnly}
             error={errors?.contract_addr}
-            fieldName={getFieldName('contract')}
+            fieldName={fieldNamePrefix + 'contract'}
             onChange={(v) => onContractChange(v.target.value)}
             register={register}
             validation={[validateRequired, validateContractAddress]}
@@ -75,7 +75,7 @@ export const MigrateContractComponent: ActionComponent<MigrateOptions> = ({
           <NumberInput
             disabled={readOnly}
             error={errors?.code_id}
-            fieldName={getFieldName('codeId')}
+            fieldName={fieldNamePrefix + 'codeId'}
             register={register}
             validation={[validateRequired, validatePositive]}
           />
@@ -90,7 +90,7 @@ export const MigrateContractComponent: ActionComponent<MigrateOptions> = ({
         <CodeMirrorInput
           control={control}
           error={errors?.msg}
-          fieldName={getFieldName('msg')}
+          fieldName={fieldNamePrefix + 'msg'}
           readOnly={readOnly}
           validation={[validateJSON]}
         />

--- a/packages/actions/components/NativeCoinSelector.tsx
+++ b/packages/actions/components/NativeCoinSelector.tsx
@@ -24,7 +24,7 @@ export interface NativeCoinSelectorProps
 
 export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
   onRemove,
-  getFieldName,
+  fieldNamePrefix,
   errors,
   readOnly,
   options: { nativeBalances },
@@ -33,8 +33,8 @@ export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
   const { t } = useTranslation()
   const { register, setValue, watch, setError, clearErrors } = useFormContext()
 
-  const watchAmount = watch(getFieldName('amount'))
-  const watchDenom = watch(getFieldName('denom'))
+  const watchAmount = watch(fieldNamePrefix + 'amount')
+  const watchDenom = watch(fieldNamePrefix + 'denom')
 
   const validatePossibleSpend = useCallback(
     (id: string, amount: string): string | boolean => {
@@ -77,15 +77,15 @@ export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
   // denom was changed.
   useEffect(() => {
     if (!watchAmount || !watchDenom) {
-      clearErrors(getFieldName('_error'))
+      clearErrors(fieldNamePrefix + '_error')
       return
     }
 
     const validation = validatePossibleSpend(watchDenom, watchAmount)
     if (validation === true) {
-      clearErrors(getFieldName('_error'))
+      clearErrors(fieldNamePrefix + '_error')
     } else if (typeof validation === 'string') {
-      setError(getFieldName('_error'), {
+      setError(fieldNamePrefix + '_error', {
         type: 'custom',
         message: validation,
       })
@@ -94,7 +94,7 @@ export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
     setError,
     clearErrors,
     validatePossibleSpend,
-    getFieldName,
+    fieldNamePrefix,
     watchAmount,
     watchDenom,
   ])
@@ -105,16 +105,16 @@ export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
         <NumberInput
           disabled={readOnly}
           error={errors?.amount}
-          fieldName={getFieldName('amount')}
+          fieldName={fieldNamePrefix + 'amount'}
           onPlusMinus={[
             () =>
               setValue(
-                getFieldName('amount'),
+                fieldNamePrefix + 'amount',
                 Math.max(Number(watchAmount) + 1, 1 / 10 ** NATIVE_DECIMALS)
               ),
             () =>
               setValue(
-                getFieldName('amount'),
+                fieldNamePrefix + 'amount',
                 Math.max(Number(watchAmount) - 1, 1 / 10 ** NATIVE_DECIMALS)
               ),
           ]}
@@ -128,7 +128,7 @@ export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
           defaultValue={NATIVE_DENOM}
           disabled={readOnly}
           error={errors?.denom}
-          fieldName={getFieldName('denom')}
+          fieldName={fieldNamePrefix + 'denom'}
           register={register}
         >
           {nativeBalances.map(({ denom }) => (

--- a/packages/actions/components/RemoveToken.tsx
+++ b/packages/actions/components/RemoveToken.tsx
@@ -26,7 +26,7 @@ type RemoveTokenOptions = TokenInfoDisplayProps & {
 }
 
 export const RemoveTokenComponent: ActionComponent<RemoveTokenOptions> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -35,7 +35,7 @@ export const RemoveTokenComponent: ActionComponent<RemoveTokenOptions> = ({
   const { t } = useTranslation()
   const { register, watch, setValue } = useFormContext()
 
-  const tokenAddress = watch(getFieldName('address'))
+  const tokenAddress = watch(fieldNamePrefix + 'address')
 
   const validateIsTreasuryToken = (v: string) =>
     existingTokens.some(({ address }) => address === v) ||
@@ -58,7 +58,7 @@ export const RemoveTokenComponent: ActionComponent<RemoveTokenOptions> = ({
                   'text-secondary bg-transparent': address !== tokenAddress,
                 })}
                 disabled={readOnly}
-                onClick={() => setValue(getFieldName('address'), address)}
+                onClick={() => setValue(fieldNamePrefix + 'address', address)}
                 size="sm"
                 type="button"
                 variant="secondary"
@@ -75,7 +75,7 @@ export const RemoveTokenComponent: ActionComponent<RemoveTokenOptions> = ({
         <AddressInput
           disabled={readOnly}
           error={errors?.address}
-          fieldName={getFieldName('address')}
+          fieldName={fieldNamePrefix + 'address'}
           register={register}
           validation={[
             validateRequired,

--- a/packages/actions/components/Spend.tsx
+++ b/packages/actions/components/Spend.tsx
@@ -34,7 +34,7 @@ interface SpendOptions {
 }
 
 export const SpendComponent: ActionComponent<SpendOptions> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -43,8 +43,8 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
   const { t } = useTranslation()
   const { register, watch, setValue, setError, clearErrors } = useFormContext()
 
-  const spendAmount = watch(getFieldName('amount'))
-  const spendDenom = watch(getFieldName('denom'))
+  const spendAmount = watch(fieldNamePrefix + 'amount')
+  const spendDenom = watch(fieldNamePrefix + 'denom')
 
   const validatePossibleSpend = useCallback(
     (id: string, amount: string): string | boolean => {
@@ -106,15 +106,15 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
   // denom was changed.
   useEffect(() => {
     if (!spendDenom || !spendAmount) {
-      clearErrors(getFieldName('_error'))
+      clearErrors(fieldNamePrefix + '_error')
       return
     }
 
     const validation = validatePossibleSpend(spendDenom, spendAmount)
     if (validation === true) {
-      clearErrors(getFieldName('_error'))
+      clearErrors(fieldNamePrefix + '_error')
     } else if (typeof validation === 'string') {
-      setError(getFieldName('_error'), {
+      setError(fieldNamePrefix + '_error', {
         type: 'custom',
         message: validation,
       })
@@ -125,7 +125,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
     setError,
     clearErrors,
     validatePossibleSpend,
-    getFieldName,
+    fieldNamePrefix,
   ])
 
   const amountDecimals = useMemo(
@@ -142,11 +142,11 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
           <NumberInput
             disabled={readOnly}
             error={errors?.amount}
-            fieldName={getFieldName('amount')}
+            fieldName={fieldNamePrefix + 'amount'}
             onPlusMinus={[
               () =>
                 setValue(
-                  getFieldName('amount'),
+                  fieldNamePrefix + 'amount',
                   Math.max(
                     Number(spendAmount) + 1,
                     1 / 10 ** amountDecimals
@@ -154,7 +154,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
                 ),
               () =>
                 setValue(
-                  getFieldName('amount'),
+                  fieldNamePrefix + 'amount',
                   Math.max(
                     Number(spendAmount) - 1,
                     1 / 10 ** amountDecimals
@@ -171,7 +171,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
             defaultValue={NATIVE_DENOM}
             disabled={readOnly}
             error={errors?.denom}
-            fieldName={getFieldName('denom')}
+            fieldName={fieldNamePrefix + 'denom'}
             register={register}
           >
             {nativeBalances.map(({ denom }) => (
@@ -195,7 +195,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
             containerClassName="grow"
             disabled={readOnly}
             error={errors?.to}
-            fieldName={getFieldName('to')}
+            fieldName={fieldNamePrefix + 'to'}
             register={register}
             validation={[validateRequired, validateAddress]}
           />

--- a/packages/actions/components/Stake.tsx
+++ b/packages/actions/components/Stake.tsx
@@ -49,7 +49,7 @@ interface StakeOptions {
 }
 
 export const StakeComponent: ActionComponent<StakeOptions> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -58,9 +58,9 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
   const { t } = useTranslation()
   const { register, watch, setError, clearErrors, setValue } = useFormContext()
 
-  const stakeType = watch(getFieldName('stakeType'))
-  const amount = watch(getFieldName('amount'))
-  const denom = watch(getFieldName('denom'))
+  const stakeType = watch(fieldNamePrefix + 'stakeType')
+  const amount = watch(fieldNamePrefix + 'amount')
+  const denom = watch(fieldNamePrefix + 'denom')
 
   const validatePossibleSpend = useCallback(
     (denom: string, amount: string): string | boolean => {
@@ -105,15 +105,15 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
   // denom was changed.
   useEffect(() => {
     if (!amount || !denom) {
-      clearErrors(getFieldName('_error'))
+      clearErrors(fieldNamePrefix + '_error')
       return
     }
 
     const validation = validatePossibleSpend(denom, amount)
     if (validation === true) {
-      clearErrors(getFieldName('_error'))
+      clearErrors(fieldNamePrefix + '_error')
     } else if (typeof validation === 'string') {
-      setError(getFieldName('_error'), {
+      setError(fieldNamePrefix + '_error', {
         type: 'custom',
         message: validation,
       })
@@ -122,7 +122,7 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
     setError,
     clearErrors,
     validatePossibleSpend,
-    getFieldName,
+    fieldNamePrefix,
     amount,
     denom,
   ])
@@ -134,7 +134,7 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
           defaultValue={stakeActions[0].type}
           disabled={readOnly}
           error={errors?.stakeType}
-          fieldName={getFieldName('stakeType')}
+          fieldName={fieldNamePrefix + 'stakeType'}
           register={register}
         >
           {stakeActions.map(({ name, type }, idx) => (
@@ -150,16 +150,16 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
               containerClassName="grow"
               disabled={readOnly}
               error={errors?.amount}
-              fieldName={getFieldName('amount')}
+              fieldName={fieldNamePrefix + 'amount'}
               onPlusMinus={[
                 () =>
                   setValue(
-                    getFieldName('amount'),
+                    fieldNamePrefix + 'amount',
                     Math.max(amount + 1, 1 / 10 ** NATIVE_DECIMALS)
                   ),
                 () =>
                   setValue(
-                    getFieldName('amount'),
+                    fieldNamePrefix + 'amount',
                     Math.max(amount - 1, 1 / 10 ** NATIVE_DECIMALS)
                   ),
               ]}
@@ -171,7 +171,7 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
             <SelectInput
               disabled={readOnly}
               error={errors?.denom}
-              fieldName={getFieldName('denom')}
+              fieldName={fieldNamePrefix + 'denom'}
               register={register}
             >
               {nativeBalances.length !== 0 ? (
@@ -201,7 +201,7 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
             <AddressInput
               disabled={readOnly}
               error={errors?.fromValidator}
-              fieldName={getFieldName('fromValidator')}
+              fieldName={fieldNamePrefix + 'fromValidator'}
               register={register}
               validation={[validateValidatorAddress]}
             />
@@ -222,7 +222,7 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
         <AddressInput
           disabled={readOnly}
           error={errors?.validator}
-          fieldName={getFieldName('validator')}
+          fieldName={fieldNamePrefix + 'validator'}
           register={register}
           validation={[validateRequired, validateValidatorAddress]}
         />

--- a/packages/actions/components/UpdateAdmin.tsx
+++ b/packages/actions/components/UpdateAdmin.tsx
@@ -18,7 +18,7 @@ export interface UpdateAdminOptions {
 }
 
 export const UpdateAdminComponent: ActionComponent<UpdateAdminOptions> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -43,7 +43,7 @@ export const UpdateAdminComponent: ActionComponent<UpdateAdminOptions> = ({
           <AddressInput
             disabled={readOnly}
             error={errors?.contract}
-            fieldName={getFieldName('contract')}
+            fieldName={fieldNamePrefix + 'contract'}
             onChange={(e) => onContractChange(e.target.value)}
             register={register}
             validation={[validateRequired, validateContractAddress]}
@@ -55,7 +55,7 @@ export const UpdateAdminComponent: ActionComponent<UpdateAdminOptions> = ({
           <AddressInput
             disabled={readOnly}
             error={errors?.newAdmin}
-            fieldName={getFieldName('newAdmin')}
+            fieldName={fieldNamePrefix + 'newAdmin'}
             register={register}
             validation={[validateRequired, validateAddress]}
           />

--- a/packages/actions/components/UpdateInfo.tsx
+++ b/packages/actions/components/UpdateInfo.tsx
@@ -22,7 +22,7 @@ export type UpdateInfoData = ConfigResponse
 export const UpdateInfoComponent: ActionComponent<
   undefined,
   UpdateInfoData
-> = ({ getFieldName, errors, onRemove, readOnly, data, Logo }) => {
+> = ({ fieldNamePrefix, errors, onRemove, readOnly, data, Logo }) => {
   const { t } = useTranslation()
   const { register, watch, setValue } = useFormContext()
 
@@ -38,7 +38,7 @@ export const UpdateInfoComponent: ActionComponent<
             <>
               <ImageSelector
                 error={errors?.name}
-                fieldName={getFieldName('image_url')}
+                fieldName={fieldNamePrefix + 'image_url'}
                 register={register}
                 validation={[validateUrl]}
                 watch={watch}
@@ -62,7 +62,7 @@ export const UpdateInfoComponent: ActionComponent<
             <TextInput
               disabled={readOnly}
               error={errors?.name}
-              fieldName={getFieldName('name')}
+              fieldName={fieldNamePrefix + 'name'}
               placeholder={t('form.name')}
               register={register}
               validation={[validateRequired]}
@@ -73,7 +73,7 @@ export const UpdateInfoComponent: ActionComponent<
             <TextAreaInput
               disabled={readOnly}
               error={errors?.description}
-              fieldName={getFieldName('description')}
+              fieldName={fieldNamePrefix + 'description'}
               placeholder={t('form.description')}
               register={register}
               validation={[validateRequired]}
@@ -92,7 +92,7 @@ export const UpdateInfoComponent: ActionComponent<
                 </p>
               </div>
               <FormSwitch
-                fieldName={getFieldName('automatically_add_cw20s')}
+                fieldName={fieldNamePrefix + 'automatically_add_cw20s'}
                 readOnly={readOnly}
                 setValue={setValue}
                 sizing="sm"
@@ -110,7 +110,7 @@ export const UpdateInfoComponent: ActionComponent<
                 </p>
               </div>
               <FormSwitch
-                fieldName={getFieldName('automatically_add_cw721s')}
+                fieldName={fieldNamePrefix + 'automatically_add_cw721s'}
                 readOnly={readOnly}
                 setValue={setValue}
                 sizing="sm"

--- a/packages/actions/types.ts
+++ b/packages/actions/types.ts
@@ -41,7 +41,7 @@ export interface FormProposalData {
 export type ActionComponentProps<T = undefined, D = any> = {
   coreAddress: string
   proposalModule: ProposalModule
-  getFieldName: (field: string) => string
+  fieldNamePrefix: string
   onRemove?: () => void
   errors?: FieldErrors
   readOnly?: boolean

--- a/packages/proposal-module-adapter/adapters/cw-proposal-single/common/actions/makeUpdateProposalConfigAction/UpdateProposalConfigComponent.tsx
+++ b/packages/proposal-module-adapter/adapters/cw-proposal-single/common/actions/makeUpdateProposalConfigAction/UpdateProposalConfigComponent.tsx
@@ -26,7 +26,7 @@ export interface UpdateProposalConfigOptions {
 export const UpdateProposalConfigComponent: ActionComponent<
   UpdateProposalConfigOptions
 > = ({
-  getFieldName,
+  fieldNamePrefix,
   errors,
   onRemove,
   readOnly,
@@ -36,13 +36,13 @@ export const UpdateProposalConfigComponent: ActionComponent<
   const { t } = useTranslation()
   const { register, setValue, watch } = useFormContext()
 
-  const depositRequired = watch(getFieldName('depositRequired'))
-  const thresholdType = watch(getFieldName('thresholdType'))
-  const quorumType = watch(getFieldName('quorumType'))
-  const proposalDuration = watch(getFieldName('proposalDuration'))
-  const proposalDurationUnits = watch(getFieldName('proposalDurationUnits'))
-  const thresholdPercentage = watch(getFieldName('thresholdPercentage'))
-  const quorumPercentage = watch(getFieldName('quorumPercentage'))
+  const depositRequired = watch(fieldNamePrefix + 'depositRequired')
+  const thresholdType = watch(fieldNamePrefix + 'thresholdType')
+  const quorumType = watch(fieldNamePrefix + 'quorumType')
+  const proposalDuration = watch(fieldNamePrefix + 'proposalDuration')
+  const proposalDurationUnits = watch(fieldNamePrefix + 'proposalDurationUnits')
+  const thresholdPercentage = watch(fieldNamePrefix + 'thresholdPercentage')
+  const quorumPercentage = watch(fieldNamePrefix + 'quorumPercentage')
 
   const percentageThresholdSelected = thresholdType === '%'
   const percentageQuorumSelected = quorumType === '%'
@@ -82,7 +82,7 @@ export const UpdateProposalConfigComponent: ActionComponent<
               </p>
             </div>
             <FormSwitch
-              fieldName={getFieldName('depositRequired')}
+              fieldName={fieldNamePrefix + 'depositRequired'}
               readOnly={readOnly}
               setValue={setValue}
               sizing="sm"
@@ -101,7 +101,7 @@ export const UpdateProposalConfigComponent: ActionComponent<
             </p>
           </div>
           <FormSwitch
-            fieldName={getFieldName('onlyMembersExecute')}
+            fieldName={fieldNamePrefix + 'onlyMembersExecute'}
             readOnly={readOnly}
             setValue={setValue}
             sizing="sm"
@@ -131,7 +131,7 @@ export const UpdateProposalConfigComponent: ActionComponent<
               <NumberInput
                 disabled={readOnly}
                 error={errors?.depositInfo?.deposit}
-                fieldName={getFieldName('depositInfo.deposit')}
+                fieldName={fieldNamePrefix + 'depositInfo.deposit'}
                 register={register}
                 step={0.000001}
                 validation={[validateRequired, validatePositive]}
@@ -149,7 +149,9 @@ export const UpdateProposalConfigComponent: ActionComponent<
                 </p>
               </div>
               <FormSwitch
-                fieldName={getFieldName('depositInfo.refundFailedProposals')}
+                fieldName={
+                  fieldNamePrefix + 'depositInfo.refundFailedProposals'
+                }
                 readOnly={readOnly}
                 setValue={setValue}
                 sizing="sm"
@@ -175,16 +177,16 @@ export const UpdateProposalConfigComponent: ActionComponent<
               <NumberInput
                 disabled={readOnly}
                 error={errors?.thresholdPercentage}
-                fieldName={getFieldName('thresholdPercentage')}
+                fieldName={fieldNamePrefix + 'thresholdPercentage'}
                 onPlusMinus={[
                   () =>
                     setValue(
-                      getFieldName('thresholdPercentage'),
+                      fieldNamePrefix + 'thresholdPercentage',
                       Math.max(thresholdPercentage + 1, 1)
                     ),
                   () =>
                     setValue(
-                      getFieldName('thresholdPercentage'),
+                      fieldNamePrefix + 'thresholdPercentage',
                       Math.max(thresholdPercentage - 1, 1)
                     ),
                 ]}
@@ -197,7 +199,7 @@ export const UpdateProposalConfigComponent: ActionComponent<
           )}
           <SelectInput
             disabled={readOnly}
-            fieldName={getFieldName('thresholdType')}
+            fieldName={fieldNamePrefix + 'thresholdType'}
             register={register}
           >
             <option value="majority">{t('info.majority')}</option>
@@ -219,16 +221,16 @@ export const UpdateProposalConfigComponent: ActionComponent<
               <NumberInput
                 disabled={readOnly}
                 error={errors?.quorumPercentage}
-                fieldName={getFieldName('quorumPercentage')}
+                fieldName={fieldNamePrefix + 'quorumPercentage'}
                 onPlusMinus={[
                   () =>
                     setValue(
-                      getFieldName('quorumPercentage'),
+                      fieldNamePrefix + 'quorumPercentage',
                       Math.max(quorumPercentage + 1, 1)
                     ),
                   () =>
                     setValue(
-                      getFieldName('quorumPercentage'),
+                      fieldNamePrefix + 'quorumPercentage',
                       Math.max(quorumPercentage - 1, 1)
                     ),
                 ]}
@@ -241,7 +243,7 @@ export const UpdateProposalConfigComponent: ActionComponent<
           )}
           <SelectInput
             disabled={readOnly}
-            fieldName={getFieldName('quorumType')}
+            fieldName={fieldNamePrefix + 'quorumType'}
             register={register}
           >
             <option value="majority">{t('info.majority')}</option>
@@ -264,16 +266,16 @@ export const UpdateProposalConfigComponent: ActionComponent<
             <NumberInput
               disabled={readOnly}
               error={errors?.proposalDuration}
-              fieldName={getFieldName('proposalDuration')}
+              fieldName={fieldNamePrefix + 'proposalDuration'}
               onPlusMinus={[
                 () =>
                   setValue(
-                    getFieldName('proposalDuration'),
+                    fieldNamePrefix + 'proposalDuration',
                     Math.max(proposalDuration + 1, 1)
                   ),
                 () =>
                   setValue(
-                    getFieldName('proposalDuration'),
+                    fieldNamePrefix + 'proposalDuration',
                     Math.max(proposalDuration - 1, 1)
                   ),
               ]}
@@ -295,7 +297,7 @@ export const UpdateProposalConfigComponent: ActionComponent<
           </div>
           <SelectInput
             disabled={readOnly}
-            fieldName={getFieldName('proposalDurationUnits')}
+            fieldName={fieldNamePrefix + 'proposalDurationUnits'}
             register={register}
           >
             <option value="weeks">
@@ -326,7 +328,7 @@ export const UpdateProposalConfigComponent: ActionComponent<
         </div>
         <div className="flex grow justify-center items-center">
           <FormSwitch
-            fieldName={getFieldName('allowRevoting')}
+            fieldName={fieldNamePrefix + 'allowRevoting'}
             readOnly={readOnly}
             setValue={setValue}
             watch={watch}

--- a/packages/proposal-module-adapter/adapters/cw-proposal-single/common/components/CreateProposalForm.tsx
+++ b/packages/proposal-module-adapter/adapters/cw-proposal-single/common/components/CreateProposalForm.tsx
@@ -439,9 +439,7 @@ export const CreateProposalForm = ({
                     coreAddress={coreAddress}
                     data={actionData.data}
                     errors={errors.actionData?.[index]?.data || {}}
-                    getFieldName={(fieldName) =>
-                      `actionData.${index}.data.${fieldName}`
-                    }
+                    fieldNamePrefix={`actionData.${index}.data.`}
                     index={index}
                     onRemove={() => remove(index)}
                     proposalModule={proposalModule}

--- a/packages/state/recoil/selectors/chain.ts
+++ b/packages/state/recoil/selectors/chain.ts
@@ -56,7 +56,6 @@ export const nativeBalancesSelector = selectorFamily({
     (address: string) =>
     async ({ get }) => {
       const client = get(stargateClientSelector)
-      if (!client) return
 
       get(refreshWalletBalancesIdAtom(address))
 

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/actions/makeMintAction/MintComponent.tsx
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/actions/makeMintAction/MintComponent.tsx
@@ -15,7 +15,7 @@ export interface MintOptions {
 }
 
 export const MintComponent: ActionComponent<MintOptions> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -23,7 +23,7 @@ export const MintComponent: ActionComponent<MintOptions> = ({
 }) => {
   const { t } = useTranslation()
   const { register, watch, setValue } = useFormContext()
-  const amount = watch(getFieldName('amount'))
+  const amount = watch(fieldNamePrefix + 'amount')
 
   return (
     <ActionCard Icon={MintIcon} onRemove={onRemove} title={t('title.mint')}>
@@ -33,16 +33,16 @@ export const MintComponent: ActionComponent<MintOptions> = ({
             <NumberInput
               disabled={readOnly}
               error={errors?.amount}
-              fieldName={getFieldName('amount')}
+              fieldName={fieldNamePrefix + 'amount'}
               onPlusMinus={[
                 () =>
                   setValue(
-                    getFieldName('amount'),
+                    fieldNamePrefix + 'amount',
                     (Number(amount) + 1).toString()
                   ),
                 () =>
                   setValue(
-                    getFieldName('amount'),
+                    fieldNamePrefix + 'amount',
                     (Number(amount) - 1).toString()
                   ),
               ]}
@@ -65,7 +65,7 @@ export const MintComponent: ActionComponent<MintOptions> = ({
             containerClassName="grow"
             disabled={readOnly}
             error={errors?.to}
-            fieldName={getFieldName('to')}
+            fieldName={fieldNamePrefix + 'to'}
             register={register}
             validation={[validateRequired, validateAddress]}
           />

--- a/packages/voting-module-adapter/adapters/cw4-voting/actions/makeManageMembersAction/ManageMembersComponent.tsx
+++ b/packages/voting-module-adapter/adapters/cw4-voting/actions/makeManageMembersAction/ManageMembersComponent.tsx
@@ -28,7 +28,7 @@ export interface ManageMembersOptions {
 }
 
 export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
-  getFieldName,
+  fieldNamePrefix,
   onRemove,
   errors,
   readOnly,
@@ -43,7 +43,7 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
     remove: toAddRemove,
   } = useFieldArray({
     control,
-    name: getFieldName('toAdd') as 'toAdd',
+    name: (fieldNamePrefix + 'toAdd') as 'toAdd',
   })
   const {
     fields: toRemoveFields,
@@ -51,7 +51,7 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
     remove: toRemoveRemove,
   } = useFieldArray({
     control,
-    name: getFieldName('toRemove') as 'toRemove',
+    name: (fieldNamePrefix + 'toRemove') as 'toRemove',
   })
 
   return (
@@ -63,12 +63,10 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
       <InputLabel className="mt-2" name={t('form.membersToAddOrUpdate')} />
       <div className="flex flex-col gap-2 items-stretch">
         {toAddFields.map(({ id, weight }, index) => {
-          const addrFieldName = getFieldName(
-            `toAdd.${index}.addr`
-          ) as `toAdd.${number}.addr`
-          const weightFieldName = getFieldName(
-            `toAdd.${index}.weight`
-          ) as `toAdd.${number}.weight`
+          const addrFieldName = (fieldNamePrefix +
+            `toAdd.${index}.addr`) as `toAdd.${number}.addr`
+          const weightFieldName = (fieldNamePrefix +
+            `toAdd.${index}.weight`) as `toAdd.${number}.weight`
 
           return (
             <div key={id} className="flex flex-row gap-4 items-center">
@@ -142,9 +140,8 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
                 disabled={readOnly}
                 error={errors?.toRemove?.[index]?.addr}
                 fieldName={
-                  getFieldName(
-                    `toRemove.${index}.addr`
-                  ) as `toRemove.${number}.addr`
+                  (fieldNamePrefix +
+                    `toRemove.${index}.addr`) as `toRemove.${number}.addr`
                 }
                 register={register}
                 validation={[


### PR DESCRIPTION
This refactors `getFieldName` into `fieldNamePrefix` in action components, since `getFieldName` was not easily memoizable as a callback in a few places, but the `fieldNamePrefix` string will always be constant.

This is necessary because `getFieldName` being used inside `useEffect`s or other React hooks, as it was in the Spend action component, caused React hooks with dependency arrays to re-execute on every render, even when the field name getter did not functionally change.