### PR TITLE
Display loader when navigating from a command action

### DIFF
--- a/apps/dapp/components/CommandModal/CommandBar.tsx
+++ b/apps/dapp/components/CommandModal/CommandBar.tsx
@@ -1,19 +1,19 @@
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SearchBar } from '@dao-dao/ui'
 
 interface CommandBarProps {
-  currentRefinement: string
-  refine: (s: string) => void
+  input: string
+  setInput: (s: string) => void
+  // Triggered when backspace is pressed and the text field is empty.
   onEmptyBack: () => void
 }
 
-export const CommandBar: FC<CommandBarProps> = ({
-  currentRefinement,
-  refine,
+export const CommandBar = ({
+  input,
+  setInput,
   onEmptyBack,
-}) => {
+}: CommandBarProps) => {
   const { t } = useTranslation()
 
   return (
@@ -21,15 +21,16 @@ export const CommandBar: FC<CommandBarProps> = ({
       className="px-2"
       hideIcon
       onBlur={(ev) => ev.target.focus()}
-      onChange={(event) => refine(event.currentTarget.value)}
+      onChange={(event) => setInput(event.currentTarget.value)}
       onKeyDown={(ev) => {
-        if (ev.key == 'ArrowUp' || ev.key == 'ArrowDown')
+        if (ev.key === 'ArrowUp' || ev.key === 'ArrowDown') {
           return ev.preventDefault()
-        else if (currentRefinement == '' && ev.key == 'Backspace')
+        } else if (ev.key === 'Backspace' && !input.length) {
           return onEmptyBack()
+        }
       }}
       placeholder={t('commandBar.prompt')}
-      value={currentRefinement}
+      value={input}
     />
   )
 }

--- a/apps/dapp/components/CommandModal/CommandHits.tsx
+++ b/apps/dapp/components/CommandModal/CommandHits.tsx
@@ -1,9 +1,8 @@
 import clsx from 'clsx'
-import { useRouter } from 'next/router'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Logo } from '@dao-dao/ui'
+import { Loader, Logo } from '@dao-dao/ui'
 
 import { DaoHit, Hit, HitType } from '.'
 
@@ -11,16 +10,18 @@ const HitView = ({
   hit,
   selected,
   onClick,
+  loading,
 }: {
   hit: Hit
   selected: boolean
   onClick: () => void
+  loading: boolean
 }) => {
   const { t } = useTranslation()
   return (
     <div
       className={clsx(
-        'flex gap-2 items-center py-2 px-1 font-medium text-tertiary hover:text-primary align-middle hover:bg-primary rounded-md cursor-pointer',
+        'flex flex-row gap-2 items-center py-2 px-1 font-medium text-tertiary hover:text-primary align-middle hover:bg-primary rounded-md cursor-pointer',
         selected && 'text-primary bg-primary'
       )}
       onClick={onClick}
@@ -44,6 +45,12 @@ const HitView = ({
         </div>
       )}
       <div>{hit.name}</div>
+
+      {loading && (
+        <div className="flex flex-row grow justify-end items-center pr-2">
+          <Loader fill={false} size={20} />
+        </div>
+      )}
     </div>
   )
 }
@@ -60,12 +67,13 @@ export const CommandHits = ({
   sectionData,
   hits,
   onChoice,
+  navigatingFromHit,
 }: {
   sectionData: HitSectionData
   hits: Hit[]
   onChoice: (hit: Hit) => void
+  navigatingFromHit: Hit | undefined
 }) => {
-  const router = useRouter()
   const { sections, sectionNames } = sectionData
   const [selection, setSelection] = useState(0)
   const listRef = useRef<HTMLDivElement>(null)
@@ -77,18 +85,16 @@ export const CommandHits = ({
       switch (event.key) {
         case 'ArrowUp':
           setSelection((selection) => Math.max(selection - 1, 0))
-          router.prefetch(`/dao/${hits[selection].id}`)
           break
         case 'ArrowDown':
           setSelection((selection) => Math.min(selection + 1, hits.length - 1))
-          router.prefetch(`/dao/${hits[selection].id}`)
           break
         case 'Enter':
           onChoice(hits[selection])
           break
       }
     },
-    [hits, selection, router, onChoice]
+    [onChoice, hits, selection]
   )
 
   useEffect(() => {
@@ -130,6 +136,16 @@ export const CommandHits = ({
       className="flex overflow-hidden overflow-y-auto flex-col grow justify-start py-2 px-4"
       ref={listRef}
     >
+      {/* If hit we're currently navigating to is no longer part of the hits to render, just display the top with the loader. */}
+      {navigatingFromHit && !hits.includes(navigatingFromHit) && (
+        <HitView
+          hit={navigatingFromHit}
+          loading
+          onClick={() => null}
+          selected={false}
+        />
+      )}
+
       {sections.map((sectionIndex, i) => (
         <>
           <div className="py-1 font-medium text-gray-400">
@@ -142,6 +158,7 @@ export const CommandHits = ({
             <HitView
               key={hit.id}
               hit={hit}
+              loading={navigatingFromHit === hit}
               onClick={() => onChoice(hit)}
               selected={
                 (i === 0 ? index : sections[i - 1] + index) === selection

--- a/apps/dapp/components/CommandModal/index.tsx
+++ b/apps/dapp/components/CommandModal/index.tsx
@@ -52,6 +52,7 @@ export interface ActionHit {
   id: ActionHitId
   name: string
   hitType: HitType.AppAction
+  navigatesOnSelect?: boolean
 }
 
 export interface DaoHit {
@@ -62,6 +63,7 @@ export interface DaoHit {
   proposal_count: number
   treasury_balance: string
   hitType: HitType.Dao
+  navigatesOnSelect?: boolean
 }
 
 enum DaoActionHitId {
@@ -75,6 +77,7 @@ export interface DaoActionHit {
   id: DaoActionHitId
   name: string
   hitType: HitType.DaoAction
+  navigatesOnSelect?: boolean
 }
 
 const APP_ACTIONS: ActionHit[] = [
@@ -82,6 +85,7 @@ const APP_ACTIONS: ActionHit[] = [
     icon: '➕',
     id: ActionHitId.CreateDao,
     name: 'Create a DAO',
+    navigatesOnSelect: true,
   },
   {
     icon: '🗺',
@@ -98,11 +102,13 @@ const DAO_ACTIONS: DaoActionHit[] = [
     icon: '☘️',
     id: DaoActionHitId.GotoDao,
     name: 'Go to DAO page',
+    navigatesOnSelect: true,
   },
   {
     icon: '🗳',
     id: DaoActionHitId.NewProposal,
     name: 'Start a new proposal',
+    navigatesOnSelect: true,
   },
   {
     icon: '🏛',
@@ -115,7 +121,12 @@ const DAO_ACTIONS: DaoActionHit[] = [
   //   id: DaoActionHitId.AddToken,
   //   name: 'Add token to Keplr',
   // },
-  // { icon: '💵', id: DaoActionHitId.Stake, name: 'Manage staking' },
+  // {
+  //   icon: '💵',
+  //   id: DaoActionHitId.Stake,
+  //   name: 'Manage staking',
+  //   navigatesOnSelect: true,
+  // },
 ].map((data) => ({
   ...data,
   hitType: HitType.DaoAction,
@@ -141,39 +152,40 @@ export const CommandModal: FC<CommandModalProps> = ({ onClose }) => {
   const [commandState, setCommandState] = useState<CommandState>({
     type: CommandStateType.Home,
   })
-  const [currentRefinement, refine] = useState<string>('')
+  const [input, setInput] = useState('')
   const [hits, setHits] = useState<Hit[]>([])
+  const [navigatingFromHit, setNavigatingFromHit] = useState<Hit>()
 
   useEffect(() => {
     ;(async () => {
-      const res = await index.search(currentRefinement)
-      const daoHits = res.hits
-        .slice(0, MAX_DAOS_DISPLAYED)
-        .map((hit) => ({ ...hit, hitType: HitType.Dao })) as DaoHit[]
+      const res = await index.search(input)
+      const daoHits = res.hits.slice(0, MAX_DAOS_DISPLAYED).map((hit) => ({
+        ...hit,
+        hitType: HitType.Dao,
+        navigatesOnSelect: commandState.type === CommandStateType.NavigateDao,
+      })) as DaoHit[]
+
+      const baseHits: Hit[] =
+        commandState.type === CommandStateType.Home
+          ? [...APP_ACTIONS, ...daoHits]
+          : commandState.type === CommandStateType.DaoChosen
+          ? DAO_ACTIONS
+          : commandState.type === CommandStateType.NavigateDao
+          ? daoHits
+          : []
 
       // Display default options
-      if (!currentRefinement) {
-        if (commandState.type === CommandStateType.Home) {
-          setHits([...daoHits, ...APP_ACTIONS])
-        } else if (commandState.type === CommandStateType.DaoChosen) {
-          setHits([...DAO_ACTIONS])
-        } else if (commandState.type === CommandStateType.NavigateDao) {
-          setHits([...daoHits])
-        }
-        return
+      if (!input) {
+        return setHits(baseHits)
       }
-      // Else search
-      const fuse = new Fuse(
-        commandState.type === CommandStateType.DaoChosen
-          ? [...APP_ACTIONS, ...daoHits, ...DAO_ACTIONS]
-          : [...APP_ACTIONS, ...daoHits],
-        FUSE_OPTIONS
-      )
-      setHits(fuse.search(currentRefinement).map((o) => o.item))
-    })()
-  }, [currentRefinement, commandState])
 
-  const [sections, sectionNames] = useMemo(() => {
+      // Else search
+      const fuse = new Fuse(baseHits, FUSE_OPTIONS)
+      setHits(fuse.search(input).map((o) => o.item))
+    })()
+  }, [input, commandState])
+
+  const sectionData = useMemo(() => {
     // Sort sections by order of first appearance of hits
     // ordered list of hit types
     const hitTypes = hits.reduce(
@@ -188,7 +200,7 @@ export const CommandModal: FC<CommandModalProps> = ({ onClose }) => {
     // Section index array based on contiguous elements, end exclusive
     const sections = [
       ...sortedHits.reduce((arr, hit, i) => {
-        return i != 0 && hit.hitType != sortedHits[i - 1].hitType
+        return i !== 0 && hit.hitType !== sortedHits[i - 1].hitType
           ? [...arr, i]
           : arr
       }, [] as number[]),
@@ -205,16 +217,24 @@ export const CommandModal: FC<CommandModalProps> = ({ onClose }) => {
         : ''
     )
 
-    return [sections, sectionNames]
+    return {
+      sections,
+      sectionNames,
+    }
   }, [hits])
 
   const onChoice = useCallback(
     (hit: Hit) => {
+      if (hit.navigatesOnSelect) {
+        setNavigatingFromHit(hit)
+      }
+
       // Global app actions do not depend on command context
       if (hit.hitType === HitType.AppAction) {
-        if (hit.id === ActionHitId.CreateDao) return router.push(`/dao/create`)
-        else if (hit.id === ActionHitId.NavigateDao) {
-          refine('')
+        if (hit.id === ActionHitId.CreateDao) {
+          return router.push(`/dao/create`)
+        } else if (hit.id === ActionHitId.NavigateDao) {
+          setInput('')
           return setCommandState({ type: CommandStateType.NavigateDao })
         }
       }
@@ -224,7 +244,7 @@ export const CommandModal: FC<CommandModalProps> = ({ onClose }) => {
         (commandState.type === CommandStateType.Home ||
           commandState.type === CommandStateType.DaoChosen)
       ) {
-        refine('') // Reset text
+        setInput('') // Reset text
         return setCommandState({
           type: CommandStateType.DaoChosen,
           name: hit.name,
@@ -252,14 +272,23 @@ export const CommandModal: FC<CommandModalProps> = ({ onClose }) => {
         }
       }
     },
-    [refine, commandState, setCommandState, router]
+    [setInput, commandState, setCommandState, router]
   )
+
+  // Go back to home when input is empty and backspace is pressed, unless
+  // currently navigating as a result of choosing a hit, in which case we don't
+  // want the user to get confused since the loader will disappear.
+  const onEmptyBack = useCallback(() => {
+    if (navigatingFromHit) {
+      return
+    }
+
+    setCommandState({ type: CommandStateType.Home })
+  }, [navigatingFromHit])
 
   return (
     <Modal
-      containerClassName={
-        'p-0 w-full max-w-[550px] h-[450px] max-h-[90vh] border animate-fadein'
-      }
+      containerClassName="p-0 w-full max-w-[550px] h-[450px] max-h-[90vh] border animate-fadein"
       hideCloseButton
       onClose={onClose}
     >
@@ -275,17 +304,18 @@ export const CommandModal: FC<CommandModalProps> = ({ onClose }) => {
         </div>
 
         <CommandBar
-          currentRefinement={currentRefinement}
-          onEmptyBack={() => setCommandState({ type: CommandStateType.Home })}
-          refine={refine}
+          input={input}
+          onEmptyBack={onEmptyBack}
+          setInput={setInput}
         />
 
         {/* Because the command items take different actions in different contexts, they
             have to be handled here */}
         <CommandHits
           hits={hits}
+          navigatingFromHit={navigatingFromHit}
           onChoice={onChoice}
-          sectionData={{ sections, sectionNames }}
+          sectionData={sectionData}
         />
       </div>
     </Modal>


### PR DESCRIPTION
Resolves #763 

Right now, the command modal does not provide any feedback to the user that a page is being loaded. This adds a loader upon choosing an action that navigates.

<img width="569" alt="Screen Shot 2022-07-28 at 4 47 34 PM" src="https://user-images.githubusercontent.com/6721426/181656754-b417d7a5-b8ee-4ae3-a2c5-ed88ef126c84.png">

It also makes the loading row sticky at the top in case the user changes the input text and causes the hit that is navigating to hide.
<img width="568" alt="Screen Shot 2022-07-28 at 5 06 20 PM" src="https://user-images.githubusercontent.com/6721426/181656877-553bcdc7-5275-4fca-a44e-1e486f0c6903.png">
<img width="566" alt="Screen Shot 2022-07-28 at 5 06 03 PM" src="https://user-images.githubusercontent.com/6721426/181656879-a520bb68-75ce-45a6-b55b-a9a41bb43dc6.png">

