### PR TITLE
Fixed staking modal with proposal deposit

### DIFF
--- a/apps/dapp/pages/dao/[address]/index.tsx
+++ b/apps/dapp/pages/dao/[address]/index.tsx
@@ -5,7 +5,7 @@ import axios from 'axios'
 import { getAverageColor } from 'fast-average-color-node'
 import type { GetStaticPaths, GetStaticProps, NextPage } from 'next'
 import { useRouter } from 'next/router'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -15,10 +15,14 @@ import {
 } from '@dao-dao/common'
 import { makeGetDaoStaticProps } from '@dao-dao/common/server'
 import { MemberCheck } from '@dao-dao/icons'
+import { matchAndLoadCommon } from '@dao-dao/proposal-module-adapter'
 import { useVotingModule } from '@dao-dao/state'
+import { CheckedDepositInfo } from '@dao-dao/state/clients/cw-proposal-single'
 import {
   Breadcrumbs,
   GradientHero,
+  Loader,
+  Logo,
   MobileMenuTab,
   PageLoader,
   PinToggle,
@@ -49,11 +53,31 @@ enum MobileMenuTabSelection {
 
 const InnerMobileDaoHome = () => {
   const { t } = useTranslation()
+  const { coreAddress, proposalModules } = useDaoInfoContext()
   const {
     components: { Membership },
   } = useVotingModuleAdapter()
   const [tab, setTab] = useState(MobileMenuTabSelection.Proposal)
   const makeTabSetter = (tab: MobileMenuTabSelection) => () => setTab(tab)
+
+  const useDepositInfoHooks = useMemo(
+    () =>
+      proposalModules.map(
+        (proposalModule) =>
+          matchAndLoadCommon(proposalModule, {
+            coreAddress,
+            Loader,
+            Logo,
+          }).hooks.useDepositInfo
+      ),
+    [coreAddress, proposalModules]
+  )
+  const proposalModuleDepositInfos = useDepositInfoHooks
+    .map((useDepositInfo) =>
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useDepositInfo?.()
+    )
+    .filter(Boolean) as CheckedDepositInfo[]
 
   return (
     <div className="flex flex-col gap-2">
@@ -87,7 +111,11 @@ const InnerMobileDaoHome = () => {
       </div>
       <div className="py-5 px-6">
         {tab === MobileMenuTabSelection.Proposal && <DaoProposals />}
-        {tab === MobileMenuTabSelection.Membership && <Membership.Mobile />}
+        {tab === MobileMenuTabSelection.Membership && (
+          <Membership.Mobile
+            proposalModuleDepositInfos={proposalModuleDepositInfos}
+          />
+        )}
         {tab === MobileMenuTabSelection.Treasury && (
           <div className="space-y-8">
             <DaoTreasury />
@@ -104,11 +132,30 @@ const InnerDAOHome = () => {
   const { t } = useTranslation()
   const router = useRouter()
 
-  const { coreAddress, name } = useDaoInfoContext()
+  const { coreAddress, name, proposalModules } = useDaoInfoContext()
   const {
     components: { Membership },
   } = useVotingModuleAdapter()
   const { isMember } = useVotingModule(coreAddress, { fetchMembership: true })
+
+  const useDepositInfoHooks = useMemo(
+    () =>
+      proposalModules.map(
+        (proposalModule) =>
+          matchAndLoadCommon(proposalModule, {
+            coreAddress,
+            Loader,
+            Logo,
+          }).hooks.useDepositInfo
+      ),
+    [coreAddress, proposalModules]
+  )
+  const proposalModuleDepositInfos = useDepositInfoHooks
+    .map((useDepositInfo) =>
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useDepositInfo?.()
+    )
+    .filter(Boolean) as CheckedDepositInfo[]
 
   const { isPinned, setPinned, setUnpinned } = usePinnedDAOs()
   const pinned = isPinned(coreAddress)
@@ -154,7 +201,9 @@ const InnerDAOHome = () => {
               <DaoThinInfo />
             </div>
             <div className="block mt-4 lg:hidden">
-              <Membership.Desktop />
+              <Membership.Desktop
+                proposalModuleDepositInfos={proposalModuleDepositInfos}
+              />
             </div>
             <div className="pt-[22px] pb-[28px] border-b border-inactive">
               <DaoInfo />
@@ -167,7 +216,9 @@ const InnerDAOHome = () => {
         </div>
       </div>
       <div className="hidden col-span-2 p-6 w-full h-full min-h-screen lg:block">
-        <Membership.Desktop />
+        <Membership.Desktop
+          proposalModuleDepositInfos={proposalModuleDepositInfos}
+        />
       </div>
     </div>
   )

--- a/packages/proposal-module-adapter/adapters/cw-proposal-single/common/hooks/index.ts
+++ b/packages/proposal-module-adapter/adapters/cw-proposal-single/common/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './makeUseDepositInfo'
 export * from './makeUseListAllProposalInfos'
 export * from './makeUseProposalCount'
 export * from './makeUseReverseProposalInfos'

--- a/packages/proposal-module-adapter/adapters/cw-proposal-single/common/hooks/makeUseDepositInfo.ts
+++ b/packages/proposal-module-adapter/adapters/cw-proposal-single/common/hooks/makeUseDepositInfo.ts
@@ -1,0 +1,14 @@
+import { useRecoilValue } from 'recoil'
+
+import { CwProposalSingleSelectors } from '@dao-dao/state'
+import { CheckedDepositInfo } from '@dao-dao/state/clients/cw-proposal-single'
+import { ProposalModule } from '@dao-dao/utils'
+
+export const makeUseDepositInfo =
+  ({ address }: ProposalModule) =>
+  (): CheckedDepositInfo | undefined =>
+    useRecoilValue(
+      CwProposalSingleSelectors.configSelector({
+        contractAddress: address,
+      })
+    ).deposit_info ?? undefined

--- a/packages/proposal-module-adapter/adapters/cw-proposal-single/index.tsx
+++ b/packages/proposal-module-adapter/adapters/cw-proposal-single/index.tsx
@@ -5,6 +5,7 @@ import {
   CreateProposalForm,
   DaoInfoVotingConfiguration,
   ProposalModuleInfo,
+  makeUseDepositInfo,
   makeUseListAllProposalInfos,
   makeUseProposalCount,
   makeUseReverseProposalInfos,
@@ -40,6 +41,7 @@ export const CwProposalSingleAdapter: ProposalModuleAdapter = {
       useListAllProposalInfos: makeUseListAllProposalInfos(proposalModule),
       useProposalCount: makeUseProposalCount(proposalModule),
       useActions,
+      useDepositInfo: makeUseDepositInfo(proposalModule),
     },
 
     // Components

--- a/packages/proposal-module-adapter/types.ts
+++ b/packages/proposal-module-adapter/types.ts
@@ -2,6 +2,7 @@ import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate'
 import { ComponentType } from 'react'
 
 import { Action, FormProposalData } from '@dao-dao/actions'
+import { CheckedDepositInfo } from '@dao-dao/state/clients/cw-proposal-single'
 import { LoaderProps, LogoProps } from '@dao-dao/ui'
 import { ProcessedThresholdQuorum, ProposalModule } from '@dao-dao/utils'
 import { BaseProposalDetailsVotingPowerWidgetProps } from '@dao-dao/voting-module-adapter'
@@ -18,6 +19,7 @@ export interface IProposalModuleAdapterCommon {
     ) => CommonProposalListInfo[]
     useProposalCount: () => number
     useActions: () => Action[]
+    useDepositInfo?: () => CheckedDepositInfo | undefined
   }
 
   // Components

--- a/packages/ui/components/StakingModal/StakingModal.tsx
+++ b/packages/ui/components/StakingModal/StakingModal.tsx
@@ -205,23 +205,25 @@ const StakeUnstakeModesBody: FC<StakeUnstakeModesBodyProps> = ({
             setAmount={setAmount}
             tokenDecimals={tokenDecimals}
           />
-          {!!proposalDeposit && max > proposalDeposit && (
-            <PercentButton
-              absoluteOffset={-proposalDeposit}
-              amount={amount}
-              className="mt-1"
-              label={t('button.stakeAllButProposalDeposit', {
-                proposalDeposit: proposalDeposit.toLocaleString(undefined, {
-                  maximumFractionDigits: tokenDecimals,
-                }),
-                tokenSymbol,
-              })}
-              max={max}
-              percent={1}
-              setAmount={setAmount}
-              tokenDecimals={tokenDecimals}
-            />
-          )}
+          {mode === StakingMode.Stake &&
+            !!proposalDeposit &&
+            max > proposalDeposit && (
+              <PercentButton
+                absoluteOffset={-proposalDeposit}
+                amount={amount}
+                className="mt-1"
+                label={t('button.stakeAllButProposalDeposit', {
+                  proposalDeposit: proposalDeposit.toLocaleString(undefined, {
+                    maximumFractionDigits: tokenDecimals,
+                  }),
+                  tokenSymbol,
+                })}
+                max={max}
+                percent={1}
+                setAmount={setAmount}
+                tokenDecimals={tokenDecimals}
+              />
+            )}
         </div>
       </div>
 

--- a/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/Membership/index.tsx
+++ b/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/Membership/index.tsx
@@ -1,7 +1,7 @@
 import { HandIcon, MinusSmIcon, PlusSmIcon } from '@heroicons/react/outline'
 import { useWalletManager } from '@noahsaso/cosmodal'
 import clsx from 'clsx'
-import { ComponentType, FC, useState } from 'react'
+import { ComponentType, FC, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -19,11 +19,12 @@ import {
 } from '@dao-dao/utils'
 
 import { useVotingModuleAdapterOptions } from '../../../../react/context'
+import { BaseMembershipProps } from '../../../../types'
 import { useGovernanceTokenInfo, useStakingInfo } from '../../hooks'
 import { StakingModal } from '../StakingModal'
 import { ClaimsPendingList as DefaultClaimsPendingList } from './ClaimsPendingList'
 
-interface MembershipProps {
+interface MembershipProps extends BaseMembershipProps {
   primaryText?: boolean
   // If displayed in the SDA, we want to hide the title and claim card as
   // well as make the balance cards responsive. This is because it is laid
@@ -59,9 +60,11 @@ export const Membership = ({ primaryText, ...props }: MembershipProps) => {
 const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
   sdaMode,
   ClaimsPendingList = DefaultClaimsPendingList,
+  proposalModuleDepositInfos,
 }) => {
   const { t } = useTranslation()
   const {
+    governanceTokenAddress,
     governanceTokenInfo,
     governanceTokenMarketingInfo,
     walletBalance: unstakedGovTokenBalance,
@@ -82,6 +85,18 @@ const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
   // Set to a StakingMode to display modal.
   const [showStakingMode, setShowStakingMode] = useState<StakingMode>()
   const stakingLoading = useRecoilValue(stakingLoadingAtom)
+
+  // Get max proposal deposit that needs the governance token.
+  const maxGovernanceTokenProposalDeposit = useMemo(
+    () =>
+      Math.max(
+        0,
+        ...proposalModuleDepositInfos
+          .filter(({ token }) => token === governanceTokenAddress)
+          .map(({ deposit }) => Number(deposit))
+      ),
+    [proposalModuleDepositInfos, governanceTokenAddress]
+  )
 
   if (!connected) {
     return <ConnectWalletButton />
@@ -238,6 +253,11 @@ const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
 
       {showStakingMode !== undefined && (
         <StakingModal
+          deposit={
+            maxGovernanceTokenProposalDeposit
+              ? maxGovernanceTokenProposalDeposit.toString()
+              : undefined
+          }
           mode={showStakingMode}
           onClose={() => setShowStakingMode(undefined)}
         />

--- a/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/ProposalDetailsVotingPowerWidget.tsx
+++ b/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/ProposalDetailsVotingPowerWidget.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { StakingMode } from '@dao-dao/ui'
 
 import { BaseProposalDetailsVotingPowerWidgetProps } from '../../../types'
+import { useGovernanceTokenInfo } from '../hooks'
 import { StakingModal } from './StakingModal'
 
 export const ProposalDetailsVotingPowerWidget = ({
@@ -11,6 +12,8 @@ export const ProposalDetailsVotingPowerWidget = ({
 }: BaseProposalDetailsVotingPowerWidgetProps) => {
   const { t } = useTranslation()
   const [showStaking, setShowStaking] = useState(false)
+
+  const { governanceTokenAddress } = useGovernanceTokenInfo()
 
   return (
     <>
@@ -20,7 +23,11 @@ export const ProposalDetailsVotingPowerWidget = ({
 
       {showStaking && (
         <StakingModal
-          deposit={depositInfo?.deposit}
+          deposit={
+            depositInfo?.token === governanceTokenAddress
+              ? depositInfo.deposit
+              : undefined
+          }
           mode={StakingMode.Stake}
           onClose={() => setShowStaking(false)}
         />

--- a/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/StakingModal.tsx
+++ b/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/StakingModal.tsx
@@ -44,7 +44,6 @@ const InnerStakingModal = ({
   const { votingModuleAddress } = useVotingModuleAdapterOptions()
 
   const [stakingLoading, setStakingLoading] = useRecoilState(stakingLoadingAtom)
-  const [amount, setAmount] = useState(0)
 
   const {
     governanceTokenAddress,
@@ -75,6 +74,19 @@ const InnerStakingModal = ({
   ) {
     throw new Error(t('error.loadingData'))
   }
+
+  // When staking, default to all unstaked balance (less proposal deposit if
+  // exists).
+  const [amount, setAmount] = useState(
+    mode === StakingMode.Stake
+      ? convertMicroDenomToDenomWithDecimals(
+          !!deposit && Number(deposit) > 0 && unstakedBalance > Number(deposit)
+            ? unstakedBalance - Number(deposit)
+            : unstakedBalance,
+          governanceTokenInfo.decimals
+        )
+      : 0
+  )
 
   const doStake = CwNativeStakedBalanceVotingHooks.useStake({
     contractAddress: votingModuleAddress,

--- a/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/index.tsx
+++ b/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/index.tsx
@@ -45,7 +45,7 @@ export const CwNativeStakedBalanceVotingAdapter: VotingModuleAdapter = {
     // Components
     components: {
       Membership: {
-        Desktop: () => <Membership />,
+        Desktop: (props) => <Membership {...props} />,
         MobileTab: MembershipMobileTab,
         Mobile: (props) => <Membership {...props} primaryText />,
       },

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/Membership/index.tsx
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/Membership/index.tsx
@@ -1,7 +1,7 @@
 import { HandIcon, MinusSmIcon, PlusSmIcon } from '@heroicons/react/outline'
 import { useWalletManager } from '@noahsaso/cosmodal'
 import clsx from 'clsx'
-import { ComponentType, FC, useState } from 'react'
+import { ComponentType, FC, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -19,11 +19,12 @@ import {
 } from '@dao-dao/utils'
 
 import { useVotingModuleAdapterOptions } from '../../../../react/context'
+import { BaseMembershipProps } from '../../../../types'
 import { useGovernanceTokenInfo, useStakingInfo } from '../../hooks'
 import { StakingModal } from '../StakingModal'
 import { ClaimsPendingList as DefaultClaimsPendingList } from './ClaimsPendingList'
 
-interface MembershipProps {
+interface MembershipProps extends BaseMembershipProps {
   primaryText?: boolean
   // If displayed in the SDA, we want to hide the title and claim card as
   // well as make the balance cards responsive. This is because it is laid
@@ -59,9 +60,11 @@ export const Membership = ({ primaryText, ...props }: MembershipProps) => {
 const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
   sdaMode,
   ClaimsPendingList = DefaultClaimsPendingList,
+  proposalModuleDepositInfos,
 }) => {
   const { t } = useTranslation()
   const {
+    governanceTokenAddress,
     governanceTokenInfo,
     governanceTokenMarketingInfo,
     walletBalance: unstakedGovTokenBalance,
@@ -82,6 +85,18 @@ const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
   // Set to a StakingMode to display modal.
   const [showStakingMode, setShowStakingMode] = useState<StakingMode>()
   const stakingLoading = useRecoilValue(stakingLoadingAtom)
+
+  // Get max proposal deposit that needs the governance token.
+  const maxGovernanceTokenProposalDeposit = useMemo(
+    () =>
+      Math.max(
+        0,
+        ...proposalModuleDepositInfos
+          .filter(({ token }) => token === governanceTokenAddress)
+          .map(({ deposit }) => Number(deposit))
+      ),
+    [proposalModuleDepositInfos, governanceTokenAddress]
+  )
 
   if (!connected) {
     return <ConnectWalletButton />
@@ -238,6 +253,11 @@ const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
 
       {showStakingMode !== undefined && (
         <StakingModal
+          deposit={
+            maxGovernanceTokenProposalDeposit
+              ? maxGovernanceTokenProposalDeposit.toString()
+              : undefined
+          }
           mode={showStakingMode}
           onClose={() => setShowStakingMode(undefined)}
         />

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/ProposalDetailsVotingPowerWidget.tsx
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/ProposalDetailsVotingPowerWidget.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { StakingMode } from '@dao-dao/ui'
 
 import { BaseProposalDetailsVotingPowerWidgetProps } from '../../../types'
+import { useGovernanceTokenInfo } from '../hooks'
 import { StakingModal } from './StakingModal'
 
 export const ProposalDetailsVotingPowerWidget = ({
@@ -11,6 +12,8 @@ export const ProposalDetailsVotingPowerWidget = ({
 }: BaseProposalDetailsVotingPowerWidgetProps) => {
   const { t } = useTranslation()
   const [showStaking, setShowStaking] = useState(false)
+
+  const { governanceTokenAddress } = useGovernanceTokenInfo()
 
   return (
     <>
@@ -20,7 +23,11 @@ export const ProposalDetailsVotingPowerWidget = ({
 
       {showStaking && (
         <StakingModal
-          deposit={depositInfo?.deposit}
+          deposit={
+            depositInfo?.token === governanceTokenAddress
+              ? depositInfo.deposit
+              : undefined
+          }
           mode={StakingMode.Stake}
           onClose={() => setShowStaking(false)}
         />

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/StakingModal.tsx
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/StakingModal.tsx
@@ -44,7 +44,6 @@ const InnerStakingModal = ({
   const { refreshBalances } = useWalletBalance()
 
   const [stakingLoading, setStakingLoading] = useRecoilState(stakingLoadingAtom)
-  const [amount, setAmount] = useState(0)
 
   const {
     governanceTokenAddress,
@@ -96,6 +95,19 @@ const InnerStakingModal = ({
   ) {
     throw new Error(t('error.loadingData'))
   }
+
+  // When staking, default to all unstaked balance (less proposal deposit if
+  // exists).
+  const [amount, setAmount] = useState(
+    mode === StakingMode.Stake
+      ? convertMicroDenomToDenomWithDecimals(
+          !!deposit && Number(deposit) > 0 && unstakedBalance > Number(deposit)
+            ? unstakedBalance - Number(deposit)
+            : unstakedBalance,
+          governanceTokenInfo.decimals
+        )
+      : 0
+  )
 
   const doStake = Cw20BaseHooks.useSend({
     contractAddress: governanceTokenAddress,

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/index.tsx
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/index.tsx
@@ -48,7 +48,7 @@ export const Cw20StakedBalanceVotingAdapter: VotingModuleAdapter = {
     // Components
     components: {
       Membership: {
-        Desktop: () => <Membership />,
+        Desktop: (props) => <Membership {...props} />,
         MobileTab: MembershipMobileTab,
         Mobile: (props) => <Membership {...props} primaryText />,
       },

--- a/packages/voting-module-adapter/types.ts
+++ b/packages/voting-module-adapter/types.ts
@@ -18,6 +18,10 @@ export interface MembershipPageInfo {
   label: string
 }
 
+export interface BaseMembershipProps {
+  proposalModuleDepositInfos: CheckedDepositInfo[]
+}
+
 export interface MembershipMobileTabProps {
   onClick: () => void
   selected: boolean
@@ -115,9 +119,9 @@ export interface IVotingModuleAdapter {
   // Components
   components: {
     Membership: {
-      Desktop: ComponentType
+      Desktop: ComponentType<BaseMembershipProps>
       MobileTab: ComponentType<MembershipMobileTabProps>
-      Mobile: ComponentType
+      Mobile: ComponentType<BaseMembershipProps>
     }
     DaoThinInfoContent: ComponentType<BaseDaoThinInfoContentProps>
     DaoTreasuryFooter: ComponentType


### PR DESCRIPTION
Added back button to stake all tokens except the proposal deposit, using the maximum proposal deposit from available proposal module adapters.

Also default to max (or max less proposal deposit if exists) when showing staking modal.

<img width="404" alt="image" src="https://user-images.githubusercontent.com/6721426/184199296-695e458a-86d0-49dd-a001-b82acaf4788e.png">
