### PR TITLE
Sort treasury history transactions descending

### DIFF
--- a/packages/state/recoil/selectors/contract.ts
+++ b/packages/state/recoil/selectors/contract.ts
@@ -72,22 +72,33 @@ export const treasuryTransactionsSelector = selectorFamily({
         )
       )
 
-      return txs
-        .map((tx, index) => {
-          let events
-          try {
-            events = JSON.parse(tx.rawLog)[0].events
-          } catch {
-            return
-          }
+      return (
+        txs
+          .map((tx, index) => {
+            let events
+            try {
+              events = JSON.parse(tx.rawLog)[0].events
+            } catch {
+              return
+            }
 
-          return {
-            tx,
-            timestamp: txDates[index],
-            events,
-          }
-        })
-        .filter(Boolean) as TreasuryTransaction[]
+            return {
+              tx,
+              timestamp: txDates[index],
+              events,
+            }
+          })
+          .filter(Boolean) as TreasuryTransaction[]
+      ).sort((a, b) =>
+        // Sort descending by timestamp, putting undefined timestamps last.
+        b.timestamp && a.timestamp
+          ? b.timestamp.getTime() - a.timestamp.getTime()
+          : !a.timestamp
+          ? 1
+          : !b.timestamp
+          ? -1
+          : 0
+      )
     },
 })
 


### PR DESCRIPTION
Treasury history currently displays in ascending order. Let's fix that so most recent is at the top.

<img width="946" alt="Screen Shot 2022-08-15 at 10 51 38 AM" src="https://user-images.githubusercontent.com/6721426/184688657-8d594c2e-2133-413d-8a1d-3a4b23db5358.png">