### PR TITLE
Display loading in page titles before translations are ready

### DIFF
--- a/apps/dapp/pages/_app.tsx
+++ b/apps/dapp/pages/_app.tsx
@@ -116,15 +116,23 @@ const DApp = (props: AppProps) => {
             content: '#111213',
           },
         ]}
-        description={t('meta.description')}
+        description={t('meta.description').replace(
+          // eslint-disable-next-line i18next/no-literal-string
+          'meta.description',
+          'Loading...'
+        )}
         openGraph={{
           url: SITE_URL,
           type: 'website',
-          title: t('meta.title'),
-          description: t('meta.description'),
+          title: t('meta.title').replace('meta.title', 'Loading...'),
+          description: t('meta.description').replace(
+            'meta.description',
+            'Loading...'
+          ),
           images: SITE_IMAGE ? [{ url: SITE_IMAGE }] : [],
         }}
-        title={t('meta.title')}
+        // eslint-disable-next-line i18next/no-literal-string
+        title={t('meta.title').replace('meta.title', 'Loading...')}
         twitter={{
           cardType: 'summary_large_image',
         }}

--- a/apps/raw-sda/pages/_app.tsx
+++ b/apps/raw-sda/pages/_app.tsx
@@ -96,15 +96,23 @@ const SDA = (props: AppProps) => {
             content: '#ffffff',
           },
         ]}
-        description={t('meta.description')}
+        description={t('meta.description').replace(
+          // eslint-disable-next-line i18next/no-literal-string
+          'meta.description',
+          'Loading...'
+        )}
         openGraph={{
           url: SITE_URL,
           type: 'website',
-          title: t('meta.title'),
-          description: t('meta.description'),
+          title: t('meta.title').replace('meta.title', 'Loading...'),
+          description: t('meta.description').replace(
+            'meta.description',
+            'Loading...'
+          ),
           images: SITE_IMAGE ? [{ url: SITE_IMAGE }] : [],
         }}
-        title={t('meta.title')}
+        // eslint-disable-next-line i18next/no-literal-string
+        title={t('meta.title').replace('meta.title', 'Loading...')}
         twitter={{
           cardType: 'summary_large_image',
         }}

--- a/apps/sda-base/pages/_app.tsx
+++ b/apps/sda-base/pages/_app.tsx
@@ -96,15 +96,23 @@ const SDA = (props: AppProps) => {
             content: '#ffffff',
           },
         ]}
-        description={t('meta.description')}
+        description={t('meta.description').replace(
+          // eslint-disable-next-line i18next/no-literal-string
+          'meta.description',
+          'Loading...'
+        )}
         openGraph={{
           url: SITE_URL,
           type: 'website',
-          title: t('meta.title'),
-          description: t('meta.description'),
+          title: t('meta.title').replace('meta.title', 'Loading...'),
+          description: t('meta.description').replace(
+            'meta.description',
+            'Loading...'
+          ),
           images: SITE_IMAGE ? [{ url: SITE_IMAGE }] : [],
         }}
-        title={t('meta.title')}
+        // eslint-disable-next-line i18next/no-literal-string
+        title={t('meta.title').replace('meta.title', 'Loading...')}
         twitter={{
           cardType: 'summary_large_image',
         }}


### PR DESCRIPTION
Right now, as translations load, the page title says `meta.title`. This replaces those temporary translations with `Loading...`.