### PR TITLE
Don't add license header to next-env.d.ts

### DIFF
--- a/apps/dapp/.eslintrc.js
+++ b/apps/dapp/.eslintrc.js
@@ -4,7 +4,7 @@
 /** @type {import("eslint").Linter.Config} */
 const eslintConfig = {
   extends: [require.resolve('@dao-dao/config/eslint')],
-  ignorePatterns: ['.next', '.turbo', 'node_modules', 'out'],
+  ignorePatterns: ['.next', '.turbo', 'node_modules', 'out', 'next-env.d.ts'],
   root: true,
   plugins: ['header'],
   rules: {

--- a/apps/dapp/next-env.d.ts
+++ b/apps/dapp/next-env.d.ts
@@ -1,6 +1,3 @@
-// GNU AFFERO GENERAL PUBLIC LICENSE Version 3. Copyright (C) 2022 DAO DAO Contributors.
-// See the "LICENSE" file in the root directory of this package for more copyright information.
-
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 


### PR DESCRIPTION
`next-env.d.ts` is reset on dapp dev server runs, so the license header keeps getting removed and re-added by the linter. Let's just not add the license header to that file by not linting it.