### PR TITLE
Improved onPlusMinus NumberInput API

### DIFF
--- a/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
@@ -78,18 +78,18 @@ export const CreateDAOThresholdCard: FC<CreateDAOConfigCardSharedProps> = ({
             <NumberInput
               error={errors?.advancedVotingConfig?.thresholdQuorum?.threshold}
               fieldName="advancedVotingConfig.thresholdQuorum.threshold"
-              onPlusMinus={[
-                () =>
-                  setValue(
-                    'advancedVotingConfig.thresholdQuorum.threshold',
-                    Math.max(threshold + 1, 1)
-                  ),
-                () =>
-                  setValue(
-                    'advancedVotingConfig.thresholdQuorum.threshold',
-                    Math.max(threshold - 1, 1)
-                  ),
-              ]}
+              onMinus={() =>
+                setValue(
+                  'advancedVotingConfig.thresholdQuorum.threshold',
+                  Math.max(threshold - 1, 1)
+                )
+              }
+              onPlus={() =>
+                setValue(
+                  'advancedVotingConfig.thresholdQuorum.threshold',
+                  Math.max(threshold + 1, 1)
+                )
+              }
               // Override numeric value setter since the select below
               // attempts to set 'majority', but registering the field
               // with the numeric setter causes validation issues.
@@ -187,18 +187,18 @@ export const CreateDAOQuorumCard: FC<CreateDAOQuorumCardProps> = ({
                   disabled={readOnly}
                   error={errors?.advancedVotingConfig?.thresholdQuorum?.quorum}
                   fieldName="advancedVotingConfig.thresholdQuorum.quorum"
-                  onPlusMinus={[
-                    () =>
-                      setValue(
-                        'advancedVotingConfig.thresholdQuorum.quorum',
-                        Math.max(quorum + 1, 0)
-                      ),
-                    () =>
-                      setValue(
-                        'advancedVotingConfig.thresholdQuorum.quorum',
-                        Math.max(quorum - 1, 0)
-                      ),
-                  ]}
+                  onMinus={() =>
+                    setValue(
+                      'advancedVotingConfig.thresholdQuorum.quorum',
+                      Math.max(quorum - 1, 0)
+                    )
+                  }
+                  onPlus={() =>
+                    setValue(
+                      'advancedVotingConfig.thresholdQuorum.quorum',
+                      Math.max(quorum + 1, 0)
+                    )
+                  }
                   register={register}
                   // Override numeric value setter since the select below
                   // attempts to set 'majority', but registering the field
@@ -264,18 +264,18 @@ export const CreateDAOVotingDurationCard: FC<
             disabled={readOnly}
             error={errors?.votingDuration?.value}
             fieldName="votingDuration.value"
-            onPlusMinus={[
-              () =>
-                setValue(
-                  'votingDuration.value',
-                  Math.max(votingDuration.value + 1, 1)
-                ),
-              () =>
-                setValue(
-                  'votingDuration.value',
-                  Math.max(votingDuration.value - 1, 1)
-                ),
-            ]}
+            onMinus={() =>
+              setValue(
+                'votingDuration.value',
+                Math.max(votingDuration.value - 1, 1)
+              )
+            }
+            onPlus={() =>
+              setValue(
+                'votingDuration.value',
+                Math.max(votingDuration.value + 1, 1)
+              )
+            }
             register={register}
             sizing="sm"
             step={1}
@@ -350,18 +350,18 @@ export const CreateDAOProposalDepositCard: FC<
             disabled={readOnly}
             error={errors?.governanceTokenOptions?.proposalDeposit?.value}
             fieldName="governanceTokenOptions.proposalDeposit.value"
-            onPlusMinus={[
-              () =>
-                setValue(
-                  'governanceTokenOptions.proposalDeposit.value',
-                  Math.max(value + 1, 0)
-                ),
-              () =>
-                setValue(
-                  'governanceTokenOptions.proposalDeposit.value',
-                  Math.max(value - 1, 0)
-                ),
-            ]}
+            onMinus={() =>
+              setValue(
+                'governanceTokenOptions.proposalDeposit.value',
+                Math.max(value - 1, 0)
+              )
+            }
+            onPlus={() =>
+              setValue(
+                'governanceTokenOptions.proposalDeposit.value',
+                Math.max(value + 1, 0)
+              )
+            }
             register={register}
             sizing="sm"
             step={1}
@@ -458,18 +458,18 @@ export const CreateDAOUnstakingDurationCard: FC<
             disabled={readOnly}
             error={errors?.governanceTokenOptions?.unregisterDuration?.value}
             fieldName="governanceTokenOptions.unregisterDuration.value"
-            onPlusMinus={[
-              () =>
-                setValue(
-                  'governanceTokenOptions.unregisterDuration.value',
-                  Math.max(unregisterDuration.value + 1, 0)
-                ),
-              () =>
-                setValue(
-                  'governanceTokenOptions.unregisterDuration.value',
-                  Math.max(unregisterDuration.value - 1, 0)
-                ),
-            ]}
+            onMinus={() =>
+              setValue(
+                'governanceTokenOptions.unregisterDuration.value',
+                Math.max(unregisterDuration.value - 1, 0)
+              )
+            }
+            onPlus={() =>
+              setValue(
+                'governanceTokenOptions.unregisterDuration.value',
+                Math.max(unregisterDuration.value + 1, 0)
+              )
+            }
             register={register}
             sizing="sm"
             step={1}

--- a/apps/dapp/components/dao/create/CreateDAOTier.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOTier.tsx
@@ -142,28 +142,28 @@ export const CreateDAOTier: FC<CreateDAOTierProps> = ({
                 containerClassName="grow"
                 error={errors.tiers?.[tierIndex]?.weight}
                 fieldName={`tiers.${tierIndex}.weight`}
-                onPlusMinus={[
-                  () =>
-                    setValue(
-                      `tiers.${tierIndex}.weight`,
-                      Math.max(
-                        (newDAO.tiers?.[tierIndex]?.weight ?? 0) + 1,
-                        governanceTokenEnabled
-                          ? 1 / 10 ** NEW_DAO_CW20_DECIMALS
-                          : 1
-                      )
-                    ),
-                  () =>
-                    setValue(
-                      `tiers.${tierIndex}.weight`,
-                      Math.max(
-                        (newDAO.tiers?.[tierIndex]?.weight ?? 0) - 1,
-                        governanceTokenEnabled
-                          ? 1 / 10 ** NEW_DAO_CW20_DECIMALS
-                          : 1
-                      )
-                    ),
-                ]}
+                onMinus={() =>
+                  setValue(
+                    `tiers.${tierIndex}.weight`,
+                    Math.max(
+                      (newDAO.tiers?.[tierIndex]?.weight ?? 0) - 1,
+                      governanceTokenEnabled
+                        ? 1 / 10 ** NEW_DAO_CW20_DECIMALS
+                        : 1
+                    )
+                  )
+                }
+                onPlus={() =>
+                  setValue(
+                    `tiers.${tierIndex}.weight`,
+                    Math.max(
+                      (newDAO.tiers?.[tierIndex]?.weight ?? 0) + 1,
+                      governanceTokenEnabled
+                        ? 1 / 10 ** NEW_DAO_CW20_DECIMALS
+                        : 1
+                    )
+                  )
+                }
                 register={register}
                 step={
                   governanceTokenEnabled ? 1 / 10 ** NEW_DAO_CW20_DECIMALS : 1

--- a/apps/dapp/pages/dao/create/voting.tsx
+++ b/apps/dapp/pages/dao/create/voting.tsx
@@ -305,24 +305,24 @@ const CreateDAOVotingPage: NextPage = () => {
                           errors.governanceTokenOptions?.newInfo?.initialSupply
                         }
                         fieldName="governanceTokenOptions.newInfo.initialSupply"
-                        onPlusMinus={[
-                          () =>
-                            setValue(
-                              'governanceTokenOptions.newInfo.initialSupply',
-                              Math.max(
-                                govTokenInitialSupply + 1,
-                                1 / 10 ** NEW_DAO_CW20_DECIMALS
-                              )
-                            ),
-                          () =>
-                            setValue(
-                              'governanceTokenOptions.newInfo.initialSupply',
-                              Math.max(
-                                govTokenInitialSupply - 1,
-                                1 / 10 ** NEW_DAO_CW20_DECIMALS
-                              )
-                            ),
-                        ]}
+                        onMinus={() =>
+                          setValue(
+                            'governanceTokenOptions.newInfo.initialSupply',
+                            Math.max(
+                              govTokenInitialSupply - 1,
+                              1 / 10 ** NEW_DAO_CW20_DECIMALS
+                            )
+                          )
+                        }
+                        onPlus={() =>
+                          setValue(
+                            'governanceTokenOptions.newInfo.initialSupply',
+                            Math.max(
+                              govTokenInitialSupply + 1,
+                              1 / 10 ** NEW_DAO_CW20_DECIMALS
+                            )
+                          )
+                        }
                         register={register}
                         step={1 / 10 ** NEW_DAO_CW20_DECIMALS}
                         validation={[validatePositive, validateRequired]}
@@ -368,24 +368,24 @@ const CreateDAOVotingPage: NextPage = () => {
                             ?.initialTreasuryPercent
                         }
                         fieldName="governanceTokenOptions.newInfo.initialTreasuryPercent"
-                        onPlusMinus={[
-                          () =>
-                            setValue(
-                              'governanceTokenOptions.newInfo.initialTreasuryPercent',
-                              Math.min(
-                                Math.max(govTokenTreasuryPercent + 1, 0),
-                                100
-                              )
-                            ),
-                          () =>
-                            setValue(
-                              'governanceTokenOptions.newInfo.initialTreasuryPercent',
-                              Math.min(
-                                Math.max(govTokenTreasuryPercent - 1, 0),
-                                100
-                              )
-                            ),
-                        ]}
+                        onMinus={() =>
+                          setValue(
+                            'governanceTokenOptions.newInfo.initialTreasuryPercent',
+                            Math.min(
+                              Math.max(govTokenTreasuryPercent - 1, 0),
+                              100
+                            )
+                          )
+                        }
+                        onPlus={() =>
+                          setValue(
+                            'governanceTokenOptions.newInfo.initialTreasuryPercent',
+                            Math.min(
+                              Math.max(govTokenTreasuryPercent + 1, 0),
+                              100
+                            )
+                          )
+                        }
                         register={register}
                         step={0.001}
                         validation={[

--- a/packages/actions/components/NativeCoinSelector.tsx
+++ b/packages/actions/components/NativeCoinSelector.tsx
@@ -107,18 +107,18 @@ export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
           disabled={!isCreating}
           error={errors?.amount}
           fieldName={fieldNamePrefix + 'amount'}
-          onPlusMinus={[
-            () =>
-              setValue(
-                fieldNamePrefix + 'amount',
-                Math.max(Number(watchAmount) + 1, 1 / 10 ** NATIVE_DECIMALS)
-              ),
-            () =>
-              setValue(
-                fieldNamePrefix + 'amount',
-                Math.max(Number(watchAmount) - 1, 1 / 10 ** NATIVE_DECIMALS)
-              ),
-          ]}
+          onMinus={() =>
+            setValue(
+              fieldNamePrefix + 'amount',
+              Math.max(Number(watchAmount) - 1, 1 / 10 ** NATIVE_DECIMALS)
+            )
+          }
+          onPlus={() =>
+            setValue(
+              fieldNamePrefix + 'amount',
+              Math.max(Number(watchAmount) + 1, 1 / 10 ** NATIVE_DECIMALS)
+            )
+          }
           register={register}
           sizing="auto"
           step={1 / 10 ** NATIVE_DECIMALS}

--- a/packages/actions/components/Spend.tsx
+++ b/packages/actions/components/Spend.tsx
@@ -143,24 +143,24 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
             disabled={!isCreating}
             error={errors?.amount}
             fieldName={fieldNamePrefix + 'amount'}
-            onPlusMinus={[
-              () =>
-                setValue(
-                  fieldNamePrefix + 'amount',
-                  Math.max(
-                    Number(spendAmount) + 1,
-                    1 / 10 ** amountDecimals
-                  ).toString()
-                ),
-              () =>
-                setValue(
-                  fieldNamePrefix + 'amount',
-                  Math.max(
-                    Number(spendAmount) - 1,
-                    1 / 10 ** amountDecimals
-                  ).toString()
-                ),
-            ]}
+            onMinus={() =>
+              setValue(
+                fieldNamePrefix + 'amount',
+                Math.max(
+                  Number(spendAmount) - 1,
+                  1 / 10 ** amountDecimals
+                ).toString()
+              )
+            }
+            onPlus={() =>
+              setValue(
+                fieldNamePrefix + 'amount',
+                Math.max(
+                  Number(spendAmount) + 1,
+                  1 / 10 ** amountDecimals
+                ).toString()
+              )
+            }
             register={register}
             sizing="auto"
             step={1 / 10 ** amountDecimals}

--- a/packages/actions/components/Stake.tsx
+++ b/packages/actions/components/Stake.tsx
@@ -151,18 +151,18 @@ export const StakeComponent: ActionComponent<StakeOptions> = ({
               disabled={!isCreating}
               error={errors?.amount}
               fieldName={fieldNamePrefix + 'amount'}
-              onPlusMinus={[
-                () =>
-                  setValue(
-                    fieldNamePrefix + 'amount',
-                    Math.max(amount + 1, 1 / 10 ** NATIVE_DECIMALS)
-                  ),
-                () =>
-                  setValue(
-                    fieldNamePrefix + 'amount',
-                    Math.max(amount - 1, 1 / 10 ** NATIVE_DECIMALS)
-                  ),
-              ]}
+              onMinus={() =>
+                setValue(
+                  fieldNamePrefix + 'amount',
+                  Math.max(amount - 1, 1 / 10 ** NATIVE_DECIMALS)
+                )
+              }
+              onPlus={() =>
+                setValue(
+                  fieldNamePrefix + 'amount',
+                  Math.max(amount + 1, 1 / 10 ** NATIVE_DECIMALS)
+                )
+              }
               register={register}
               step={1 / 10 ** NATIVE_DECIMALS}
               validation={[validateRequired, validatePositive]}

--- a/packages/proposal-module-adapter/adapters/cw-proposal-single/common/actions/makeUpdateProposalConfigAction/UpdateProposalConfigComponent.tsx
+++ b/packages/proposal-module-adapter/adapters/cw-proposal-single/common/actions/makeUpdateProposalConfigAction/UpdateProposalConfigComponent.tsx
@@ -180,18 +180,18 @@ export const UpdateProposalConfigComponent: ActionComponent<
                 disabled={!isCreating}
                 error={errors?.thresholdPercentage}
                 fieldName={fieldNamePrefix + 'thresholdPercentage'}
-                onPlusMinus={[
-                  () =>
-                    setValue(
-                      fieldNamePrefix + 'thresholdPercentage',
-                      Math.max(thresholdPercentage + 1, 1)
-                    ),
-                  () =>
-                    setValue(
-                      fieldNamePrefix + 'thresholdPercentage',
-                      Math.max(thresholdPercentage - 1, 1)
-                    ),
-                ]}
+                onMinus={() =>
+                  setValue(
+                    fieldNamePrefix + 'thresholdPercentage',
+                    Math.max(thresholdPercentage - 1, 1)
+                  )
+                }
+                onPlus={() =>
+                  setValue(
+                    fieldNamePrefix + 'thresholdPercentage',
+                    Math.max(thresholdPercentage + 1, 1)
+                  )
+                }
                 register={register}
                 sizing="sm"
                 validation={[validateRequired, validatePercent]}
@@ -236,18 +236,18 @@ export const UpdateProposalConfigComponent: ActionComponent<
                   disabled={!isCreating}
                   error={errors?.quorumPercentage}
                   fieldName={fieldNamePrefix + 'quorumPercentage'}
-                  onPlusMinus={[
-                    () =>
-                      setValue(
-                        fieldNamePrefix + 'quorumPercentage',
-                        Math.max(quorumPercentage + 1, 1)
-                      ),
-                    () =>
-                      setValue(
-                        fieldNamePrefix + 'quorumPercentage',
-                        Math.max(quorumPercentage - 1, 1)
-                      ),
-                  ]}
+                  onMinus={() =>
+                    setValue(
+                      fieldNamePrefix + 'quorumPercentage',
+                      Math.max(quorumPercentage - 1, 1)
+                    )
+                  }
+                  onPlus={() =>
+                    setValue(
+                      fieldNamePrefix + 'quorumPercentage',
+                      Math.max(quorumPercentage + 1, 1)
+                    )
+                  }
                   register={register}
                   sizing="sm"
                   validation={[validateRequired, validatePercent]}
@@ -282,18 +282,18 @@ export const UpdateProposalConfigComponent: ActionComponent<
               disabled={!isCreating}
               error={errors?.proposalDuration}
               fieldName={fieldNamePrefix + 'proposalDuration'}
-              onPlusMinus={[
-                () =>
-                  setValue(
-                    fieldNamePrefix + 'proposalDuration',
-                    Math.max(proposalDuration + 1, 1)
-                  ),
-                () =>
-                  setValue(
-                    fieldNamePrefix + 'proposalDuration',
-                    Math.max(proposalDuration - 1, 1)
-                  ),
-              ]}
+              onMinus={() =>
+                setValue(
+                  fieldNamePrefix + 'proposalDuration',
+                  Math.max(proposalDuration - 1, 1)
+                )
+              }
+              onPlus={() =>
+                setValue(
+                  fieldNamePrefix + 'proposalDuration',
+                  Math.max(proposalDuration + 1, 1)
+                )
+              }
               register={register}
               sizing="sm"
               step={1}

--- a/packages/ui/components/input/NumberInput.tsx
+++ b/packages/ui/components/input/NumberInput.tsx
@@ -15,9 +15,8 @@ interface NumberInputProps<FieldValues, FieldName extends Path<FieldValues>>
   register: UseFormRegister<FieldValues>
   validation?: Validate<FieldPathValue<FieldValues, FieldName>>[]
   error?: FieldError
-  defaultValue?: string
-  step?: string | number
-  onPlusMinus?: [() => void, () => void]
+  onMinus?: () => void
+  onPlus?: () => void
   containerClassName?: string
   sizing?: 'sm' | 'md' | 'auto'
   required?: boolean
@@ -38,9 +37,8 @@ export const NumberInput = <FieldValues, FieldName extends Path<FieldValues>>({
   register,
   error,
   validation,
-  defaultValue,
-  step,
-  onPlusMinus,
+  onMinus,
+  onPlus,
   disabled,
   sizing,
   className,
@@ -54,73 +52,59 @@ export const NumberInput = <FieldValues, FieldName extends Path<FieldValues>>({
     {}
   )
 
-  const sharedProps = {
-    defaultValue,
-    disabled,
-    step,
-    type: 'number',
-    ...props,
-    ...register(fieldName, {
-      required: required && 'Required',
-      validate,
-      ...(setValueAs ? { setValueAs } : { valueAsNumber: true }),
-    }),
-  }
-
-  const _containerClassName = clsx(
-    'py-2 px-3 bg-transparent rounded-lg border border-default focus-within:outline-none focus-within:ring-1 ring-brand ring-offset-0 transition',
-    {
-      'ring-1 ring-error': error,
-      'w-28': sizing === 'sm',
-      'w-40': sizing === 'md',
-      'w-28 md:w-32 lg:w-40': sizing === 'auto',
-    },
-    containerClassName
-  )
-
-  if (onPlusMinus) {
-    return (
-      <div
-        className={clsx(
-          'flex flex-row gap-1 items-center text-sm',
-          _containerClassName
-        )}
-      >
+  return (
+    <div
+      className={clsx(
+        'flex flex-row gap-1 items-center text-sm',
+        'py-2 px-3 bg-transparent rounded-lg border border-default focus-within:outline-none focus-within:ring-1 ring-brand ring-offset-0 transition',
+        {
+          'ring-1 ring-error': error,
+          'w-28': sizing === 'sm',
+          'w-40': sizing === 'md',
+          'w-28 md:w-32 lg:w-40': sizing === 'auto',
+        },
+        containerClassName
+      )}
+    >
+      {onPlus && (
         <button
           className={clsx('transition secondary-text', {
             'hover:body-text': !disabled,
           })}
           disabled={disabled}
-          onClick={() => onPlusMinus[0]()}
+          onClick={onPlus}
           type="button"
         >
           <PlusIcon className="w-4" />
         </button>
+      )}
+      {onMinus && (
         <button
           className={clsx('transition secondary-text', {
             'hover:body-text': !disabled,
           })}
           disabled={disabled}
-          onClick={() => onPlusMinus[1]()}
+          onClick={onMinus}
           type="button"
         >
           <MinusIcon className="w-4" />
         </button>
-        <input
-          className={clsx(
-            'w-full text-right bg-transparent border-none outline-none ring-none body-text',
-            className
-          )}
-          {...sharedProps}
-        />
-      </div>
-    )
-  }
+      )}
 
-  return (
-    <input
-      className={clsx('body-text', _containerClassName)}
-      {...sharedProps}
-    />
+      <input
+        className={clsx(
+          'w-full text-right bg-transparent border-none outline-none ring-none body-text',
+          className
+        )}
+        disabled={disabled}
+        type="number"
+        {...props}
+        {...register(fieldName, {
+          required: required && 'Required',
+          validate,
+          ...(setValueAs ? { setValueAs } : { valueAsNumber: true }),
+        })}
+      />
+    </div>
   )
 }

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/actions/makeMintAction/MintComponent.tsx
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/actions/makeMintAction/MintComponent.tsx
@@ -34,18 +34,18 @@ export const MintComponent: ActionComponent<MintOptions> = ({
               disabled={!isCreating}
               error={errors?.amount}
               fieldName={fieldNamePrefix + 'amount'}
-              onPlusMinus={[
-                () =>
-                  setValue(
-                    fieldNamePrefix + 'amount',
-                    (Number(amount) + 1).toString()
-                  ),
-                () =>
-                  setValue(
-                    fieldNamePrefix + 'amount',
-                    (Number(amount) - 1).toString()
-                  ),
-              ]}
+              onMinus={() =>
+                setValue(
+                  fieldNamePrefix + 'amount',
+                  (Number(amount) - 1).toString()
+                )
+              }
+              onPlus={() =>
+                setValue(
+                  fieldNamePrefix + 'amount',
+                  (Number(amount) + 1).toString()
+                )
+              }
               register={register}
               sizing="auto"
               validation={[validateRequired, validatePositive]}

--- a/packages/voting-module-adapter/adapters/cw4-voting/actions/makeManageMembersAction/ManageMembersComponent.tsx
+++ b/packages/voting-module-adapter/adapters/cw4-voting/actions/makeManageMembersAction/ManageMembersComponent.tsx
@@ -35,7 +35,8 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
   options: { currentMembers },
 }) => {
   const { t } = useTranslation()
-  const { register, setValue, control } = useFormContext<ManageMembersData>()
+  const { register, setValue, watch, control } =
+    useFormContext<ManageMembersData>()
 
   const {
     fields: toAddFields,
@@ -62,7 +63,7 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
     >
       <InputLabel className="mt-2" name={t('form.membersToAddOrUpdate')} />
       <div className="flex flex-col gap-2 items-stretch">
-        {toAddFields.map(({ id, weight }, index) => {
+        {toAddFields.map(({ id }, index) => {
           const addrFieldName = (fieldNamePrefix +
             `toAdd.${index}.addr`) as `toAdd.${number}.addr`
           const weightFieldName = (fieldNamePrefix +
@@ -77,9 +78,14 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
                     error={errors?.toAdd?.[index]?.weight}
                     fieldName={weightFieldName}
                     onMinus={() =>
-                      setValue(weightFieldName, Math.max(weight - 1, 0))
+                      setValue(
+                        weightFieldName,
+                        Math.max(watch(weightFieldName) - 1, 0)
+                      )
                     }
-                    onPlus={() => setValue(weightFieldName, weight + 1)}
+                    onPlus={() =>
+                      setValue(weightFieldName, watch(weightFieldName) + 1)
+                    }
                     placeholder={t('form.votingWeightPlaceholder')}
                     register={register}
                     sizing="md"
@@ -121,7 +127,7 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
         {isCreating && (
           <Button
             className="self-start"
-            onClick={() => toAddAppend({ weight: 1, addr: '' })}
+            onClick={() => toAddAppend({ weight: NaN, addr: '' })}
             size="sm"
             variant="secondary"
           >

--- a/packages/voting-module-adapter/adapters/cw4-voting/actions/makeManageMembersAction/ManageMembersComponent.tsx
+++ b/packages/voting-module-adapter/adapters/cw4-voting/actions/makeManageMembersAction/ManageMembersComponent.tsx
@@ -76,10 +76,10 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
                     disabled={!isCreating}
                     error={errors?.toAdd?.[index]?.weight}
                     fieldName={weightFieldName}
-                    onPlusMinus={[
-                      () => setValue(weightFieldName, Math.max(weight - 1, 0)),
-                      () => setValue(weightFieldName, weight + 1),
-                    ]}
+                    onMinus={() =>
+                      setValue(weightFieldName, Math.max(weight - 1, 0))
+                    }
+                    onPlus={() => setValue(weightFieldName, weight + 1)}
                     placeholder={t('form.votingWeightPlaceholder')}
                     register={register}
                     sizing="md"


### PR DESCRIPTION
The `onPlusMinus` prop of `NumberInput` is currently an array of functions that control what happens when you click the plus or minus sign. The functions are not named, which makes it easy to accidentally flip the order of the functions and cause the buttons to act contrary to the expected action.

This PR replaces that API with two props, `onMinus` and `onPlus`, to make it more readable and prevent bugs.