### PR TITLE
Hide IBC denom behind tooltip if the asset is unrecognized.

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -300,7 +300,6 @@
     "treasuryReceived": "<0><0/></0><1>sent</1><2>{{amount}}</2><3>to the treasury.</3>",
     "treasurySent": "<0><0/></0><1>was sent</1><2>{{amount}}</2><3>from the treasury.</3>",
     "txAbbr": "TX",
-    "unknownAsset": "Unknown Asset",
     "unstaked": "unstaked",
     "unstakedTokens": "unstaked ${{tokenSymbol}}",
     "unstakingMechanics": "If you unstake now, it will take {{humanReadableTime}} until they are available to you. During that time, you will not receive staking rewards. You will not be able to cancel the unbonding.",

--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -300,6 +300,7 @@
     "treasuryReceived": "<0><0/></0><1>sent</1><2>{{amount}}</2><3>to the treasury.</3>",
     "treasurySent": "<0><0/></0><1>was sent</1><2>{{amount}}</2><3>from the treasury.</3>",
     "txAbbr": "TX",
+    "unknownAsset": "Unknown Asset",
     "unstaked": "unstaked",
     "unstakedTokens": "unstaked ${{tokenSymbol}}",
     "unstakingMechanics": "If you unstake now, it will take {{humanReadableTime}} until they are available to you. During that time, you will not receive staking rewards. You will not be able to cancel the unbonding.",

--- a/packages/ui/components/ContractView/BalanceIcon.tsx
+++ b/packages/ui/components/ContractView/BalanceIcon.tsx
@@ -19,3 +19,9 @@ export const BalanceIcon: FC<BalanceIconProps> = ({ iconURI }) => {
     ></div>
   )
 }
+
+export const UnknownAssetBalanceIcon = () => (
+  <div className="flex justify-center items-center w-4 h-4 text-black bg-disabled rounded-full">
+    ?
+  </div>
+)

--- a/packages/ui/components/ContractView/TreasuryView.tsx
+++ b/packages/ui/components/ContractView/TreasuryView.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { CopyToClipboard } from '@dao-dao/ui'
 import {
   NATIVE_DENOM,
   convertMicroDenomToDenomWithDecimals,
@@ -8,7 +9,6 @@ import {
   nativeTokenLogoURI,
 } from '@dao-dao/utils'
 
-import { TooltipIcon } from '../TooltipIcon'
 import { BalanceIcon, UnknownAssetBalanceIcon } from './BalanceIcon'
 import { BalanceListItem } from './BalanceListItem'
 
@@ -47,7 +47,7 @@ export const TreasuryBalances: FC<TreasuryBalancesProps> = ({
         const icon = nativeTokenLogoURI(denom)
         if (symbol.startsWith('IBC')) {
           // We're dealing with an IBC token we don't know about. Instead
-          // of showing a long hash, hide that in a tooltip.
+          // of showing a long hash, allow the user to copy it.
           return (
             <BalanceListItem key={symbol}>
               <UnknownAssetBalanceIcon />
@@ -57,10 +57,14 @@ export const TreasuryBalances: FC<TreasuryBalancesProps> = ({
               ).toLocaleString(undefined, {
                 maximumFractionDigits: decimals,
               })}{' '}
-              <span className="flex flex-row gap-1">
-                <p>{t('info.unknownAsset')}</p>
-                <TooltipIcon label={symbol} />
-              </span>
+              <CopyToClipboard
+                className="gap-0 caption-text"
+                takeStartEnd={{
+                  start: 6,
+                  end: 4,
+                }}
+                value={symbol}
+              />
             </BalanceListItem>
           )
         }

--- a/packages/ui/components/ContractView/TreasuryView.tsx
+++ b/packages/ui/components/ContractView/TreasuryView.tsx
@@ -58,7 +58,7 @@ export const TreasuryBalances: FC<TreasuryBalancesProps> = ({
                 maximumFractionDigits: decimals,
               })}{' '}
               <span className="flex flex-row gap-1">
-                <p>Unknown Asset</p>
+                <p>{t('info.unknownAsset')}</p>
                 <TooltipIcon label={symbol} />
               </span>
             </BalanceListItem>

--- a/packages/ui/components/ContractView/TreasuryView.tsx
+++ b/packages/ui/components/ContractView/TreasuryView.tsx
@@ -8,7 +8,8 @@ import {
   nativeTokenLogoURI,
 } from '@dao-dao/utils'
 
-import { BalanceIcon } from './BalanceIcon'
+import { TooltipIcon } from '../TooltipIcon'
+import { BalanceIcon, UnknownAssetBalanceIcon } from './BalanceIcon'
 import { BalanceListItem } from './BalanceListItem'
 
 export interface TreasuryBalancesProps {
@@ -44,6 +45,25 @@ export const TreasuryBalances: FC<TreasuryBalancesProps> = ({
       {nativeTokens.map(({ denom, amount, decimals }) => {
         const symbol = nativeTokenLabel(denom)
         const icon = nativeTokenLogoURI(denom)
+        if (symbol.startsWith('IBC')) {
+          // We're dealing with an IBC token we don't know about. Instead
+          // of showing a long hash, hide that in a tooltip.
+          return (
+            <BalanceListItem key={symbol}>
+              <UnknownAssetBalanceIcon />
+              {convertMicroDenomToDenomWithDecimals(
+                amount,
+                decimals
+              ).toLocaleString(undefined, {
+                maximumFractionDigits: decimals,
+              })}{' '}
+              <span className="flex flex-row gap-1">
+                <p>Unknown Asset</p>
+                <TooltipIcon label={symbol} />
+              </span>
+            </BalanceListItem>
+          )
+        }
         return (
           <BalanceListItem key={symbol}>
             <BalanceIcon iconURI={icon} />

--- a/packages/ui/components/CopyToClipboard.tsx
+++ b/packages/ui/components/CopyToClipboard.tsx
@@ -1,4 +1,5 @@
 import { CheckCircleIcon } from '@heroicons/react/outline'
+import clsx from 'clsx'
 import { FC, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
@@ -28,6 +29,7 @@ interface CopyToClipboardProps {
     end: number
   }
   loading?: boolean
+  className?: string
 }
 
 export const CopyToClipboard: FC<CopyToClipboardProps> = ({
@@ -35,12 +37,16 @@ export const CopyToClipboard: FC<CopyToClipboardProps> = ({
   success = 'Copied to clipboard!',
   takeN,
   takeStartEnd,
+  className = 'font-mono text-xs',
 }) => {
   const [copied, setCopied] = useState(false)
 
   return (
     <button
-      className="flex overflow-hidden flex-row gap-1 items-center font-mono text-xs"
+      className={clsx(
+        'flex overflow-hidden flex-row gap-1 items-center',
+        className
+      )}
       onClick={() => {
         navigator.clipboard.writeText(value)
         setTimeout(() => setCopied(false), 2000)

--- a/packages/ui/components/CopyToClipboard.tsx
+++ b/packages/ui/components/CopyToClipboard.tsx
@@ -47,6 +47,7 @@ export const CopyToClipboard: FC<CopyToClipboardProps> = ({
         'flex overflow-hidden flex-row gap-1 items-center',
         className
       )}
+      title={value}
       onClick={() => {
         navigator.clipboard.writeText(value)
         setTimeout(() => setCopied(false), 2000)


### PR DESCRIPTION
This fixes layout issues caused by IBC denoms that are too long.

Before:
<img width="1097" alt="image" src="https://user-images.githubusercontent.com/30676292/184736849-e28ca5d4-ae34-40cd-8498-cc6d19ecf3f8.png">

After:
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/30676292/184736976-acaca4db-532b-4dc9-9fc2-ad291fc27e13.png">

Hovering over the information icon shows the whole denom:
<img width="797" alt="image" src="https://user-images.githubusercontent.com/30676292/184737842-2e52f587-0924-458f-8d4e-08c6f5ec978d.png">
