### PR TITLE
Down with FunctionComponent types.

### DIFF
--- a/apps/dapp/components/BetaWarning.tsx
+++ b/apps/dapp/components/BetaWarning.tsx
@@ -2,7 +2,6 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import { ChevronRightIcon } from '@heroicons/react/outline'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@dao-dao/ui'
@@ -11,7 +10,7 @@ interface BetaWarningModalProps {
   onAccept: () => void
 }
 
-export const BetaWarningModal: FC<BetaWarningModalProps> = ({ onAccept }) => {
+export const BetaWarningModal = ({ onAccept }: BetaWarningModalProps) => {
   const { t } = useTranslation()
 
   return (

--- a/apps/dapp/components/CommandModal/index.tsx
+++ b/apps/dapp/components/CommandModal/index.tsx
@@ -4,7 +4,7 @@
 import Fuse from 'fuse.js'
 import { MeiliSearch } from 'meilisearch'
 import { useRouter } from 'next/router'
-import { FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 
@@ -29,7 +29,7 @@ type CommandState =
   | { type: CommandStateType.NavigateDao }
   | { type: CommandStateType.DaoChosen; id: string; name: string }
 
-const SearchNavElem: FC<{ name: string }> = ({ name }) => (
+const SearchNavElem = ({ name }: { name: string }) => (
   <div
     className={'p-2 w-fit font-medium bg-secondary rounded-md animate-fadein'}
   >
@@ -149,7 +149,7 @@ const searchClient = new MeiliSearch({
 const index = searchClient.index(SEARCH_INDEX)
 
 // See design at https://unique-linseed-f29.notion.site/Command-Bar-Implementation-016afb79411f47d1b46c318409cc1547
-export const CommandModal: FC<CommandModalProps> = ({ onClose }) => {
+export const CommandModal = ({ onClose }: CommandModalProps) => {
   const router = useRouter()
   const { t } = useTranslation()
   const [commandState, setCommandState] = useState<CommandState>({

--- a/apps/dapp/components/FormCard.tsx
+++ b/apps/dapp/components/FormCard.tsx
@@ -1,12 +1,12 @@
 // GNU AFFERO GENERAL PUBLIC LICENSE Version 3. Copyright (C) 2022 DAO DAO Contributors.
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 export interface FormCardProps {
   children: ReactNode
 }
 
-export const FormCard: FC<FormCardProps> = ({ children }) => (
+export const FormCard = ({ children }: FormCardProps) => (
   <div className="py-4 px-6 my-2 bg-disabled rounded-lg">{children}</div>
 )

--- a/apps/dapp/components/HomepageCards/index.tsx
+++ b/apps/dapp/components/HomepageCards/index.tsx
@@ -3,14 +3,13 @@
 
 import { EmojiHappyIcon, HandIcon } from '@heroicons/react/outline'
 import Image from 'next/image'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Discord, Github, Twitter } from '@dao-dao/icons'
 
 import { HomepageCardVote } from './HomepageCardVote'
 
-export const HomepageCards: FC = () => {
+export const HomepageCards = () => {
   const { t } = useTranslation()
 
   return (

--- a/apps/dapp/components/InstallKeplr.tsx
+++ b/apps/dapp/components/InstallKeplr.tsx
@@ -2,7 +2,6 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import { ChevronRightIcon } from '@heroicons/react/outline'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button, Modal } from '@dao-dao/ui'
@@ -11,7 +10,7 @@ interface InstallKeplrProps {
   onClose: () => void
 }
 
-export const InstallKeplr: FC<InstallKeplrProps> = ({ onClose }) => {
+export const InstallKeplr = ({ onClose }: InstallKeplrProps) => {
   const { t } = useTranslation()
   const grafs = t('info.keplrModalWalletExplanation').split('\n')
 

--- a/apps/dapp/components/NavListItem.tsx
+++ b/apps/dapp/components/NavListItem.tsx
@@ -3,19 +3,15 @@
 
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { FC } from 'react'
+import { ComponentType } from 'react'
 
 interface NavListItemProps {
   href: string
-  icon: FC<{ className?: string }>
+  icon: ComponentType<{ className?: string }>
   text: string
 }
 
-export const NavListItem: FC<NavListItemProps> = ({
-  href,
-  icon: Icon,
-  text,
-}) => {
+export const NavListItem = ({ href, icon: Icon, text }: NavListItemProps) => {
   const { asPath: currentUrl } = useRouter()
 
   return (

--- a/apps/dapp/components/NoKeplrAccountModal.tsx
+++ b/apps/dapp/components/NoKeplrAccountModal.tsx
@@ -2,7 +2,6 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import { ChevronRightIcon } from '@heroicons/react/outline'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button, Modal } from '@dao-dao/ui'
@@ -11,9 +10,7 @@ interface NoKeplrAccountModalProps {
   onClose: () => void
 }
 
-export const NoKeplrAccountModal: FC<NoKeplrAccountModalProps> = ({
-  onClose,
-}) => {
+export const NoKeplrAccountModal = ({ onClose }: NoKeplrAccountModalProps) => {
   const { t } = useTranslation()
   const grafs = t('info.configureWalletModalExplanation').split('\n')
 

--- a/apps/dapp/components/PinnedDAOCard.tsx
+++ b/apps/dapp/components/PinnedDAOCard.tsx
@@ -1,7 +1,7 @@
 // GNU AFFERO GENERAL PUBLIC LICENSE Version 3. Copyright (C) 2022 DAO DAO Contributors.
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
-import { FC, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -23,7 +23,7 @@ interface PinnedDAOCardProps {
   address: string
 }
 
-const InnerPinnedDAOCard: FC<PinnedDAOCardProps> = ({ address }) => {
+const InnerPinnedDAOCard = ({ address }: PinnedDAOCardProps) => {
   const { t } = useTranslation()
   const config = useRecoilValue(
     CwCoreV0_1_0Selectors.configSelector({ contractAddress: address })
@@ -89,7 +89,7 @@ const InnerPinnedDAOCard: FC<PinnedDAOCardProps> = ({ address }) => {
   )
 }
 
-export const PinnedDAOCard: FC<PinnedDAOCardProps> = (props) => (
+export const PinnedDAOCard = (props: PinnedDAOCardProps) => (
   <SuspenseLoader fallback={<LoadingContractCard />}>
     <InnerPinnedDAOCard {...props} />
   </SuspenseLoader>

--- a/apps/dapp/components/PinnedDAONavList.tsx
+++ b/apps/dapp/components/PinnedDAONavList.tsx
@@ -3,7 +3,7 @@
 
 import { LibraryIcon, PlusIcon } from '@heroicons/react/outline'
 import Link from 'next/link'
-import { FC, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue, waitForAll } from 'recoil'
 
@@ -13,7 +13,7 @@ import { Logo } from '@dao-dao/ui'
 import { pinnedAddressesAtom } from '@/atoms'
 import { NavListItem } from '@/components'
 
-export const PinnedDAONavList: FC = () => {
+export const PinnedDAONavList = () => {
   const { t } = useTranslation()
 
   const pinnedAddresses = useRecoilValue(pinnedAddressesAtom)
@@ -54,7 +54,7 @@ export const PinnedDAONavList: FC = () => {
   )
 }
 
-export const MobilePinnedDAONavList: FC = () => {
+export const MobilePinnedDAONavList = () => {
   const { t } = useTranslation()
 
   const pinnedAddresses = useRecoilValue(pinnedAddressesAtom)

--- a/apps/dapp/components/SmallScreenNav.tsx
+++ b/apps/dapp/components/SmallScreenNav.tsx
@@ -4,7 +4,7 @@
 import { MenuAlt1Icon, MenuIcon, SearchIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import Link from 'next/link'
-import { FC, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue, useSetRecoilState } from 'recoil'
 
@@ -19,7 +19,7 @@ interface SmallScreenNavProps {
   className?: string
 }
 
-export const SmallScreenNav: FC<SmallScreenNavProps> = ({ className }) => {
+export const SmallScreenNav = ({ className }: SmallScreenNavProps) => {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const setCommandModalVisible = useSetRecoilState(commandModalVisibleAtom)

--- a/apps/dapp/components/ThemeToggle.tsx
+++ b/apps/dapp/components/ThemeToggle.tsx
@@ -2,14 +2,13 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import { MoonIcon, SunIcon } from '@heroicons/react/outline'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Theme, useThemeContext } from '@dao-dao/ui'
 
 export const defaultTheme = 'dark'
 
-const ThemeToggle: FC = () => {
+const ThemeToggle = () => {
   const { t } = useTranslation()
   const themeContext = useThemeContext()
 

--- a/apps/dapp/components/dao/DaoTreasuryHistory.tsx
+++ b/apps/dapp/components/dao/DaoTreasuryHistory.tsx
@@ -3,7 +3,6 @@
 
 import { parseCoins } from '@cosmjs/stargate'
 import { ExternalLinkIcon } from '@heroicons/react/outline'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -72,13 +71,13 @@ interface TransactionRendererProps {
   transaction: TreasuryTransaction
 }
 
-const TransactionRenderer: FC<TransactionRendererProps> = ({
+const TransactionRenderer = ({
   transaction: {
     tx: { hash, height },
     timestamp,
     events,
   },
-}) => {
+}: TransactionRendererProps) => {
   const { coreAddress } = useDaoInfoContext()
 
   const transferEvent = events.find(({ type }) => type === 'transfer')

--- a/apps/dapp/components/dao/create/CornerGradient.tsx
+++ b/apps/dapp/components/dao/create/CornerGradient.tsx
@@ -1,8 +1,6 @@
 // GNU AFFERO GENERAL PUBLIC LICENSE Version 3. Copyright (C) 2022 DAO DAO Contributors.
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
-import { FC } from 'react'
-
 export interface CornerGradientProps {
   color: string
 }
@@ -13,7 +11,7 @@ export interface CornerGradientProps {
  *
  * This component expects that its parent has position relative.
  */
-export const CornerGradient: FC<CornerGradientProps> = ({ color }) => (
+export const CornerGradient = ({ color }: CornerGradientProps) => (
   <div
     className="absolute top-0 left-0 -z-10 w-full h-full rounded-lg"
     style={{

--- a/apps/dapp/components/dao/create/CreateDAOConfigCard.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOConfigCard.tsx
@@ -2,7 +2,7 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import clsx from 'clsx'
-import { ComponentProps, FC, ReactNode } from 'react'
+import { ComponentProps, ReactNode } from 'react'
 import { FieldError } from 'react-hook-form'
 
 import { InputErrorMessage } from '@dao-dao/ui'
@@ -18,7 +18,7 @@ interface CreateDAOConfigCardProps extends ComponentProps<'div'> {
   childContainerClassName?: string
 }
 
-export const CreateDAOConfigCard: FC<CreateDAOConfigCardProps> = ({
+export const CreateDAOConfigCard = ({
   image,
   title,
   description,
@@ -26,7 +26,7 @@ export const CreateDAOConfigCard: FC<CreateDAOConfigCardProps> = ({
   error,
   childContainerClassName,
   ...props
-}) => (
+}: CreateDAOConfigCardProps) => (
   <CreateDAOConfigCardWrapper {...props}>
     <div className="flex flex-row gap-6 items-start">
       <p className="mt-4 text-[42px]">{image}</p>
@@ -50,9 +50,14 @@ export const CreateDAOConfigCard: FC<CreateDAOConfigCardProps> = ({
   </CreateDAOConfigCardWrapper>
 )
 
-export const CreateDAOConfigCardWrapper: FC<
-  ComponentProps<'div'> & { accentColor?: string }
-> = ({ children, className, accentColor, ...rest }) => (
+export const CreateDAOConfigCardWrapper = ({
+  children,
+  className,
+  accentColor,
+  ...rest
+}: ComponentProps<'div'> & {
+  accentColor?: string
+}) => (
   <div
     className={clsx(
       'flex relative flex-col items-stretch p-6 bg-disabled rounded-lg',

--- a/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
@@ -2,7 +2,6 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import Emoji from 'a11y-react-emoji'
-import { FC } from 'react'
 import {
   FormState,
   UseFormRegister,
@@ -45,17 +44,18 @@ export interface CreateDAOConfigCardSharedProps {
   readOnly?: boolean
 }
 
-export const CreateDAOThresholdCard: FC<CreateDAOConfigCardSharedProps> = ({
+export const CreateDAOThresholdCard = ({
   newDAO: {
     advancedVotingConfig: {
       thresholdQuorum: { threshold },
     },
   },
+
   register,
   setValue,
   errors,
   readOnly,
-}) => {
+}: CreateDAOConfigCardSharedProps) => {
   const { t } = useTranslation()
 
   return (
@@ -129,19 +129,20 @@ interface CreateDAOQuorumCardProps extends CreateDAOConfigCardSharedProps {
   showWarningModal?: () => void
 }
 
-export const CreateDAOQuorumCard: FC<CreateDAOQuorumCardProps> = ({
+export const CreateDAOQuorumCard = ({
   newDAO: {
     structure,
     advancedVotingConfig: {
       thresholdQuorum: { quorumEnabled, quorum },
     },
   },
+
   register,
   setValue,
   errors,
   readOnly,
   showWarningModal,
-}) => {
+}: CreateDAOQuorumCardProps) => {
   const { t } = useTranslation()
 
   return (
@@ -238,9 +239,13 @@ export const CreateDAOQuorumCard: FC<CreateDAOQuorumCardProps> = ({
   )
 }
 
-export const CreateDAOVotingDurationCard: FC<
-  CreateDAOConfigCardSharedProps
-> = ({ newDAO: { votingDuration }, register, setValue, errors, readOnly }) => {
+export const CreateDAOVotingDurationCard = ({
+  newDAO: { votingDuration },
+  register,
+  setValue,
+  errors,
+  readOnly,
+}: CreateDAOConfigCardSharedProps) => {
   const { t } = useTranslation()
 
   return (
@@ -312,9 +317,7 @@ export const CreateDAOVotingDurationCard: FC<
   )
 }
 
-export const CreateDAOProposalDepositCard: FC<
-  CreateDAOConfigCardSharedProps
-> = ({
+export const CreateDAOProposalDepositCard = ({
   newDAO: {
     governanceTokenOptions: {
       type,
@@ -323,11 +326,12 @@ export const CreateDAOProposalDepositCard: FC<
       existingGovernanceTokenInfo: { symbol: existingSymbol } = {},
     },
   },
+
   register,
   setValue,
   errors,
   readOnly,
-}) => {
+}: CreateDAOConfigCardSharedProps) => {
   const { t } = useTranslation()
 
   return (
@@ -379,19 +383,18 @@ export const CreateDAOProposalDepositCard: FC<
   )
 }
 
-export const CreateDAORefundFailedProposalDepositCard: FC<
-  CreateDAOConfigCardSharedProps
-> = ({
+export const CreateDAORefundFailedProposalDepositCard = ({
   newDAO: {
     governanceTokenOptions: {
       proposalDeposit: { refundFailed },
     },
   },
+
   errors,
   setValue,
   watch,
   readOnly,
-}) => {
+}: CreateDAOConfigCardSharedProps) => {
   const { t } = useTranslation()
 
   return (
@@ -421,17 +424,16 @@ export const CreateDAORefundFailedProposalDepositCard: FC<
   )
 }
 
-export const CreateDAOUnstakingDurationCard: FC<
-  CreateDAOConfigCardSharedProps
-> = ({
+export const CreateDAOUnstakingDurationCard = ({
   newDAO: {
     governanceTokenOptions: { unregisterDuration },
   },
+
   errors,
   setValue,
   register,
   readOnly,
-}) => {
+}: CreateDAOConfigCardSharedProps) => {
   const { t } = useTranslation()
 
   return (
@@ -497,15 +499,16 @@ export const CreateDAOUnstakingDurationCard: FC<
   )
 }
 
-export const CreateDAOAllowRevotingCard: FC<CreateDAOConfigCardSharedProps> = ({
+export const CreateDAOAllowRevotingCard = ({
   newDAO: {
     advancedVotingConfig: { allowRevoting },
   },
+
   errors,
   setValue,
   watch,
   readOnly,
-}) => {
+}: CreateDAOConfigCardSharedProps) => {
   const { t } = useTranslation()
 
   return (

--- a/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOConfigCards.tsx
@@ -323,10 +323,9 @@ export const CreateDAOProposalDepositCard = ({
       type,
       newInfo: { symbol: newSymbol },
       proposalDeposit: { value },
-      existingGovernanceTokenInfo: { symbol: existingSymbol } = {},
+      existingGovernanceTokenInfo,
     },
   },
-
   register,
   setValue,
   errors,
@@ -345,8 +344,9 @@ export const CreateDAOProposalDepositCard = ({
       {readOnly ? (
         <InputThemedText>
           {value} $
-          {(type === GovernanceTokenType.New ? newSymbol : existingSymbol) ||
-            t('info.tokens')}
+          {(type === GovernanceTokenType.New
+            ? newSymbol
+            : existingGovernanceTokenInfo?.symbol) || t('info.tokens')}
         </InputThemedText>
       ) : (
         <div className="flex flex-row gap-2 items-center">
@@ -374,8 +374,9 @@ export const CreateDAOProposalDepositCard = ({
 
           <p className="text-tertiary">
             $
-            {(type === GovernanceTokenType.New ? newSymbol : existingSymbol) ||
-              t('info.tokens')}
+            {(type === GovernanceTokenType.New
+              ? newSymbol
+              : existingGovernanceTokenInfo?.symbol) || t('info.tokens')}
           </p>
         </div>
       )}

--- a/apps/dapp/components/dao/create/CreateDAOFormWrapper.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOFormWrapper.tsx
@@ -2,7 +2,7 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import { NextSeo } from 'next-seo'
-import { ComponentPropsWithoutRef, FC, ReactNode } from 'react'
+import { ComponentPropsWithoutRef, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -30,14 +30,14 @@ interface CreateDAOFormWrapperProps
   creating: boolean
 }
 
-export const CreateDAOFormWrapper: FC<CreateDAOFormWrapperProps> = ({
+export const CreateDAOFormWrapper = ({
   children,
   containerClassName,
   currentPageIndex,
   currentPage,
   creating,
   ...props
-}) => {
+}: CreateDAOFormWrapperProps) => {
   const { t } = useTranslation()
   const mountedInBrowser = useRecoilValue(mountedInBrowserAtom)
   const createDAOFormPages = useCreateDAOFormPages()

--- a/apps/dapp/components/dao/create/CreateDAONav.tsx
+++ b/apps/dapp/components/dao/create/CreateDAONav.tsx
@@ -2,7 +2,6 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import clsx from 'clsx'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -15,7 +14,7 @@ interface CreateDAONavProps {
   currentPageIndex: number
 }
 
-export const CreateDAONav: FC<CreateDAONavProps> = ({ currentPageIndex }) => {
+export const CreateDAONav = ({ currentPageIndex }: CreateDAONavProps) => {
   const { t } = useTranslation()
   const mountedInBrowser = useRecoilValue(mountedInBrowserAtom)
   const createDAOFormPages = useCreateDAOFormPages()

--- a/apps/dapp/components/dao/create/CreateDAOStructure.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOStructure.tsx
@@ -2,7 +2,7 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import clsx from 'clsx'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { RadioButton } from '@dao-dao/ui'
 
@@ -17,14 +17,14 @@ interface CreateDAOStructureProps {
   onChange: (structure: NewDAOStructure) => void
 }
 
-export const CreateDAOStructure: FC<CreateDAOStructureProps> = ({
+export const CreateDAOStructure = ({
   newDAO,
   emoji,
   title,
   description,
   structure,
   onChange,
-}) => {
+}: CreateDAOStructureProps) => {
   const selected = newDAO.structure === structure
 
   return (

--- a/apps/dapp/components/dao/create/CreateDAOTier.tsx
+++ b/apps/dapp/components/dao/create/CreateDAOTier.tsx
@@ -3,7 +3,6 @@
 
 import { TrashIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
-import { FC } from 'react'
 import {
   Control,
   FormState,
@@ -48,11 +47,12 @@ interface CreateDAOTierProps {
   remove?: () => void
 }
 
-export const CreateDAOTier: FC<CreateDAOTierProps> = ({
+export const CreateDAOTier = ({
   // Don't pass along to member.
   remove,
+
   ...props
-}) => {
+}: CreateDAOTierProps) => {
   const { t } = useTranslation()
   const {
     newDAO,
@@ -220,7 +220,7 @@ interface CreateDAOTierMemberProps extends CreateDAOTierProps {
   memberIndex: number
 }
 
-const CreateDAOTierMember: FC<CreateDAOTierMemberProps> = ({
+const CreateDAOTierMember = ({
   newDAO,
   tierIndex,
   memberIndex,
@@ -228,7 +228,7 @@ const CreateDAOTierMember: FC<CreateDAOTierMemberProps> = ({
   errors,
   remove,
   showColorDotOnMember,
-}) => {
+}: CreateDAOTierMemberProps) => {
   const { t } = useTranslation()
 
   const tier = newDAO.tiers?.[tierIndex]

--- a/apps/dapp/components/dao/create/Distributions.tsx
+++ b/apps/dapp/components/dao/create/Distributions.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
 } from 'chart.js'
 import clsx from 'clsx'
-import { FC, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Bar, Pie } from 'react-chartjs-2'
 import { useTranslation } from 'react-i18next'
 
@@ -53,9 +53,7 @@ interface DistributionProps {
   newDAO: NewDAO
 }
 
-export const VotingPowerPieDistribution: FC<DistributionProps> = ({
-  newDAO,
-}) => {
+export const VotingPowerPieDistribution = ({ newDAO }: DistributionProps) => {
   const { t } = useTranslation()
   const { onlyOneTier, entries } = useVotingPowerDistributionData(newDAO, true)
 
@@ -178,7 +176,7 @@ export const useVotingPowerDistributionData = (
   ])
 }
 
-const PieChart: FC<DataProps> = ({ data }) => (
+const PieChart = ({ data }: DataProps) => (
   <Pie
     className="justify-self-center !w-32 !h-32 md:!w-48 md:!h-48"
     data={{
@@ -198,7 +196,7 @@ const PieChart: FC<DataProps> = ({ data }) => (
   />
 )
 
-export const VotingPowerChart: FC<DataProps> = ({ data }) => {
+export const VotingPowerChart = ({ data }: DataProps) => {
   const { t } = useTranslation()
   const darkRgb = useNamedThemeColor('dark')
 
@@ -250,7 +248,7 @@ export const VotingPowerChart: FC<DataProps> = ({ data }) => {
   )
 }
 
-const Legend: FC<DataProps> = ({ data }) => (
+const Legend = ({ data }: DataProps) => (
   <div className="flex flex-col gap-1 md:gap-2">
     {data.map((allocation) => (
       <LegendItem key={allocation.name} data={allocation} />
@@ -262,9 +260,9 @@ interface LegendItemProps {
   data: Entry
 }
 
-const LegendItem: FC<LegendItemProps> = ({
+const LegendItem = ({
   data: { name, value: percent, color },
-}) => (
+}: LegendItemProps) => (
   <div
     key={name}
     className={clsx('grid gap-5 items-center', {

--- a/apps/dapp/components/home/PinnedDAOsList.tsx
+++ b/apps/dapp/components/home/PinnedDAOsList.tsx
@@ -3,7 +3,6 @@
 
 import { PlusIcon } from '@heroicons/react/outline'
 import Link from 'next/link'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { PinOutline } from '@dao-dao/icons'
@@ -14,7 +13,7 @@ import { usePinnedDAOs } from '@/hooks'
 import { PinnedDAOCard } from '../PinnedDAOCard'
 import { DaoCardContainer } from './DaoCardContainer'
 
-export const PinnedDAOsList: FC = () => {
+export const PinnedDAOsList = () => {
   const { t } = useTranslation()
   const { pinnedAddresses } = usePinnedDAOs()
 

--- a/apps/dapp/components/home/PinnedProposalsList.tsx
+++ b/apps/dapp/components/home/PinnedProposalsList.tsx
@@ -4,7 +4,7 @@
 import { DocumentTextIcon } from '@heroicons/react/outline'
 import groupBy from 'lodash.groupby'
 import isEqual from 'lodash.isequal'
-import { FC, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue, waitForAll } from 'recoil'
 
@@ -20,7 +20,7 @@ import {
 
 import { usePinnedDAOs } from '@/hooks'
 
-export const PinnedProposalsList: FC = () => {
+export const PinnedProposalsList = () => {
   const { t } = useTranslation()
 
   return (
@@ -41,7 +41,7 @@ export const PinnedProposalsList: FC = () => {
   )
 }
 
-const InnerPinnedProposalsList: FC = () => {
+const InnerPinnedProposalsList = () => {
   const { t } = useTranslation()
   const {
     pinnedAddresses: _pinnedAddresses,

--- a/apps/dapp/components/splash/AnnouncementCard.tsx
+++ b/apps/dapp/components/splash/AnnouncementCard.tsx
@@ -2,10 +2,9 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import { ArrowRightIcon } from '@heroicons/react/outline'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
-export const AnouncementCard: FC = () => {
+export const AnouncementCard = () => {
   const { t } = useTranslation()
 
   return (

--- a/apps/dapp/components/splash/EnterAppButton.tsx
+++ b/apps/dapp/components/splash/EnterAppButton.tsx
@@ -2,7 +2,6 @@
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
 import Link from 'next/link'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ArrowUpRight } from '@dao-dao/icons'
@@ -12,7 +11,7 @@ interface EnterAppButtonProps {
   small?: boolean
 }
 
-export const EnterAppButton: FC<EnterAppButtonProps> = ({ small }) => {
+export const EnterAppButton = ({ small }: EnterAppButtonProps) => {
   const { t } = useTranslation()
 
   return (

--- a/apps/dapp/components/splash/StatsCard.tsx
+++ b/apps/dapp/components/splash/StatsCard.tsx
@@ -1,9 +1,7 @@
 // GNU AFFERO GENERAL PUBLIC LICENSE Version 3. Copyright (C) 2022 DAO DAO Contributors.
 // See the "LICENSE" file in the root directory of this package for more copyright information.
 
-import { FC } from 'react'
-
-export const StatsCard: FC = ({ children }) => (
+export const StatsCard = ({ children }) => (
   <div className="flex flex-col gap-1 items-center px-6 md:px-6">
     {children}
   </div>

--- a/apps/raw-sda/components/DescriptionAndAirdropAllocation.tsx
+++ b/apps/raw-sda/components/DescriptionAndAirdropAllocation.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { MarkdownPreview } from '@dao-dao/ui'
 
 import { TokenDistributionPie } from './TokenDistributionPie'
@@ -8,9 +6,9 @@ export interface DescriptionAndAidropAllocationProps {
   missionMarkdown: string
 }
 
-export const DescriptionAndAirdropAllocation: FC<
-  DescriptionAndAidropAllocationProps
-> = ({ missionMarkdown }) => (
+export const DescriptionAndAirdropAllocation = ({
+  missionMarkdown,
+}: DescriptionAndAidropAllocationProps) => (
   <div className="flex flex-wrap grid-cols-5 bg-disabled rounded-lg md:grid md:gap-3">
     <MarkdownPreview
       className="col-span-3 p-10 prose-h2:mb-6 prose-h3:mb-4 max-w-full border-b border-inactive md:border-r md:border-b-0 body-text prose-h2:header-text prose-h3:title-text"

--- a/apps/raw-sda/components/PausedBanner.tsx
+++ b/apps/raw-sda/components/PausedBanner.tsx
@@ -1,5 +1,5 @@
 import { PauseIcon } from '@heroicons/react/outline'
-import { FC, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -32,7 +32,7 @@ export const remainingTime = (
   return { time: 0 }
 }
 
-export const PausedBanner: FC<PausedBannerProps> = ({}) => {
+export const PausedBanner = ({}: PausedBannerProps) => {
   const { t } = useTranslation()
   const pauseInfo = useRecoilValue(
     CwCoreV0_1_0Selectors.pauseInfoSelector({ contractAddress: DAO_ADDRESS })

--- a/apps/raw-sda/components/TokenDistributionPie.tsx
+++ b/apps/raw-sda/components/TokenDistributionPie.tsx
@@ -1,5 +1,4 @@
 import { ArcElement, Chart as ChartJS } from 'chart.js'
-import { FunctionComponent } from 'react'
 import { Pie } from 'react-chartjs-2'
 
 ChartJS.register(ArcElement)
@@ -10,7 +9,7 @@ interface AllocationSection {
   color: string
 }
 
-export const TokenDistributionPie: FunctionComponent = () => {
+export const TokenDistributionPie = () => {
   const allocationSections = [
     {
       name: 'Fairdrop',
@@ -73,9 +72,7 @@ interface LegendItemProps {
   data: AllocationSection
 }
 
-const LegendItem: FunctionComponent<LegendItemProps> = ({
-  data: { name, percent, color },
-}) => {
+const LegendItem = ({ data: { name, percent, color } }: LegendItemProps) => {
   return (
     <div
       key={name}

--- a/apps/raw-sda/components/WalletAvatarIcon.tsx
+++ b/apps/raw-sda/components/WalletAvatarIcon.tsx
@@ -1,12 +1,10 @@
-import { FunctionComponent, SVGProps, useMemo } from 'react'
+import { SVGProps, useMemo } from 'react'
 
 // Ensure radialGradient ID is unique on the page or else only one icon
 // will render.
 let id = 0
 
-export const WalletAvatarIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (
-  props
-) => {
+export const WalletAvatarIcon = (props: SVGProps<SVGSVGElement>) => {
   const currId = useMemo(() => ++id, [])
 
   return (

--- a/apps/raw-sda/components/stake/BalanceCards.tsx
+++ b/apps/raw-sda/components/stake/BalanceCards.tsx
@@ -1,5 +1,4 @@
 import { useWalletManager } from '@noahsaso/cosmodal'
-import { FunctionComponent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Trans } from '@dao-dao/ui'
@@ -17,9 +16,7 @@ interface CardProps {
   setShowStakingMode: () => void
 }
 
-export const UnstakedBalanceCard: FunctionComponent<CardProps> = ({
-  setShowStakingMode,
-}) => {
+export const UnstakedBalanceCard = ({ setShowStakingMode }: CardProps) => {
   const { t } = useTranslation()
   const {
     hooks: { useGovernanceTokenInfo },
@@ -79,9 +76,7 @@ export const UnstakedBalanceCard: FunctionComponent<CardProps> = ({
   )
 }
 
-export const StakedBalanceCard: FunctionComponent<CardProps> = ({
-  setShowStakingMode,
-}) => {
+export const StakedBalanceCard = ({ setShowStakingMode }: CardProps) => {
   const { t } = useTranslation()
   const {
     hooks: { useGovernanceTokenInfo, useStakingInfo },

--- a/apps/raw-sda/pages/vote/[proposalId].tsx
+++ b/apps/raw-sda/pages/vote/[proposalId].tsx
@@ -1,7 +1,7 @@
 import { useWallet } from '@noahsaso/cosmodal'
 import type { GetStaticPaths, NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { FC, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 
@@ -23,7 +23,7 @@ import { useVotingModuleAdapter } from '@dao-dao/voting-module-adapter'
 import { Loader, Logo, PageLoader, PageWrapper } from '@/components'
 import { DAO_ADDRESS } from '@/util'
 
-const InnerProposal: FC = () => {
+const InnerProposal = () => {
   const { t } = useTranslation()
   const router = useRouter()
   const { address: walletAddress, connected } = useWallet()

--- a/apps/sda-base/components/PausedBanner.tsx
+++ b/apps/sda-base/components/PausedBanner.tsx
@@ -1,5 +1,5 @@
 import { PauseIcon } from '@heroicons/react/outline'
-import { FC, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -32,7 +32,7 @@ export const remainingTime = (
   return { time: 0 }
 }
 
-export const PausedBanner: FC<PausedBannerProps> = ({}) => {
+export const PausedBanner = ({}: PausedBannerProps) => {
   const { t } = useTranslation()
   const pauseInfo = useRecoilValue(
     CwCoreV0_1_0Selectors.pauseInfoSelector({ contractAddress: DAO_ADDRESS })

--- a/apps/sda-base/components/WalletAvatarIcon.tsx
+++ b/apps/sda-base/components/WalletAvatarIcon.tsx
@@ -1,12 +1,10 @@
-import { FunctionComponent, SVGProps, useMemo } from 'react'
+import { SVGProps, useMemo } from 'react'
 
 // Ensure radialGradient ID is unique on the page or else only one icon
 // will render.
 let id = 0
 
-export const WalletAvatarIcon: FunctionComponent<SVGProps<SVGSVGElement>> = (
-  props
-) => {
+export const WalletAvatarIcon = (props: SVGProps<SVGSVGElement>) => {
   const currId = useMemo(() => ++id, [])
 
   return (

--- a/apps/sda-base/pages/vote/[proposalId].tsx
+++ b/apps/sda-base/pages/vote/[proposalId].tsx
@@ -1,7 +1,7 @@
 import { useWallet } from '@noahsaso/cosmodal'
 import type { GetStaticPaths, NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { FC, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 
@@ -23,7 +23,7 @@ import { useVotingModuleAdapter } from '@dao-dao/voting-module-adapter'
 import { Loader, Logo, PageLoader, PageWrapper } from '@/components'
 import { DAO_ADDRESS } from '@/util'
 
-const InnerProposal: FC = () => {
+const InnerProposal = () => {
   const { t } = useTranslation()
   const router = useRouter()
   const { address: walletAddress, connected } = useWallet()

--- a/packages/actions/components/ActionCard.tsx
+++ b/packages/actions/components/ActionCard.tsx
@@ -1,5 +1,5 @@
 import { XIcon } from '@heroicons/react/solid'
-import { ComponentType, FC } from 'react'
+import { ComponentType } from 'react'
 
 import { LoaderProps } from '@dao-dao/ui'
 
@@ -10,12 +10,12 @@ interface ActionCardProps extends Pick<ActionComponentProps, 'onRemove'> {
   title: string
 }
 
-export const ActionCard: FC<ActionCardProps> = ({
+export const ActionCard = ({
   Icon,
   title,
   onRemove,
   children,
-}) => (
+}: ActionCardProps) => (
   <div className="flex flex-col gap-2 p-3 my-2 bg-primary rounded-lg">
     <div className="flex flex-row gap-2 justify-between items-start">
       <div className="flex flex-row gap-2 items-center">

--- a/packages/actions/components/ActionCard.tsx
+++ b/packages/actions/components/ActionCard.tsx
@@ -1,11 +1,12 @@
 import { XIcon } from '@heroicons/react/solid'
-import { ComponentType } from 'react'
+import { ComponentType, ReactNode } from 'react'
 
 import { LoaderProps } from '@dao-dao/ui'
 
 import { ActionComponentProps } from '..'
 
 interface ActionCardProps extends Pick<ActionComponentProps, 'onRemove'> {
+  children: ReactNode | ReactNode[]
   Icon: ComponentType
   title: string
 }

--- a/packages/actions/components/NativeCoinSelector.tsx
+++ b/packages/actions/components/NativeCoinSelector.tsx
@@ -1,6 +1,6 @@
 import { Coin } from '@cosmjs/stargate'
 import { XIcon } from '@heroicons/react/solid'
-import { ComponentProps, FC, useCallback, useEffect } from 'react'
+import { ComponentProps, useCallback, useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -23,14 +23,14 @@ export type NativeCoinSelectorProps = ComponentProps<
   className?: string
 }
 
-export const NativeCoinSelector: FC<NativeCoinSelectorProps> = ({
+export const NativeCoinSelector = ({
   onRemove,
   fieldNamePrefix,
   errors,
   isCreating,
   options: { nativeBalances },
   className,
-}) => {
+}: NativeCoinSelectorProps) => {
   const { t } = useTranslation()
   const { register, setValue, watch, setError, clearErrors } = useFormContext()
 

--- a/packages/actions/types.ts
+++ b/packages/actions/types.ts
@@ -1,4 +1,5 @@
-import { ComponentType } from 'react'
+// eslint-disable-next-line regex/invalid
+import { ComponentType, FunctionComponent } from 'react'
 import { FieldErrors } from 'react-hook-form'
 
 import { CosmosMsgFor_Empty } from '@dao-dao/types/contracts/cw3-dao'
@@ -63,7 +64,8 @@ export type ActionComponentProps<T = undefined, D = any> = {
 ) &
   (T extends undefined ? {} : { options: T })
 
-export type ActionComponent<T = undefined, D = any> = ComponentType<
+// eslint-disable-next-line regex/invalid
+export type ActionComponent<T = undefined, D = any> = FunctionComponent<
   ActionComponentProps<T, D>
 >
 

--- a/packages/actions/types.ts
+++ b/packages/actions/types.ts
@@ -1,4 +1,4 @@
-import { ComponentType, FunctionComponent } from 'react'
+import { ComponentType } from 'react'
 import { FieldErrors } from 'react-hook-form'
 
 import { CosmosMsgFor_Empty } from '@dao-dao/types/contracts/cw3-dao'
@@ -63,7 +63,7 @@ export type ActionComponentProps<T = undefined, D = any> = {
 ) &
   (T extends undefined ? {} : { options: T })
 
-export type ActionComponent<T = undefined, D = any> = FunctionComponent<
+export type ActionComponent<T = undefined, D = any> = ComponentType<
   ActionComponentProps<T, D>
 >
 

--- a/packages/common/components/ConnectWalletButton.tsx
+++ b/packages/common/components/ConnectWalletButton.tsx
@@ -1,7 +1,6 @@
 import { useWalletManager } from '@noahsaso/cosmodal'
 import { isMobile } from '@walletconnect/browser-utils'
 import clsx from 'clsx'
-import { FC } from 'react'
 
 import { useWalletBalance } from '@dao-dao/state'
 import {
@@ -16,11 +15,11 @@ export interface ConnectWalletButtonProps extends Partial<WalletConnectProps> {
   mobile?: boolean
 }
 
-export const ConnectWalletButton: FC<ConnectWalletButtonProps> = ({
+export const ConnectWalletButton = ({
   mobile,
   className,
   ...props
-}) => {
+}: ConnectWalletButtonProps) => {
   const {
     connect,
     disconnect,

--- a/packages/config/eslint/index.js
+++ b/packages/config/eslint/index.js
@@ -103,38 +103,22 @@ const eslintConfig = {
             {
               regex: '\\@\\/\\.\\.\\/\\.\\.\\/packages',
               replacement: '@dao-dao',
-              files: {
-                // Don't replace in this file since the pattern appears above.
-                ignore: 'import\\.js',
-              },
               message:
                 'Import from @dao-dao/* instead of a relative path (i.e. replace "@/../../packages" with "@dao-dao").',
             },
             {
               regex: '\\@dao\\-dao\\/ui\\/(components|theme)[^\'"]*',
               replacement: '@dao-dao/ui',
-              files: {
-                // Don't replace in this file since the pattern appears above.
-                ignore: 'import\\.js',
-              },
               message:
                 'Import from root @dao-dao/ui instead of a direct path. Ensure the export has been added to its sibling index.',
             },
             {
               regex: '\\@dao\\-dao\\/state\\/hooks\\/clients[^\'"]*',
-              files: {
-                // Don't replace in this file since the pattern appears above.
-                ignore: 'import\\.js',
-              },
               message:
                 'Import from root @dao-dao/state using a grouped export, such as CwCoreHooks, instead of a direct path.',
             },
             {
               regex: '\\@dao\\-dao\\/state\\/recoil\\/selectors[^\'"]*',
-              files: {
-                // Don't replace in this file since the pattern appears above.
-                ignore: 'import\\.js',
-              },
               message:
                 'Import from root @dao-dao/state instead of a direct path. If using contract client selectors, use a grouped export, such as CwCoreV0_1_0Selectors.',
             },
@@ -175,6 +159,11 @@ const eslintConfig = {
               },
               message:
                 '`animate-spin` is too fast. Use `animate-spin-medium` for a chiller vibe.',
+            },
+            {
+              regex: '\\b(FC|FunctionComponent)\\b',
+              message:
+                "Using React's FunctionComponent is discouraged. Type the props explicitly: `export const Component = (props: ComponentProps) => { ... }`",
             },
           ],
         ],

--- a/packages/proposal-module-adapter/adapters/cw-proposal-single/components/ProposalInfoCard.tsx
+++ b/packages/proposal-module-adapter/adapters/cw-proposal-single/components/ProposalInfoCard.tsx
@@ -1,5 +1,4 @@
 import { ExternalLinkIcon } from '@heroicons/react/outline'
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { constSelector, useRecoilValue } from 'recoil'
 
@@ -167,7 +166,7 @@ interface YouTooltipProps {
   label: string
 }
 
-const YouTooltip: FC<YouTooltipProps> = ({ label }) => (
+const YouTooltip = ({ label }: YouTooltipProps) => (
   <Tooltip label={label}>
     <p className="flex justify-center items-center p-1 w-4 h-4 font-mono text-xs rounded-full border cursor-pointer text-tertiary border-tertiary">
       ?

--- a/packages/ui/components/ActionSelector.tsx
+++ b/packages/ui/components/ActionSelector.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import Fuse from 'fuse.js'
-import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Action } from '@dao-dao/actions'
@@ -14,11 +14,11 @@ export interface ActionSelectorProps {
   onSelectAction: (action: Action) => void
 }
 
-export const ActionSelector: FC<ActionSelectorProps> = ({
+export const ActionSelector = ({
   actions,
   onClose,
   onSelectAction,
-}) => {
+}: ActionSelectorProps) => {
   const { t } = useTranslation()
   const actionsFuse = useMemo(
     () => new Fuse(actions, { keys: ['label', 'description'] }),
@@ -128,11 +128,11 @@ interface ActionDisplayItemProps {
   selected: boolean
 }
 
-const ActionDisplayItem: FC<ActionDisplayItemProps> = ({
+const ActionDisplayItem = ({
   action: { Icon, label, description },
   onClick,
   selected,
-}) => (
+}: ActionDisplayItemProps) => (
   <button
     className={clsx(
       'flex flex-row gap-3 items-center p-2 w-full text-left hover:bg-primary rounded transition',

--- a/packages/ui/components/Breadcrumbs.tsx
+++ b/packages/ui/components/Breadcrumbs.tsx
@@ -1,7 +1,6 @@
 import { ArrowNarrowLeftIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
 import Link from 'next/link'
-import { FC } from 'react'
 
 export interface BreadcrumbsProps {
   crumbs: Array<[string, string]>
@@ -9,7 +8,7 @@ export interface BreadcrumbsProps {
 }
 
 // Navigation breadcrumbs. We hide these on small screens prefering the nav bar.
-export const Breadcrumbs: FC<BreadcrumbsProps> = ({ crumbs, className }) => (
+export const Breadcrumbs = ({ crumbs, className }: BreadcrumbsProps) => (
   <ul className={clsx('hidden list-none lg:flex link-text', className)}>
     <li key="icon">
       <Link href={crumbs[crumbs.length - 2][0]}>

--- a/packages/ui/components/Claims/ClaimsAvailableCard.tsx
+++ b/packages/ui/components/Claims/ClaimsAvailableCard.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { TokenInfoResponse } from '@dao-dao/types/contracts/stake-cw20'
@@ -13,12 +12,12 @@ export interface ClaimsAvailableCardProps {
   loading: boolean
 }
 
-export const ClaimsAvailableCard: FC<ClaimsAvailableCardProps> = ({
+export const ClaimsAvailableCard = ({
   available,
   tokenInfo,
   onClaim,
   loading,
-}) => {
+}: ClaimsAvailableCardProps) => {
   const { t } = useTranslation()
 
   return (

--- a/packages/ui/components/Claims/ClaimsListItem.tsx
+++ b/packages/ui/components/Claims/ClaimsListItem.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon } from '@heroicons/react/outline'
-import { FC, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Duration } from '@dao-dao/types/contracts/cw3-dao'
@@ -39,13 +39,13 @@ export interface ClaimsListItemProps {
   iconURI?: string
 }
 
-export const ClaimsListItem: FC<ClaimsListItemProps> = ({
+export const ClaimsListItem = ({
   claim,
   blockHeight,
   tokenInfo,
   onClaimAvailable,
   iconURI,
-}) => {
+}: ClaimsListItemProps) => {
   const { t } = useTranslation()
   const available = claimAvailable(claim, blockHeight)
   const initialDurationRemaining = claimDurationRemaining(claim, blockHeight)

--- a/packages/ui/components/ContractView/BalanceCard.tsx
+++ b/packages/ui/components/ContractView/BalanceCard.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button'
 import { LogoNoBorder } from '../Logo'
 
 export interface BalanceCardProps {
+  children: ReactNode | ReactNode[]
   title: ReactNode
   icon?: ReactNode
   buttonLabel: ReactNode

--- a/packages/ui/components/ContractView/BalanceCard.tsx
+++ b/packages/ui/components/ContractView/BalanceCard.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { Button } from '../Button'
 import { LogoNoBorder } from '../Logo'
@@ -13,7 +13,7 @@ export interface BalanceCardProps {
   opaque?: boolean
 }
 
-export const BalanceCard: FC<BalanceCardProps> = ({
+export const BalanceCard = ({
   title,
   icon,
   buttonLabel,
@@ -21,7 +21,7 @@ export const BalanceCard: FC<BalanceCardProps> = ({
   onClick,
   opaque,
   children,
-}) => (
+}: BalanceCardProps) => (
   <div
     className={clsx('p-5 w-full rounded-lg', {
       'border border-default': !opaque,

--- a/packages/ui/components/ContractView/BalanceIcon.tsx
+++ b/packages/ui/components/ContractView/BalanceIcon.tsx
@@ -1,12 +1,10 @@
-import { FC } from 'react'
-
 import { useThemeContext } from '../../theme'
 
 export interface BalanceIconProps {
   iconURI?: string
 }
 
-export const BalanceIcon: FC<BalanceIconProps> = ({ iconURI }) => {
+export const BalanceIcon = ({ iconURI }: BalanceIconProps) => {
   const { accentColor } = useThemeContext()
 
   return (

--- a/packages/ui/components/ContractView/BalanceListItem.tsx
+++ b/packages/ui/components/ContractView/BalanceListItem.tsx
@@ -1,10 +1,10 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 export interface BalanceListItemProps {
   children: ReactNode
 }
 
-export const BalanceListItem: FC<BalanceListItemProps> = ({ children }) => (
+export const BalanceListItem = ({ children }: BalanceListItemProps) => (
   <li className="flex overflow-auto flex-row gap-2 items-center whitespace-nowrap caption-text">
     {children}
   </li>

--- a/packages/ui/components/ContractView/EstablishedDate.tsx
+++ b/packages/ui/components/ContractView/EstablishedDate.tsx
@@ -1,11 +1,10 @@
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export interface EstablishedDateProps {
   date: Date
 }
 
-export const EstablishedDate: FC<EstablishedDateProps> = ({ date }) => {
+export const EstablishedDate = ({ date }: EstablishedDateProps) => {
   const { t } = useTranslation()
   const formattedDate = date.toLocaleDateString(undefined, {
     year: 'numeric',
@@ -22,7 +21,7 @@ export const EstablishedDate: FC<EstablishedDateProps> = ({ date }) => {
 
 // Note that this is invisible; this date is not rendered. It just takes up the
 // right amount of space.
-export const EstablishedDateLoader: FC = () => (
+export const EstablishedDateLoader = () => (
   <p className="invisible mb-3 text-sm">
     {/* eslint-disable-next-line i18next/no-literal-string */}
     <span className="inline bg-dark rounded-sm animate-pulse">

--- a/packages/ui/components/ContractView/GovInfoListItem.tsx
+++ b/packages/ui/components/ContractView/GovInfoListItem.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 export interface GovInfoListItemProps {
   icon: ReactNode
@@ -7,12 +7,12 @@ export interface GovInfoListItemProps {
   loading?: boolean
 }
 
-export const GovInfoListItem: FC<GovInfoListItemProps> = ({
+export const GovInfoListItem = ({
   icon,
   text,
   value,
   loading,
-}) => (
+}: GovInfoListItemProps) => (
   <li className="flex flex-row items-center caption-text">
     <span className="flex gap-1 items-center mr-1">
       {icon} {text}:

--- a/packages/ui/components/ContractView/GradientHero.tsx
+++ b/packages/ui/components/ContractView/GradientHero.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 import { useThemeContext } from '../../theme'
 
@@ -6,7 +6,7 @@ export interface GradientHeroProps {
   children: ReactNode
 }
 
-export const GradientHero: FC<GradientHeroProps> = ({ children }) => {
+export const GradientHero = ({ children }: GradientHeroProps) => {
   const theme = useThemeContext()
   const endStop = theme.theme === 'dark' ? '#111213' : '#FFFFFF'
   const baseRgb = theme.accentColor

--- a/packages/ui/components/ContractView/MobileMenuTab.tsx
+++ b/packages/ui/components/ContractView/MobileMenuTab.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import { FC } from 'react'
 
 export interface MobileMenuTabProps {
   icon: string
@@ -8,12 +7,12 @@ export interface MobileMenuTabProps {
   selected: boolean
 }
 
-export const MobileMenuTab: FC<MobileMenuTabProps> = ({
+export const MobileMenuTab = ({
   icon,
   text,
   onClick,
   selected,
-}) => (
+}: MobileMenuTabProps) => (
   <button
     className={clsx(
       'flex flex-col flex-1 gap-3 items-center p-5 min-w-[100px] rounded transition',

--- a/packages/ui/components/ContractView/TreasuryView.tsx
+++ b/packages/ui/components/ContractView/TreasuryView.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -26,11 +25,11 @@ export interface TreasuryBalancesProps {
   usdcValue: number
 }
 
-export const TreasuryBalances: FC<TreasuryBalancesProps> = ({
+export const TreasuryBalances = ({
   nativeTokens,
   cw20Tokens,
   usdcValue,
-}) => {
+}: TreasuryBalancesProps) => {
   const { t } = useTranslation()
   return (
     <ul className="flex flex-col gap-2 mt-6 list-none">

--- a/packages/ui/components/CopyToClipboard.tsx
+++ b/packages/ui/components/CopyToClipboard.tsx
@@ -1,5 +1,5 @@
 import { CheckCircleIcon } from '@heroicons/react/outline'
-import { FC, useState } from 'react'
+import { useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 
@@ -30,12 +30,12 @@ interface CopyToClipboardProps {
   loading?: boolean
 }
 
-export const CopyToClipboard: FC<CopyToClipboardProps> = ({
+export const CopyToClipboard = ({
   value,
   success = 'Copied to clipboard!',
   takeN,
   takeStartEnd,
-}) => {
+}: CopyToClipboardProps) => {
   const [copied, setCopied] = useState(false)
 
   return (
@@ -64,11 +64,11 @@ export const CopyToClipboard: FC<CopyToClipboardProps> = ({
   )
 }
 
-export const CopyToClipboardMobile: FC<CopyToClipboardProps> = ({
+export const CopyToClipboardMobile = ({
   value,
   success = 'Copied to clipboard',
   takeN = 7,
-}) => {
+}: CopyToClipboardProps) => {
   const { t } = useTranslation()
   const [copied, setCopied] = useState(false)
 

--- a/packages/ui/components/CosmosMessageDisplay.tsx
+++ b/packages/ui/components/CosmosMessageDisplay.tsx
@@ -2,7 +2,6 @@ import 'codemirror/lib/codemirror.css'
 import 'codemirror/theme/material-ocean.css'
 import 'codemirror/theme/material.css'
 
-import { FC } from 'react'
 import { UnControlled as CodeMirror } from 'react-codemirror2'
 
 import { useThemeContext } from '../theme'
@@ -16,9 +15,7 @@ export interface CosmosMessageDisplayProps {
   value: string
 }
 
-export const CosmosMessageDisplay: FC<CosmosMessageDisplayProps> = ({
-  value,
-}) => {
+export const CosmosMessageDisplay = ({ value }: CosmosMessageDisplayProps) => {
   const themeCtx = useThemeContext()
   const editorTheme = themeCtx.theme !== 'dark' ? 'default' : 'material-ocean'
   return (

--- a/packages/ui/components/FormCard.tsx
+++ b/packages/ui/components/FormCard.tsx
@@ -1,9 +1,9 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 export interface FormCardProps {
   children: ReactNode
 }
 
-export const FormCard: FC<FormCardProps> = ({ children }) => (
+export const FormCard = ({ children }: FormCardProps) => (
   <div className="py-4 px-6 my-2 bg-disabled rounded-lg">{children}</div>
 )

--- a/packages/ui/components/LinkText.tsx
+++ b/packages/ui/components/LinkText.tsx
@@ -1,11 +1,11 @@
 import Link, { LinkProps } from 'next/link'
-import { ComponentProps, FC } from 'react'
+import { ComponentProps } from 'react'
 
 export interface LinkTextProps extends LinkProps {
   aProps: ComponentProps<'a'>
 }
 
-export const LinkText: FC<LinkTextProps> = ({ children, aProps, ...props }) => (
+export const LinkText = ({ children, aProps, ...props }: LinkTextProps) => (
   <Link {...props}>
     <a {...aProps}>{children}</a>
   </Link>

--- a/packages/ui/components/LinkText.tsx
+++ b/packages/ui/components/LinkText.tsx
@@ -1,7 +1,8 @@
 import Link, { LinkProps } from 'next/link'
-import { ComponentProps } from 'react'
+import { ComponentProps, ReactNode } from 'react'
 
 export interface LinkTextProps extends LinkProps {
+  children: ReactNode | ReactNode[]
   aProps: ComponentProps<'a'>
 }
 

--- a/packages/ui/components/MarkdownPreview.tsx
+++ b/packages/ui/components/MarkdownPreview.tsx
@@ -1,7 +1,7 @@
 import { CheckCircleIcon } from '@heroicons/react/outline'
 import { LinkIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
-import { FC, createElement, useEffect, useState } from 'react'
+import { createElement, useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { HeadingComponent } from 'react-markdown/lib/ast-to-react'
 
@@ -10,10 +10,10 @@ export interface MarkdownPreviewProps {
   className?: string
 }
 
-export const MarkdownPreview: FC<MarkdownPreviewProps> = ({
+export const MarkdownPreview = ({
   markdown,
   className,
-}) => (
+}: MarkdownPreviewProps) => (
   <ReactMarkdown
     className={clsx('break-words prose prose-sm dark:prose-invert', className)}
     components={{

--- a/packages/ui/components/MobileWalletConnect.tsx
+++ b/packages/ui/components/MobileWalletConnect.tsx
@@ -4,26 +4,28 @@ import {
   XIcon,
 } from '@heroicons/react/outline'
 import clsx from 'clsx'
-import { FC, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Wallet } from '@dao-dao/icons'
 import { Modal, WalletConnectProps } from '@dao-dao/ui'
 import { CHAIN_NAME } from '@dao-dao/utils'
 
-export const MobileWalletConnect: FC<WalletConnectProps> = ({
+export const MobileWalletConnect = ({
   connected,
   walletName,
   onConnect,
   onDisconnect,
   className,
+
   // Need to take but ignore these fields so that they don't get passed
   // along to the button and make React mad.
   walletAddress: _a,
+
   walletBalance: _b,
   walletBalanceDenom: _d,
   ...buttonProps
-}) => {
+}: WalletConnectProps) => {
   const { t } = useTranslation()
 
   return connected ? (
@@ -60,7 +62,7 @@ export const MobileWalletConnect: FC<WalletConnectProps> = ({
   )
 }
 
-export const NoMobileWallet: FC = () => {
+export const NoMobileWallet = () => {
   const { t } = useTranslation()
   const [showInfo, setShowInfo] = useState(false)
 

--- a/packages/ui/components/Modal.tsx
+++ b/packages/ui/components/Modal.tsx
@@ -1,6 +1,6 @@
 import { XIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
-import { FC, ReactNode, useCallback, useEffect } from 'react'
+import { ReactNode, useCallback, useEffect } from 'react'
 
 export interface ModalProps {
   children: ReactNode
@@ -10,13 +10,13 @@ export interface ModalProps {
   hideCloseButton?: boolean
 }
 
-export const Modal: FC<ModalProps> = ({
+export const Modal = ({
   children,
   onClose,
   backdropClassName,
   containerClassName,
   hideCloseButton,
-}) => {
+}: ModalProps) => {
   const handleKeyPress = useCallback(
     (event) => {
       if (event.key === 'Escape') {

--- a/packages/ui/components/RotatableLogo.tsx
+++ b/packages/ui/components/RotatableLogo.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, FC, useState } from 'react'
+import { ComponentType, useState } from 'react'
 
 import { Logo as DefaultLogo, LogoProps } from '@dao-dao/ui'
 
@@ -7,11 +7,11 @@ export interface RotatableLogoProps extends LogoProps {
   initialRotation: number
 }
 
-export const RotatableLogo: FC<RotatableLogoProps> = ({
+export const RotatableLogo = ({
   Logo = DefaultLogo,
   initialRotation,
   ...props
-}) => {
+}: RotatableLogoProps) => {
   const [rotation, setRotation] = useState(initialRotation)
 
   return (

--- a/packages/ui/components/SearchBar.tsx
+++ b/packages/ui/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { SearchIcon } from '@heroicons/react/solid'
 import clsx from 'clsx'
-import { ComponentProps, FC } from 'react'
+import { ComponentProps } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export interface SearchBarProps extends Omit<ComponentProps<'input'>, 'type'> {
@@ -8,12 +8,12 @@ export interface SearchBarProps extends Omit<ComponentProps<'input'>, 'type'> {
   hideIcon?: boolean
 }
 
-export const SearchBar: FC<SearchBarProps> = ({
+export const SearchBar = ({
   containerClassName,
   className,
   hideIcon,
   ...props
-}) => {
+}: SearchBarProps) => {
   const { t } = useTranslation()
 
   return (

--- a/packages/ui/components/StakingModal/ActionButton.tsx
+++ b/packages/ui/components/StakingModal/ActionButton.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '../Button'
@@ -12,12 +12,12 @@ export interface ActionButtonProps {
   onClick: () => void
 }
 
-export const ActionButton: FC<ActionButtonProps> = ({
+export const ActionButton = ({
   error,
   mode,
   loading,
   onClick,
-}) => {
+}: ActionButtonProps) => {
   const stakingModeButtonLabel = useStakingModeButtonLabel()
   return (
     <Tooltip label={error}>

--- a/packages/ui/components/StakingModal/AmountSelector.tsx
+++ b/packages/ui/components/StakingModal/AmountSelector.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/outline'
-import { ChangeEvent, FC } from 'react'
+import { ChangeEvent } from 'react'
 
 export interface AmountSelectorProps {
   setAmount: (newValue: number) => void
@@ -7,11 +7,11 @@ export interface AmountSelectorProps {
   max: number
 }
 
-export const AmountSelector: FC<AmountSelectorProps> = ({
+export const AmountSelector = ({
   setAmount,
   amount,
   max,
-}) => (
+}: AmountSelectorProps) => (
   <div className="relative">
     <button
       className={`absolute top-0 left-0 flex h-[56px] w-[51px] items-center justify-center rounded-l bg-primary ${

--- a/packages/ui/components/StakingModal/ModeButton.tsx
+++ b/packages/ui/components/StakingModal/ModeButton.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 export interface ModeButtonProps {
   onClick: () => void
@@ -6,11 +6,7 @@ export interface ModeButtonProps {
   children: ReactNode
 }
 
-export const ModeButton: FC<ModeButtonProps> = ({
-  onClick,
-  active,
-  children,
-}) => (
+export const ModeButton = ({ onClick, active, children }: ModeButtonProps) => (
   <button
     className={`rounded py-2 px-4  transition ${
       active

--- a/packages/ui/components/StakingModal/PercentSelector.tsx
+++ b/packages/ui/components/StakingModal/PercentSelector.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import { FC } from 'react'
 
 import { Button } from '../Button'
 
@@ -10,7 +9,7 @@ export interface PercentSelectorProps {
   setAmount: (newAmount: number) => void
 }
 
-export const PercentSelector: FC<PercentSelectorProps> = (props) => (
+export const PercentSelector = (props: PercentSelectorProps) => (
   <div className="grid grid-cols-5 gap-1">
     <PercentButton label="10%" percent={0.1} {...props} />
     <PercentButton label="25%" percent={0.25} {...props} />
@@ -31,7 +30,7 @@ export interface PercentButtonProps {
   absoluteOffset?: number
 }
 
-export const PercentButton: FC<PercentButtonProps> = ({
+export const PercentButton = ({
   label,
   max,
   percent,
@@ -40,7 +39,7 @@ export const PercentButton: FC<PercentButtonProps> = ({
   tokenDecimals,
   className,
   absoluteOffset,
-}) => (
+}: PercentButtonProps) => (
   <Button
     active={
       (max * percent + (absoluteOffset ?? 0)).toFixed(tokenDecimals) ===

--- a/packages/ui/components/StakingModal/StakingModal.tsx
+++ b/packages/ui/components/StakingModal/StakingModal.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Duration } from '@dao-dao/types/contracts/cw3-dao'
@@ -170,7 +170,7 @@ interface StakeUnstakeModesBodyProps {
   proposalDeposit?: number
 }
 
-const StakeUnstakeModesBody: FC<StakeUnstakeModesBodyProps> = ({
+const StakeUnstakeModesBody = ({
   amount,
   setAmount,
   mode,
@@ -179,7 +179,7 @@ const StakeUnstakeModesBody: FC<StakeUnstakeModesBodyProps> = ({
   tokenDecimals,
   unstakingDuration,
   proposalDeposit,
-}) => {
+}: StakeUnstakeModesBodyProps) => {
   const { t } = useTranslation()
 
   return (
@@ -248,11 +248,11 @@ interface ClaimModeBodyProps {
   tokenSymbol: string
 }
 
-const ClaimModeBody: FC<ClaimModeBodyProps> = ({
+const ClaimModeBody = ({
   amount,
   tokenSymbol,
   tokenDecimals,
-}) => {
+}: ClaimModeBodyProps) => {
   const { t } = useTranslation()
 
   return (
@@ -276,10 +276,10 @@ interface UnstakingDurationDisplayProps {
   mode: StakingMode
 }
 
-const UnstakingDurationDisplay: FC<UnstakingDurationDisplayProps> = ({
+const UnstakingDurationDisplay = ({
   unstakingDuration,
   mode,
-}) => {
+}: UnstakingDurationDisplayProps) => {
   const { t } = useTranslation()
 
   return (

--- a/packages/ui/components/SuspenseLoader.tsx
+++ b/packages/ui/components/SuspenseLoader.tsx
@@ -1,10 +1,5 @@
 import { useRouter } from 'next/router'
-import {
-  ComponentType,
-  FunctionComponent,
-  Suspense,
-  SuspenseProps,
-} from 'react'
+import { ComponentType, Suspense, SuspenseProps } from 'react'
 import { useRecoilValue } from 'recoil'
 
 import { mountedInBrowserAtom } from '@dao-dao/state'
@@ -15,13 +10,13 @@ export interface SuspenseLoaderProps extends SuspenseProps {
   forceFallback?: boolean
 }
 
-export const SuspenseLoader: FunctionComponent<SuspenseLoaderProps> = ({
+export const SuspenseLoader = ({
   ErrorBoundaryComponent = ErrorBoundary,
   forceFallback,
   fallback,
   children,
   ...props
-}) => {
+}: SuspenseLoaderProps) => {
   const { isFallback, isReady } = useRouter()
 
   // Prevent loading on the server since Next.js cannot intuitively

--- a/packages/ui/components/Tooltip.tsx
+++ b/packages/ui/components/Tooltip.tsx
@@ -1,12 +1,12 @@
 import ReachTooltip from '@reach/tooltip'
-import { FC, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 export interface TooltipProps {
   label: ReactNode | undefined
   children: ReactNode
 }
 
-export const Tooltip: FC<TooltipProps> = ({ label, children }) =>
+export const Tooltip = ({ label, children }: TooltipProps) =>
   !!label ? (
     <ReachTooltip label={label}>{children}</ReachTooltip>
   ) : (

--- a/packages/ui/components/VoteBalanceCard.tsx
+++ b/packages/ui/components/VoteBalanceCard.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import { BalanceIcon, CopyToClipboard } from '@dao-dao/ui'
 import { formatPercentOf100 } from '@dao-dao/utils'
 
@@ -10,12 +8,12 @@ interface VoteBalanceCardProps {
   addrTitle?: boolean
 }
 
-export const VoteBalanceCard: FC<VoteBalanceCardProps> = ({
+export const VoteBalanceCard = ({
   weight,
   title,
   weightTotal,
   addrTitle,
-}) => (
+}: VoteBalanceCardProps) => (
   <div className="py-4 px-6 w-full rounded-lg border border-default">
     {addrTitle ? (
       <CopyToClipboard value={title} />

--- a/packages/ui/components/WalletConnect.tsx
+++ b/packages/ui/components/WalletConnect.tsx
@@ -1,6 +1,6 @@
 import { CheckCircleIcon, LogoutIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
-import { FC, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Copy, Wallet } from '@dao-dao/icons'
@@ -20,7 +20,7 @@ export interface WalletConnectProps extends Partial<ButtonProps> {
   className?: string
 }
 
-export const WalletConnect: FC<WalletConnectProps> = ({
+export const WalletConnect = ({
   connected,
   walletAddress,
   walletName,
@@ -30,7 +30,7 @@ export const WalletConnect: FC<WalletConnectProps> = ({
   onDisconnect,
   className,
   ...buttonProps
-}) => {
+}: WalletConnectProps) => {
   const { t } = useTranslation()
 
   return connected ? (
@@ -72,7 +72,7 @@ interface CopyButtonProps {
   text: string
 }
 
-const CopyButton: FC<CopyButtonProps> = ({ text }) => {
+const CopyButton = ({ text }: CopyButtonProps) => {
   const { t } = useTranslation()
   const [copied, setCopied] = useState(false)
 
@@ -100,7 +100,7 @@ interface DisconnectButtonProps {
   onClick: () => void
 }
 
-const DisconnectButton: FC<DisconnectButtonProps> = ({ onClick }) => {
+const DisconnectButton = ({ onClick }: DisconnectButtonProps) => {
   const { t } = useTranslation()
 
   return (

--- a/packages/ui/components/input/InputErrorMessage.tsx
+++ b/packages/ui/components/input/InputErrorMessage.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import { FC } from 'react'
 import { FieldError } from 'react-hook-form'
 
 interface InputErrorMessageProps {
@@ -7,10 +6,10 @@ interface InputErrorMessageProps {
   className?: string
 }
 
-export const InputErrorMessage: FC<InputErrorMessageProps> = ({
+export const InputErrorMessage = ({
   error,
   className,
-}) =>
+}: InputErrorMessageProps) =>
   error?.message ? (
     <span
       className={clsx(

--- a/packages/ui/components/input/InputLabel.tsx
+++ b/packages/ui/components/input/InputLabel.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { ComponentProps, FC, ReactNode } from 'react'
+import { ComponentProps, ReactNode } from 'react'
 
 import { TooltipIcon } from '../TooltipIcon'
 
@@ -11,14 +11,14 @@ export interface InputLabelProps
   containerProps?: Omit<ComponentProps<'label'>, 'children'>
 }
 
-export const InputLabel: FC<InputLabelProps> = ({
+export const InputLabel = ({
   className,
   mono,
   name,
   tooltip,
   containerProps: { className: labelClassName, ...containerProps } = {},
   ...rest
-}) => (
+}: InputLabelProps) => (
   <label
     className={clsx('flex items-center space-x-1', labelClassName)}
     {...containerProps}

--- a/packages/ui/components/input/InputThemedText.tsx
+++ b/packages/ui/components/input/InputThemedText.tsx
@@ -1,13 +1,13 @@
 import clsx from 'clsx'
-import { ComponentProps, FC } from 'react'
+import { ComponentProps } from 'react'
 
 export type InputThemedTextProps = ComponentProps<'p'>
 
-export const InputThemedText: FC<InputThemedTextProps> = ({
+export const InputThemedText = ({
   className,
   children,
   ...props
-}) => (
+}: InputThemedTextProps) => (
   <p
     className={clsx('py-2 px-3 rounded-lg border border-default', className)}
     {...props}

--- a/packages/ui/components/input/RadioInput.tsx
+++ b/packages/ui/components/input/RadioInput.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import { FC } from 'react'
 import {
   Path,
   PathValue,
@@ -54,13 +53,13 @@ export interface RadioButtonProps {
   className?: string
 }
 
-export const RadioButton: FC<RadioButtonProps> = ({
+export const RadioButton = ({
   selected,
   onClick,
   label,
   background,
   className,
-}) => (
+}: RadioButtonProps) => (
   <div
     className={clsx(
       'flex flex-row gap-3 items-center transition',

--- a/packages/ui/components/input/Switch.tsx
+++ b/packages/ui/components/input/Switch.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx'
-import { FC } from 'react'
 import { Path, PathValue, UseFormSetValue, UseFormWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -11,13 +10,13 @@ interface SwitchProps {
   readOnly?: boolean
 }
 
-export const Switch: FC<SwitchProps> = ({
+export const Switch = ({
   enabled,
   onClick,
   className,
   sizing = 'lg',
   readOnly,
-}) => (
+}: SwitchProps) => (
   <div
     className={clsx(
       'flex relative flex-none items-center rounded-full',
@@ -58,12 +57,12 @@ export interface SwitchCardProps extends SwitchProps {
   offLabel?: string
 }
 
-export const SwitchCard: FC<SwitchCardProps> = ({
+export const SwitchCard = ({
   containerClassName,
   onLabel: _onLabel,
   offLabel: _offLabel,
   ...props
-}) => {
+}: SwitchCardProps) => {
   const { t } = useTranslation()
 
   const onLabel = _onLabel ?? t('info.enabled')

--- a/packages/ui/components/toasts/ErrorToast.tsx
+++ b/packages/ui/components/toasts/ErrorToast.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { Toast } from 'react-hot-toast'
 
 import { ToastCard } from './ToastCard'
@@ -7,6 +6,6 @@ export interface ErrorToastProps {
   toast: Toast
 }
 
-export const ErrorToast: FC<ErrorToastProps> = (props) => (
+export const ErrorToast = (props: ErrorToastProps) => (
   <ToastCard containerClassName="text-[#ffffff] bg-error" {...props} />
 )

--- a/packages/ui/components/toasts/LoadingToast.tsx
+++ b/packages/ui/components/toasts/LoadingToast.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { Toast } from 'react-hot-toast'
 
 import { Loader } from '../Loader'
@@ -9,7 +8,7 @@ export interface LoadingToastProps {
   toast: Toast
 }
 
-export const LoadingToast: FC<LoadingToastProps> = (props) => (
+export const LoadingToast = (props: LoadingToastProps) => (
   <ToastCard
     containerClassName="text-light text-sm bg-dark"
     preMessage={

--- a/packages/ui/components/toasts/SuccessToast.tsx
+++ b/packages/ui/components/toasts/SuccessToast.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { Toast } from 'react-hot-toast'
 
 import { ToastCard } from './ToastCard'
@@ -7,6 +6,6 @@ export interface SuccessToastProps {
   toast: Toast
 }
 
-export const SuccessToast: FC<SuccessToastProps> = (props) => (
+export const SuccessToast = (props: SuccessToastProps) => (
   <ToastCard containerClassName="text-light bg-dark" {...props} />
 )

--- a/packages/ui/components/toasts/ToastCard.tsx
+++ b/packages/ui/components/toasts/ToastCard.tsx
@@ -1,6 +1,6 @@
 import { XIcon } from '@heroicons/react/outline'
 import clsx from 'clsx'
-import { FC, ReactNode, cloneElement } from 'react'
+import { ReactNode, cloneElement } from 'react'
 import { Toast, ToastBar, toast as hotToast } from 'react-hot-toast'
 
 export interface ToastCardProps {
@@ -9,11 +9,11 @@ export interface ToastCardProps {
   preMessage?: ReactNode
 }
 
-export const ToastCard: FC<ToastCardProps> = ({
+export const ToastCard = ({
   toast,
   containerClassName,
   preMessage,
-}) => (
+}: ToastCardProps) => (
   <ToastBar toast={toast}>
     {({ message }) => (
       <div

--- a/packages/ui/theme/index.tsx
+++ b/packages/ui/theme/index.tsx
@@ -1,4 +1,4 @@
-import { FC, createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
 
 export type UpdateThemeFn = (themeName: Theme) => void
 export type SetAccentColorFn = (accentColor: string | undefined) => void
@@ -31,14 +31,14 @@ export const DEFAULT_THEME: IThemeContext = {
 
 export const ThemeContext = createContext<IThemeContext>(DEFAULT_THEME)
 
-export const ThemeProvider: FC<IThemeContext> = ({
+export const ThemeProvider = ({
   children,
   theme,
   themeChangeCount,
   updateTheme,
   accentColor,
   setAccentColor,
-}) => (
+}: IThemeContext) => (
   <ThemeContext.Provider
     value={{
       ...DEFAULT_THEME,

--- a/packages/ui/theme/index.tsx
+++ b/packages/ui/theme/index.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
 
 export type UpdateThemeFn = (themeName: Theme) => void
 export type SetAccentColorFn = (accentColor: string | undefined) => void
@@ -38,7 +44,7 @@ export const ThemeProvider = ({
   updateTheme,
   accentColor,
   setAccentColor,
-}: IThemeContext) => (
+}: PropsWithChildren<IThemeContext>) => (
   <ThemeContext.Provider
     value={{
       ...DEFAULT_THEME,

--- a/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/Membership/index.tsx
+++ b/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/components/Membership/index.tsx
@@ -1,7 +1,7 @@
 import { HandIcon, MinusSmIcon, PlusSmIcon } from '@heroicons/react/outline'
 import { useWalletManager } from '@noahsaso/cosmodal'
 import clsx from 'clsx'
-import { ComponentType, FC, useMemo, useState } from 'react'
+import { ComponentType, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -57,11 +57,11 @@ export const Membership = ({ primaryText, ...props }: MembershipProps) => {
   )
 }
 
-const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
+const InnerMembership = ({
   sdaMode,
   ClaimsPendingList = DefaultClaimsPendingList,
   proposalModuleDepositInfos,
-}) => {
+}: Omit<MembershipProps, 'primaryText'>) => {
   const { t } = useTranslation()
   const {
     governanceTokenAddress,

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/Membership/index.tsx
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/components/Membership/index.tsx
@@ -1,7 +1,7 @@
 import { HandIcon, MinusSmIcon, PlusSmIcon } from '@heroicons/react/outline'
 import { useWalletManager } from '@noahsaso/cosmodal'
 import clsx from 'clsx'
-import { ComponentType, FC, useMemo, useState } from 'react'
+import { ComponentType, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
@@ -57,11 +57,11 @@ export const Membership = ({ primaryText, ...props }: MembershipProps) => {
   )
 }
 
-const InnerMembership: FC<Omit<MembershipProps, 'primaryText'>> = ({
+const InnerMembership = ({
   sdaMode,
   ClaimsPendingList = DefaultClaimsPendingList,
   proposalModuleDepositInfos,
-}) => {
+}: Omit<MembershipProps, 'primaryText'>) => {
   const { t } = useTranslation()
   const {
     governanceTokenAddress,


### PR DESCRIPTION
React 18 removes implicit `children` from the `FunctionComponent` (and `FC`) type, which will cause issues when upgrading React if we use this type as it's been used for all of time. `FunctionComponent` is also notoriously impossible to make generic, which makes it difficult to use generic props interfaces, but a function can easily be made generic by prefixing its definition with `< ... >`. See the example below:

```tsx
const Component = <T>({ genericProp }: ComponentProps<T>) => { ... }`
```

Here is an article about why this happened: https://solverfox.dev/writing/no-implicit-children/

This PR removes all FunctionComponent usage and adds a linter rule that prevents it.

Used https://github.com/gndelia/codemod-replace-react-fc-typescript to do transformation.