### PR TITLE
Minor number display tweaks

### DIFF
--- a/apps/dapp/components/FeaturedCard.tsx
+++ b/apps/dapp/components/FeaturedCard.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx'
 import { useEffect, useState } from 'react'
 
 import { Dao } from '@dao-dao/icons'
+import { Tooltip } from '@dao-dao/ui'
 
 import { getCardFallbackImage } from '@/util'
 
@@ -65,8 +66,27 @@ export const FeaturedCard = ({
       <div className="flex flex-col gap-1 mt-5 items-left">
         <p className="text-sm">
           <Dao className="inline mr-2 mb-1 w-4" fill="currentColor" />
-          {/* eslint-disable-next-line i18next/no-literal-string */}
-          {Number(TVL).toLocaleString()} $USDC TVL
+          <Tooltip
+            label={
+              Number(TVL).toLocaleString(undefined, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+                // eslint-disable-next-line i18next/no-literal-string
+              }) + ' $USDC'
+            }
+          >
+            <span>
+              {Number(TVL).toLocaleString(undefined, {
+                // eslint-disable-next-line i18next/no-literal-string
+                notation: 'compact',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+                // eslint-disable-next-line i18next/no-literal-string
+              })}{' '}
+              $USDC
+            </span>
+          </Tooltip>{' '}
+          <span className="caption-text">TVL</span>
         </p>
       </div>
     </a>

--- a/packages/ui/components/ContractView/TreasuryBalances.tsx
+++ b/packages/ui/components/ContractView/TreasuryBalances.tsx
@@ -44,7 +44,7 @@ export const TreasuryBalances = ({
       {nativeTokens.map(({ denom, amount, decimals }) => {
         const symbol = nativeTokenLabel(denom)
         const icon = nativeTokenLogoURI(denom)
-        if (symbol.startsWith('IBC')) {
+        if (symbol.toLowerCase().startsWith('ibc')) {
           // We're dealing with an IBC token we don't know about. Instead
           // of showing a long hash, allow the user to copy it.
           return (

--- a/packages/utils/ibc.ts
+++ b/packages/utils/ibc.ts
@@ -10,9 +10,7 @@ export function nativeTokenLabel(denom: string): string {
 
   return (
     asset?.symbol ||
-    (denom.startsWith('u')
-      ? denom.substring(1).toUpperCase()
-      : denom.toLowerCase())
+    (denom.startsWith('u') ? denom.substring(1) : denom).toUpperCase()
   )
 }
 


### PR DESCRIPTION
Made featured DAO card TVL's display as compact numbers. Displays a tooltip with the full number on hover.

![Screen Shot 2022-08-17 at 2 21 32 PM](https://user-images.githubusercontent.com/6721426/185245524-5f4ef197-3485-492b-8c08-25f08feb7259.png)

Also fixed IBC denom formatting.