### PR TITLE
Improve segmented control component

### DIFF
--- a/packages/ui/components/SegmentedControls.tsx
+++ b/packages/ui/components/SegmentedControls.tsx
@@ -1,10 +1,12 @@
 import clsx from 'clsx'
+import { useState } from 'react'
 
 import { Button } from './Button'
 
 export interface SegmentedControlsTab {
   name: string
   selected?: boolean
+  loading?: boolean
   onClick: () => void
 }
 
@@ -12,25 +14,57 @@ export interface SegmentedControlsProps {
   tabs: SegmentedControlsTab[]
 }
 
-export const SegmentedControls = ({ tabs }: SegmentedControlsProps) => (
-  <div className="grid grid-flow-col auto-cols-fr bg-background-tertiary">
-    {tabs.map(({ name, onClick, selected }, index) => (
-      <div key={name} className="flex flex-row items-center">
-        {index !== 0 && !tabs[index - 1].selected && !selected && (
-          <div className="w-[1px] h-4 bg-border-primary"></div>
-        )}
+export const SegmentedControls = ({ tabs }: SegmentedControlsProps) => {
+  const [hovering, setHovering] = useState<number>()
 
-        <Button
-          className={clsx(
-            'flex justify-center items-center w-full',
-            selected && 'bg-background-primary body-text'
-          )}
-          onClick={onClick}
-          variant="ghost"
-        >
-          {name}
-        </Button>
-      </div>
-    ))}
-  </div>
-)
+  return (
+    <div
+      className="group grid grid-flow-col auto-cols-fr bg-background-tertiary"
+      onMouseLeave={() => setHovering(undefined)}
+    >
+      {tabs.map(({ name, onClick, selected, loading }, index) => (
+        <div key={name} className="flex flex-row items-center">
+          <div
+            className={clsx(
+              'w-[1px] h-4 bg-border-primary opacity-100 transition-opacity',
+              {
+                // Do not show left border if...
+                '!opacity-0':
+                  // first element.
+                  index === 0 ||
+                  // left tab selected.
+                  tabs[index - 1].selected ||
+                  // current tab selected.
+                  selected ||
+                  // left tab hovering.
+                  hovering === index - 1 ||
+                  // current tab hovering.
+                  hovering === index,
+              }
+            )}
+          ></div>
+
+          <Button
+            className={clsx(
+              'flex justify-center items-center w-full',
+              selected || hovering === index
+                ? // Brighten text when selected or hovering over this tab.
+                  'body-text'
+                : // Dim text when not selected and not hovering over this tab.
+                  'text-text-secondary',
+              // Highlight background when selected and not hovering over any
+              // tab. Button contains its own hover background class.
+              selected && hovering === undefined && 'bg-background-primary'
+            )}
+            loading={loading}
+            onClick={onClick}
+            onMouseOver={() => setHovering(index)}
+            variant="ghost"
+          >
+            {name}
+          </Button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/ui/components/SegmentedControls.tsx
+++ b/packages/ui/components/SegmentedControls.tsx
@@ -23,10 +23,10 @@ export const SegmentedControls = ({ tabs }: SegmentedControlsProps) => {
       onMouseLeave={() => setHovering(undefined)}
     >
       {tabs.map(({ name, onClick, selected, loading }, index) => (
-        <div key={name} className="flex flex-row items-center">
+        <div key={name} className="flex flex-row items-stretch">
           <div
             className={clsx(
-              'w-[1px] h-4 bg-border-primary opacity-100 transition-opacity',
+              'self-center w-[1px] h-4 bg-border-primary opacity-100 transition-opacity',
               {
                 // Do not show left border if...
                 '!opacity-0':
@@ -52,9 +52,9 @@ export const SegmentedControls = ({ tabs }: SegmentedControlsProps) => {
                   'body-text'
                 : // Dim text when not selected and not hovering over this tab.
                   'text-text-secondary',
-              // Highlight background when selected and not hovering over any
-              // tab. Button contains its own hover background class.
-              selected && hovering === undefined && 'bg-background-primary'
+              // Highlight background when selected. Button contains its own
+              // hover background class.
+              selected && 'bg-background-primary'
             )}
             loading={loading}
             onClick={onClick}

--- a/packages/ui/components/SegmentedControls.tsx
+++ b/packages/ui/components/SegmentedControls.tsx
@@ -19,7 +19,7 @@ export const SegmentedControls = ({ tabs }: SegmentedControlsProps) => {
 
   return (
     <div
-      className="group grid grid-flow-col auto-cols-fr bg-background-tertiary"
+      className="group grid grid-flow-col auto-cols-fr bg-background-tertiary rounded-md"
       onMouseLeave={() => setHovering(undefined)}
     >
       {tabs.map(({ name, onClick, selected, loading }, index) => (


### PR DESCRIPTION
[comment]: <> (don't forget to run `yarn format` from the root :D)

## Fixed stretching responsiveness and rounding when wrapping

Before:
<img width="614" alt="Screen Shot 2022-08-24 at 1 35 14 AM" src="https://user-images.githubusercontent.com/6721426/186371101-1707540b-3a7b-4a3c-b1c2-2cf8c67736f8.png">

After:
<img width="615" alt="Screen Shot 2022-08-24 at 1 37 00 AM" src="https://user-images.githubusercontent.com/6721426/186371521-42285325-05d9-4b92-ab9a-fe8f6d130162.png">

## Hides spacers on both sides when hovering to prevent the buttons from appearing like they're touching

Before:
<img width="603" alt="Screen Shot 2022-08-24 at 1 34 55 AM" src="https://user-images.githubusercontent.com/6721426/186371042-7127e0e1-d1de-4158-9df8-6976f6125801.png">

After:
<img width="614" alt="Screen Shot 2022-08-24 at 1 37 34 AM" src="https://user-images.githubusercontent.com/6721426/186371649-b76ae63e-4d19-4510-a6b4-2ef2e232dc94.png">
<img width="613" alt="Screen Shot 2022-08-24 at 1 33 09 AM" src="https://user-images.githubusercontent.com/6721426/186370683-9d8c8b27-68e2-4574-9d2a-c3077f08df7e.png">

## Added loader capability to tabs
<img width="609" alt="Screen Shot 2022-08-24 at 1 34 28 AM" src="https://user-images.githubusercontent.com/6721426/186370955-88aaeede-f6cd-49e3-bab3-61665125fa1e.png">
