### PR TITLE
Include cw-core address and version in Sentry report during static props getter

### DIFF
--- a/packages/common/server/makeGetDaoStaticProps.ts
+++ b/packages/common/server/makeGetDaoStaticProps.ts
@@ -251,7 +251,7 @@ export const makeGetDaoStaticProps: GetDaoStaticPropsMaker =
           error: processError(error, {
             forceCapture: true,
             tags: { coreAddress, coreVersion: coreVersion ?? '<undefined>' },
-            extra: { context }
+            extra: { context },
           }),
         },
         // Regenerate the page at most once per second. Serves cached copy and

--- a/packages/common/server/makeGetDaoStaticProps.ts
+++ b/packages/common/server/makeGetDaoStaticProps.ts
@@ -17,6 +17,7 @@ import { Loader, Logo } from '@dao-dao/ui'
 import {
   CHAIN_RPC_ENDPOINT,
   CI,
+  CwCoreVersion,
   DAO_STATIC_PROPS_CACHE_SECONDS,
   LEGACY_URL_PREFIX,
   MAX_META_CHARS_PROPOSAL_DESCRIPTION,
@@ -26,7 +27,6 @@ import {
   parseCoreVersion,
   processError,
   validateContractAddress,
-  CwCoreVersion,
 } from '@dao-dao/utils'
 
 import { DaoPageWrapperProps } from '../components'
@@ -251,6 +251,7 @@ export const makeGetDaoStaticProps: GetDaoStaticPropsMaker =
           error: processError(error, {
             forceCapture: true,
             tags: { coreAddress, coreVersion: coreVersion ?? '<undefined>' },
+            extra: { context }
           }),
         },
         // Regenerate the page at most once per second. Serves cached copy and

--- a/packages/utils/error.ts
+++ b/packages/utils/error.ts
@@ -11,8 +11,8 @@ export const processError = (
     overrideCapture,
     forceCapture,
   }: {
-    tags?: Record<string, string | number>
-    extra?: Record<string, string | number>
+    tags?: Record<string, string | number | boolean | null | undefined>
+    extra?: Record<string, unknown>
     transform?: Partial<Record<CommonError, string>>
     overrideCapture?: Partial<Record<CommonError, boolean>>
     // If set to true, will capture error. If set to false, will not capture


### PR DESCRIPTION
Whenever errors are logged inside Next.js's `getStaticProps`, our current Sentry error reporting includes almost no information. This PR adds more context so that we can assess the problem better.