### PR TITLE
Fix spend action formatting issue caused by IBC assets

### DIFF
--- a/packages/actions/components/Spend.tsx
+++ b/packages/actions/components/Spend.tsx
@@ -173,6 +173,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
             error={errors?.denom}
             fieldName={fieldNamePrefix + 'denom'}
             register={register}
+            style={{ maxWidth: '8.2rem' }}
           >
             {nativeBalances.map(({ denom }) => (
               <option key={denom} value={denom}>


### PR DESCRIPTION
Long IBC assets in SubDAOs cause formatting issues.

You can see this in the most recent C-Root proposal: http://daodao.zone/dao/juno1gpwekludv6vu8pkpnp2hwwf7f84a7mcvgm9t2cvp92hvpxk07kdq8z4xj2/proposals/A12