### PR TITLE
Fix infinite spinning when waiting for tokens to unstake

### DIFF
--- a/packages/ui/components/Claims/ClaimsListItem.tsx
+++ b/packages/ui/components/Claims/ClaimsListItem.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon } from '@heroicons/react/outline'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Duration } from '@dao-dao/types/contracts/cw3-dao'
@@ -47,8 +47,13 @@ export const ClaimsListItem = ({
   iconURI,
 }: ClaimsListItemProps) => {
   const { t } = useTranslation()
-  const available = claimAvailable(claim, blockHeight)
-  const initialDurationRemaining = claimDurationRemaining(claim, blockHeight)
+  const { available, initialDurationRemaining } = useMemo(
+    () => ({
+      available: claimAvailable(claim, blockHeight),
+      initialDurationRemaining: claimDurationRemaining(claim, blockHeight),
+    }),
+    [blockHeight, claim]
+  )
 
   // Format for humans each second to count down.
   const [durationRemainingForHumans, setDurationRemainingForHumans] = useState(
@@ -65,11 +70,12 @@ export const ClaimsListItem = ({
     const id = setInterval(update, 1000)
 
     return () => clearInterval(id)
-  }, [claim, blockHeight, setDurationRemainingForHumans])
+  }, [blockHeight, claim])
 
   // Notify when the claim expires.
   const initialDurationRemainingTime =
-    'time' in initialDurationRemaining && initialDurationRemaining.time
+    'time' in initialDurationRemaining &&
+    Math.round(initialDurationRemaining.time)
   useEffect(() => {
     if (initialDurationRemainingTime) {
       const id = setTimeout(

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/hooks/useStakingInfo.ts
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/hooks/useStakingInfo.ts
@@ -60,7 +60,10 @@ export const useStakingInfo = ({
   )
 
   const _setClaimsId = useSetRecoilState(refreshClaimsIdAtom(walletAddress))
-  const refreshClaims = () => _setClaimsId((id) => id + 1)
+  const refreshClaims = useCallback(
+    () => _setClaimsId((id) => id + 1),
+    [_setClaimsId]
+  )
 
   const claims = useRecoilValue(
     fetchClaims && walletAddress


### PR DESCRIPTION
Error reported on Discord (https://discord.com/channels/895922260047720449/941044521909780500/1017766801951690833) where the voting power sidebar would infinitely refresh when waiting for tokens to unstake. This was happening on Neta DAO https://daodao.zone/dao/juno1c5v6jkmre5xa9vf9aas6yxewc7aqmjy0rlkkyk4d88pnwuhclyhsrhhns6
