### PR TITLE
Lower PROP_LOAD_LIMIT to prevent out-of-gas with 20+ proposals.

### DIFF
--- a/packages/common/components/ProposalList.tsx
+++ b/packages/common/components/ProposalList.tsx
@@ -23,7 +23,7 @@ import { useDaoInfoContext } from './DaoPageWrapper'
 import { SuspenseLoader } from './SuspenseLoader'
 
 // Max = 30
-const PROP_LOAD_LIMIT = 30
+const PROP_LOAD_LIMIT = 25
 
 export interface ProposalListProps {
   proposalCreateUrl: string

--- a/packages/common/components/ProposalList.tsx
+++ b/packages/common/components/ProposalList.tsx
@@ -22,8 +22,9 @@ import {
 import { useDaoInfoContext } from './DaoPageWrapper'
 import { SuspenseLoader } from './SuspenseLoader'
 
-// Max = 30
-const PROP_LOAD_LIMIT = 25
+// Contracts enforce a max of 30, though this is on the edge for DAOs with
+// proposals that have a large size.
+const PROP_LOAD_LIMIT = 20
 
 export interface ProposalListProps {
   proposalCreateUrl: string


### PR DESCRIPTION
We can not definitively set this so that an out-of-gas error will never occur, but we can lower when we run into things. DAO that was failing: <https://daodao.zone/dao/juno1luw9kspq5dwrqrxgkvfwt443ue99umdaqmm57afg7ms5y0rkz3dsfeudxp>