### PR TITLE
Properly divide out decimals in price selector.

### DIFF
--- a/packages/state/recoil/selectors/price.ts
+++ b/packages/state/recoil/selectors/price.ts
@@ -85,7 +85,7 @@ export const usdcPerMicroTokenSelector = selectorFamily<
         ) / tokenAmount
 
       // (uUSDC / uJUNO) / ( uTOKEN / uJUNO )
-      // price = (uTOKEN / uJUNO) / (uUSDC / uJUNO) = uTOKEN / uUSDC
+      // price = (uUSDC / uJUNO) / (uTOKEN / uJUNO) = uUSDC / uTOKEN
       const price =
         Number(nativeUSDC) /
         Number(tokenPairPrice) /

--- a/packages/state/recoil/selectors/price.ts
+++ b/packages/state/recoil/selectors/price.ts
@@ -46,7 +46,7 @@ export const tokenUSDCPriceSelector = selectorFamily<
 
       // Query for price of 1000000 tokens since decimals are not returned
       // by API. This will give us up to 10^-6 precision for calculations
-      const tokenAmount = 1000000
+      const tokenAmount = Math.pow(10, NATIVE_DECIMALS)
 
       // Query and calculate price for 1 native token
       const nativeUSDC =
@@ -91,7 +91,10 @@ export const tokenUSDCPriceSelector = selectorFamily<
       const price =
         Number(tokenPairPrice) *
         Number(nativeUSDC) *
-        Math.pow(10, -denomDecimals)
+        // Need to divide out token decimals and NATIVE_DECIMALS twice as we
+        // query prices in terms of Math.pow(10, NATIVE_DECIMALS) and if we're
+        // here we've done so twice.
+        Math.pow(10, -(denomDecimals + NATIVE_DECIMALS * 2))
 
       return price
     },

--- a/packages/state/recoil/selectors/price.ts
+++ b/packages/state/recoil/selectors/price.ts
@@ -71,8 +71,8 @@ export const usdcPerMicroTokenSelector = selectorFamily<
         return Number(nativeUSDC) / Math.pow(10, NATIVE_DECIMALS)
       }
 
-      // Get token price in terms of native token
-      // uTOKEN / uJUNO
+      // Get juno price in terms of the native token.
+      // uJUNO / uTOKEN
       const tokenPairPrice =
         Number(
           (
@@ -84,11 +84,9 @@ export const usdcPerMicroTokenSelector = selectorFamily<
           ).token1_amount
         ) / tokenAmount
 
-      // (uUSDC / uJUNO) / ( uTOKEN / uJUNO )
-      // price = (uUSDC / uJUNO) / (uTOKEN / uJUNO) = uUSDC / uTOKEN
+      // price = (uUSDC / uJUNO) * (uJUNO / uTOKEN) = uUSDC / uTOKEN
       const price =
-        Number(nativeUSDC) /
-        Number(tokenPairPrice) /
+        (Number(nativeUSDC) * Number(tokenPairPrice)) /
         // Divide out the number of decimals in USDC.
         Math.pow(10, NATIVE_DECIMALS)
 

--- a/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/hooks/useGovernanceTokenInfo.ts
+++ b/packages/voting-module-adapter/adapters/cw-native-staked-balance-voting/hooks/useGovernanceTokenInfo.ts
@@ -6,7 +6,7 @@ import {
   CwNativeStakedBalanceVotingSelectors,
   nativeDenomBalanceSelector,
   nativeSupplySelector,
-  tokenUSDCPriceSelector,
+  usdcPerMicroTokenSelector,
 } from '@dao-dao/state'
 import {
   MarketingInfoResponse,
@@ -86,9 +86,8 @@ export const useGovernanceTokenInfo = ({
   // Price info
   const price = useRecoilValue(
     fetchUSDCPrice && governanceTokenInfo
-      ? tokenUSDCPriceSelector({
+      ? usdcPerMicroTokenSelector({
           denom,
-          tokenDecimals: governanceTokenInfo.decimals,
         })
       : constSelector(undefined)
   )

--- a/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/hooks/useGovernanceTokenInfo.ts
+++ b/packages/voting-module-adapter/adapters/cw20-staked-balance-voting/hooks/useGovernanceTokenInfo.ts
@@ -4,7 +4,7 @@ import { constSelector, useRecoilValue } from 'recoil'
 import {
   Cw20BaseSelectors,
   Cw20StakedBalanceVotingSelectors,
-  tokenUSDCPriceSelector,
+  usdcPerMicroTokenSelector,
 } from '@dao-dao/state'
 
 import { useVotingModuleAdapterOptions } from '../../../react/context'
@@ -70,9 +70,8 @@ export const useGovernanceTokenInfo = ({
   // Price info
   const price = useRecoilValue(
     fetchUSDCPrice
-      ? tokenUSDCPriceSelector({
+      ? usdcPerMicroTokenSelector({
           denom: governanceTokenAddress,
-          tokenDecimals: governanceTokenInfo.decimals,
         })
       : constSelector(undefined)
   )


### PR DESCRIPTION
Fixes an issue where we were not dividing out decimals for cw20 tokens properly.
