### PR TITLE
Fix members action prefill in members tab.

### DIFF
--- a/apps/dapp/pages/dao/[address]/index.tsx
+++ b/apps/dapp/pages/dao/[address]/index.tsx
@@ -28,7 +28,7 @@ import {
   useVotingModule,
   useWalletProfile,
 } from '@dao-dao/stateful'
-import { useActionForKey } from '@dao-dao/stateful/actions'
+import { useCoreActionForKey } from '@dao-dao/stateful/actions'
 import { matchAndLoadCommon } from '@dao-dao/stateful/proposal-module-adapter'
 import { makeGetDaoStaticProps } from '@dao-dao/stateful/server'
 import { useVotingModuleAdapter } from '@dao-dao/stateful/voting-module-adapter'
@@ -40,7 +40,7 @@ import {
   useAppLayoutContext,
   useDaoInfoContext,
 } from '@dao-dao/stateless'
-import { ActionKey } from '@dao-dao/types'
+import { CoreActionKey } from '@dao-dao/types'
 import { CheckedDepositInfo } from '@dao-dao/types/contracts/common'
 import { SITE_URL } from '@dao-dao/utils'
 
@@ -75,7 +75,7 @@ const InnerDaoHome = () => {
         })
       : constSelector(undefined)
   )
-  const manageSubDaosAction = useActionForKey(ActionKey.ManageSubDaos)
+  const manageSubDaosAction = useCoreActionForKey(CoreActionKey.ManageSubDaos)
   // Prefill URL only valid if action exists.
   const prefillValid = !!manageSubDaosAction
   const encodedAddSubDaoProposalPrefill = useEncodedCwdProposalSinglePrefill(

--- a/apps/dapp/pages/dao/[address]/proposals/[proposalId].tsx
+++ b/apps/dapp/pages/dao/[address]/proposals/[proposalId].tsx
@@ -15,7 +15,7 @@ import {
   Trans,
   useProfile,
 } from '@dao-dao/stateful'
-import { useActions } from '@dao-dao/stateful/actions'
+import { useCoreActions } from '@dao-dao/stateful/actions'
 import {
   ProposalModuleAdapterProvider,
   useProposalModuleAdapterContext,
@@ -28,7 +28,7 @@ import {
   ProposalNotFound,
   useDaoInfoContext,
 } from '@dao-dao/stateless'
-import { ActionKey, CommonProposalInfo } from '@dao-dao/types'
+import { ActionKey, CommonProposalInfo, CoreActionKey } from '@dao-dao/types'
 import { SITE_URL } from '@dao-dao/utils'
 
 interface InnerProposalProps {
@@ -60,7 +60,7 @@ const InnerProposal = ({ proposalInfo }: InnerProposalProps) => {
 
   const votingModuleActions = useVotingModuleActions()
   const proposalModuleActions = useProposalModuleActions()
-  const actions = useActions(
+  const actions = useCoreActions(
     useMemo(
       () => [...votingModuleActions, ...proposalModuleActions],
       [proposalModuleActions, votingModuleActions]
@@ -77,7 +77,7 @@ const InnerProposal = ({ proposalInfo }: InnerProposalProps) => {
   // and sorting the actions in ascending order.
   const orderedActions = useMemo(() => {
     const keyToValue = (key: ActionKey) =>
-      key === ActionKey.Execute ? 1 : key === ActionKey.Custom ? 2 : 0
+      key === CoreActionKey.Execute ? 1 : key === CoreActionKey.Custom ? 2 : 0
 
     return actions.sort((a, b) => {
       const aValue = keyToValue(a.key)

--- a/apps/dapp/pages/wallet.tsx
+++ b/apps/dapp/pages/wallet.tsx
@@ -13,7 +13,7 @@ import { useRecoilState } from 'recoil'
 import { serverSideTranslations } from '@dao-dao/i18n/serverSideTranslations'
 import { walletTransactionAtom } from '@dao-dao/state'
 import { ProfileHomeCard, SuspenseLoader } from '@dao-dao/stateful'
-import { ActionsProvider, useActions } from '@dao-dao/stateful/actions'
+import { ActionsProvider, useCoreActions } from '@dao-dao/stateful/actions'
 import {
   Loader,
   ProfileDisconnectedCard,
@@ -44,7 +44,7 @@ const InnerWallet = () => {
     signingCosmWasmClient,
   } = useWallet()
 
-  const actions = useActions()
+  const actions = useCoreActions()
 
   // Call relevant action hooks in the same order every time.
   const actionsWithData: Partial<

--- a/packages/stateful/actions/README.md
+++ b/packages/stateful/actions/README.md
@@ -42,10 +42,10 @@ Now that the library has been setup, you can use the hook anywhere as a
 descendant of the Provider to access the actions.
 
 ```tsx
-import { useActions } from '@dao-dao/stateful/actions'
+import { useCoreActions } from '@dao-dao/stateful/actions'
 
 const ActionPicker = () => {
-  const actions = useActions()
+  const actions = useCoreActions()
 
   return actions.map((action) => (
     <ActionPickerOption action={action} key={action.key} />

--- a/packages/stateful/actions/actions/AddCw20.tsx
+++ b/packages/stateful/actions/actions/AddCw20.tsx
@@ -7,9 +7,9 @@ import { Cw20BaseSelectors } from '@dao-dao/state'
 import { TokenEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
   ActionOptionsContextType,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -122,7 +122,7 @@ export const makeAddCw20Action: ActionMaker<AddCw20Data> = ({
     )
 
   return {
-    key: ActionKey.AddCw20,
+    key: CoreActionKey.AddCw20,
     Icon: TokenEmoji,
     label: t('title.addCw20ToTreasury'),
     description: t('info.addCw20ToTreasuryActionDescription'),

--- a/packages/stateful/actions/actions/AddCw721.tsx
+++ b/packages/stateful/actions/actions/AddCw721.tsx
@@ -7,9 +7,9 @@ import { Cw721BaseSelectors } from '@dao-dao/state'
 import { ImageEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
   ActionOptionsContextType,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -122,7 +122,7 @@ export const makeAddCw721Action: ActionMaker<AddCw721Data> = ({
     )
 
   return {
-    key: ActionKey.AddCw721,
+    key: CoreActionKey.AddCw721,
     Icon: ImageEmoji,
     label: t('title.addCw721ToTreasury'),
     description: t('info.addCw721ToTreasuryActionDescription'),

--- a/packages/stateful/actions/actions/Custom.tsx
+++ b/packages/stateful/actions/actions/Custom.tsx
@@ -3,8 +3,8 @@ import { useCallback, useMemo } from 'react'
 
 import { RobotEmoji } from '@dao-dao/stateless'
 import {
-  ActionKey,
   ActionMaker,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -52,7 +52,7 @@ const useDecodedCosmosMsg: UseDecodedCosmosMsg<CustomData> = (
   )
 
 export const makeCustomAction: ActionMaker<CustomData> = ({ t, context }) => ({
-  key: ActionKey.Custom,
+  key: CoreActionKey.Custom,
   Icon: RobotEmoji,
   label: t('title.custom'),
   description: t('info.customActionDescription', {

--- a/packages/stateful/actions/actions/Execute.tsx
+++ b/packages/stateful/actions/actions/Execute.tsx
@@ -7,8 +7,8 @@ import { nativeBalancesSelector } from '@dao-dao/state'
 import { SwordsEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -104,7 +104,7 @@ export const makeExecuteAction: ActionMaker<ExecuteData> = ({ t, address }) => {
   }
 
   return {
-    key: ActionKey.Execute,
+    key: CoreActionKey.Execute,
     Icon: SwordsEmoji,
     label: t('title.executeSmartContract'),
     description: t('info.executeSmartContractActionDescription'),

--- a/packages/stateful/actions/actions/Instantiate.tsx
+++ b/packages/stateful/actions/actions/Instantiate.tsx
@@ -11,8 +11,8 @@ import {
 import { BabyEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -143,7 +143,7 @@ export const makeInstantiateAction: ActionMaker<InstantiateData> = ({
       const instantiateActionsData = props.allActionsWithData
         .filter(
           ({ key, data }) =>
-            key === ActionKey.Instantiate &&
+            key === CoreActionKey.Instantiate &&
             'codeId' in data &&
             data.codeId === codeId
         )
@@ -198,7 +198,7 @@ export const makeInstantiateAction: ActionMaker<InstantiateData> = ({
   }
 
   return {
-    key: ActionKey.Instantiate,
+    key: CoreActionKey.Instantiate,
     Icon: BabyEmoji,
     label: t('title.instantiateSmartContract'),
     description: t('info.instantiateSmartContractActionDescription'),

--- a/packages/stateful/actions/actions/ManageSubDaos.tsx
+++ b/packages/stateful/actions/actions/ManageSubDaos.tsx
@@ -5,10 +5,10 @@ import { CwdCoreV2Selectors } from '@dao-dao/state'
 import { FamilyEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
   ActionOptionsContextType,
   ContractVersion,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -112,7 +112,7 @@ export const makeManageSubDaosAction: ActionMaker<ManageSubDaosData> = ({
   }
 
   return {
-    key: ActionKey.ManageSubDaos,
+    key: CoreActionKey.ManageSubDaos,
     Icon: FamilyEmoji,
     label: t('title.manageSubDaos'),
     description: t('info.manageSubDaosActionDescription'),

--- a/packages/stateful/actions/actions/MigrateContract.tsx
+++ b/packages/stateful/actions/actions/MigrateContract.tsx
@@ -5,8 +5,8 @@ import { contractAdminSelector } from '@dao-dao/state'
 import { WhaleEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -79,7 +79,7 @@ export const makeMigrateAction: ActionMaker<MigrateData> = ({ t }) => {
   }
 
   return {
-    key: ActionKey.Migrate,
+    key: CoreActionKey.Migrate,
     Icon: WhaleEmoji,
     label: t('title.migrateSmartContract'),
     description: t('info.migrateSmartContractActionDescription'),

--- a/packages/stateful/actions/actions/RemoveCw20.tsx
+++ b/packages/stateful/actions/actions/RemoveCw20.tsx
@@ -12,9 +12,9 @@ import { Cw20BaseSelectors, CwdCoreV2Selectors } from '@dao-dao/state'
 import { XEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
   ActionOptionsContextType,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -172,7 +172,7 @@ export const makeRemoveCw20Action: ActionMaker<RemoveCw20Data> = ({
     )
 
   return {
-    key: ActionKey.RemoveCw20,
+    key: CoreActionKey.RemoveCw20,
     Icon: XEmoji,
     label: t('title.removeCw20FromTreasury'),
     description: t('info.removeCw20FromTreasuryActionDescription'),

--- a/packages/stateful/actions/actions/RemoveCw721.tsx
+++ b/packages/stateful/actions/actions/RemoveCw721.tsx
@@ -12,9 +12,9 @@ import { Cw721BaseSelectors, CwdCoreV2Selectors } from '@dao-dao/state'
 import { XEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
   ActionOptionsContextType,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -173,7 +173,7 @@ export const makeRemoveCw721Action: ActionMaker<RemoveCw721Data> = ({
     )
 
   return {
-    key: ActionKey.RemoveCw721,
+    key: CoreActionKey.RemoveCw721,
     Icon: XEmoji,
     label: t('title.removeCw721FromTreasury'),
     description: t('info.removeCw721FromTreasuryActionDescription'),

--- a/packages/stateful/actions/actions/Spend.tsx
+++ b/packages/stateful/actions/actions/Spend.tsx
@@ -14,9 +14,9 @@ import {
 } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
   ActionOptionsContextType,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -241,7 +241,7 @@ export const makeSpendAction: ActionMaker<SpendData> = ({
   }
 
   return {
-    key: ActionKey.Spend,
+    key: CoreActionKey.Spend,
     Icon: MoneyEmoji,
     label: t('title.spend'),
     description: t('info.spendActionDescription', {

--- a/packages/stateful/actions/actions/Stake.tsx
+++ b/packages/stateful/actions/actions/Stake.tsx
@@ -12,8 +12,8 @@ import {
 } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -170,7 +170,7 @@ export const makeStakeAction: ActionMaker<StakeData> = ({ t, address }) => {
   }
 
   return {
-    key: ActionKey.Stake,
+    key: CoreActionKey.Stake,
     Icon: DepositEmoji,
     label: t('title.stake'),
     description: t('info.stakeActionDescription'),

--- a/packages/stateful/actions/actions/UpdateAdmin.tsx
+++ b/packages/stateful/actions/actions/UpdateAdmin.tsx
@@ -5,8 +5,8 @@ import { contractAdminSelector } from '@dao-dao/state'
 import { MushroomEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -85,7 +85,7 @@ export const makeUpdateAdminAction: ActionMaker<UpdateAdminData> = ({
   }
 
   return {
-    key: ActionKey.UpdateAdmin,
+    key: CoreActionKey.UpdateAdmin,
     Icon: MushroomEmoji,
     label: t('title.updateContractAdmin'),
     description: t('info.updateContractAdminActionDescription'),

--- a/packages/stateful/actions/actions/UpdateInfo.tsx
+++ b/packages/stateful/actions/actions/UpdateInfo.tsx
@@ -9,7 +9,7 @@ import {
   ContractVersion,
 } from '@dao-dao/types'
 import {
-  ActionKey,
+  CoreActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -114,7 +114,7 @@ export const makeUpdateInfoAction: ActionMaker<UpdateInfoData> = ({
     )
 
   return {
-    key: ActionKey.UpdateInfo,
+    key: CoreActionKey.UpdateInfo,
     Icon: InfoEmoji,
     label: t('title.updateInfo'),
     description: t('info.updateInfoActionDescription'),

--- a/packages/stateful/actions/react/context.ts
+++ b/packages/stateful/actions/react/context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo } from 'react'
 
-import { Action, ActionKey, IActionsContext } from '@dao-dao/types/actions'
+import { Action, CoreActionKey, IActionsContext } from '@dao-dao/types/actions'
 
 //! External
 
@@ -18,7 +18,7 @@ const useActionsContext = (): IActionsContext => {
   return context
 }
 
-export const useActions = (additionalActions?: Action[]): Action[] => {
+export const useCoreActions = (additionalActions?: Action[]): Action[] => {
   const baseActions = useActionsContext().actions
 
   return useMemo(
@@ -32,8 +32,11 @@ export const useActions = (additionalActions?: Action[]): Action[] => {
     [additionalActions, baseActions]
   )
 }
-export const useActionForKey = (actionKey: ActionKey) =>
-  useActions().find(({ key }) => key === actionKey)
+
+// Only core actions are provided by the top-level context. Adapter-specific
+// actions are only available in the adapter.
+export const useCoreActionForKey = (actionKey: CoreActionKey) =>
+  useCoreActions().find(({ key }) => key === actionKey)
 
 //! Internal
 

--- a/packages/stateful/components/dao/TokenCard.tsx
+++ b/packages/stateful/components/dao/TokenCard.tsx
@@ -8,11 +8,11 @@ import {
   useCachedLoadable,
   useDaoInfoContext,
 } from '@dao-dao/stateless'
-import { ActionKey } from '@dao-dao/types'
+import { CoreActionKey } from '@dao-dao/types'
 import { TokenCardInfo } from '@dao-dao/types/dao'
 import { StakeType, loadableToLoadingData, useAddToken } from '@dao-dao/utils'
 
-import { useActionForKey } from '../../actions'
+import { useCoreActionForKey } from '../../actions'
 import { useEncodedCwdProposalSinglePrefill } from '../../hooks'
 import { tokenCardLazyInfoSelector } from '../../recoil'
 import { ButtonLink } from '../ButtonLink'
@@ -56,7 +56,7 @@ export const TokenCard = (props: TokenCardInfo) => {
 
   const stakesWithRewards = lazyStakes.filter(({ rewards }) => rewards > 0)
 
-  const stakeAction = useActionForKey(ActionKey.Stake)
+  const stakeAction = useCoreActionForKey(CoreActionKey.Stake)
   // Prefill URLs only valid if action exists.
   const prefillValid = !!stakeAction
   const encodedProposalPrefillClaim = useEncodedCwdProposalSinglePrefill({

--- a/packages/stateful/components/dao/tabs/TreasuryAndNftsTab.tsx
+++ b/packages/stateful/components/dao/tabs/TreasuryAndNftsTab.tsx
@@ -6,10 +6,10 @@ import {
   useCachedLoadable,
   useDaoInfoContext,
 } from '@dao-dao/stateless'
-import { ActionKey } from '@dao-dao/types'
+import { CoreActionKey } from '@dao-dao/types'
 import { loadableToLoadingData } from '@dao-dao/utils'
 
-import { useActionForKey } from '../../../actions'
+import { useCoreActionForKey } from '../../../actions'
 import {
   useEncodedCwdProposalSinglePrefill,
   useVotingModule,
@@ -66,7 +66,7 @@ export const TreasuryAndNftsTab = () => {
     treasuryTokenCardInfosLoadable.state,
   ])
 
-  const addCw721Action = useActionForKey(ActionKey.AddCw721)
+  const addCw721Action = useCoreActionForKey(CoreActionKey.AddCw721)
   // Prefill URL only valid if action exists.
   const prefillValid = !!addCw721Action
   const encodedProposalPrefill = useEncodedCwdProposalSinglePrefill({

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdatePreProposeConfigAction/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdatePreProposeConfigAction/index.tsx
@@ -7,8 +7,8 @@ import { Cw20BaseSelectors } from '@dao-dao/state'
 import { GearEmoji, useDaoInfoContext } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  AdapterActionKey,
   DepositRefundPolicy,
   ProposalModule,
   UseDecodedCosmosMsg,
@@ -349,7 +349,7 @@ export const makeUpdatePreProposeConfigAction: ActionMaker<
   }
 
   return {
-    key: ActionKey.UpdatePreProposeConfig,
+    key: AdapterActionKey.UpdatePreProposeConfig,
     Icon: GearEmoji,
     label: t('form.updateProposalSubmissionConfigTitle'),
     description: t('info.updateProposalSubmissionConfigActionDescription'),

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV1Action/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV1Action/index.tsx
@@ -5,8 +5,8 @@ import { Cw20BaseSelectors } from '@dao-dao/state'
 import { GearEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  AdapterActionKey,
   ContractVersion,
   ProposalModule,
   UseDecodedCosmosMsg,
@@ -340,7 +340,7 @@ export const makeUpdateProposalConfigV1Action: ActionMaker<
   }
 
   return {
-    key: ActionKey.UpdateProposalConfig,
+    key: AdapterActionKey.UpdateProposalConfig,
     Icon: GearEmoji,
     label: t('form.updateVotingConfigTitle'),
     description: t('info.updateVotingConfigActionDescription'),

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV2Action/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV2Action/index.tsx
@@ -4,8 +4,8 @@ import { useRecoilValue } from 'recoil'
 import { GearEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  AdapterActionKey,
   ContractVersion,
   ProposalModule,
   UseDecodedCosmosMsg,
@@ -278,7 +278,7 @@ export const makeUpdateProposalConfigV2Action: ActionMaker<
   }
 
   return {
-    key: ActionKey.UpdateProposalConfig,
+    key: AdapterActionKey.UpdateProposalConfig,
     Icon: GearEmoji,
     label: t('form.updateVotingConfigTitle'),
     description: t('info.updateVotingConfigActionDescription'),

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/components/NewProposal.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/components/NewProposal.tsx
@@ -40,7 +40,7 @@ import {
   processError,
 } from '@dao-dao/utils'
 
-import { useActions } from '../../../../../actions'
+import { useCoreActions } from '../../../../../actions'
 import {
   Cw20BaseHooks,
   useAwaitNextBlock,
@@ -93,7 +93,7 @@ export const NewProposal = ({
   } = useVotingModuleAdapter()
   const votingModuleActions = useVotingModuleActions()
   const proposalModuleActions = makeUseProposalModuleActions(options)()
-  const actions = useActions(
+  const actions = useCoreActions(
     useMemo(
       () => [...votingModuleActions, ...proposalModuleActions],
       [proposalModuleActions, votingModuleActions]

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/ui/NewProposal.stories.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/ui/NewProposal.stories.tsx
@@ -14,7 +14,7 @@ import {
   UseTransformToCosmos,
 } from '@dao-dao/types'
 
-import { useActions } from '../../../../../actions'
+import { useCoreActions } from '../../../../../actions'
 import { useVotingModuleAdapter } from '../../../../../voting-module-adapter'
 import { matchAdapter as matchProposalModuleAdapter } from '../../../../core'
 import { CwdProposalSingleAdapter } from '../../index'
@@ -47,7 +47,7 @@ const Template: ComponentStory<typeof NewProposal> = (args) => {
     proposalModule: singleChoiceProposalModule,
     coreAddress,
   })()
-  const actions = useActions(
+  const actions = useCoreActions(
     useMemo(
       () => [...votingModuleActions, ...proposalModuleActions],
       [proposalModuleActions, votingModuleActions]

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/index.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/index.tsx
@@ -3,8 +3,8 @@ import { useCallback, useMemo } from 'react'
 import { HerbEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  AdapterActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -97,7 +97,7 @@ export const makeMintAction: ActionMaker<MintData> = ({ t, address }) => {
   })
 
   return {
-    key: ActionKey.Mint,
+    key: AdapterActionKey.Mint,
     Icon: HerbEmoji,
     label: t('title.mint'),
     description: t('info.mintActionDescription'),

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/index.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/index.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next'
 import { PeopleEmoji } from '@dao-dao/stateless'
 import {
   ActionComponent,
-  ActionKey,
   ActionMaker,
+  AdapterActionKey,
   UseDecodedCosmosMsg,
   UseDefaults,
   UseTransformToCosmos,
@@ -101,7 +101,7 @@ export const makeManageMembersAction: ActionMaker<ManageMembersData> = ({
   }
 
   return {
-    key: ActionKey.ManageMembers,
+    key: AdapterActionKey.ManageMembers,
     Icon: PeopleEmoji,
     label: t('title.manageMembers'),
     description: t('info.manageMembersActionDescription'),

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/components/MembersTab.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/components/MembersTab.tsx
@@ -2,15 +2,15 @@ import { ComponentPropsWithoutRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { MembersTab as StatelessMembersTab } from '@dao-dao/stateless'
-import { ActionKey } from '@dao-dao/types'
 
-import { useActionForKey } from '../../../../actions'
+import { useActionOptions } from '../../../../actions'
 import { ButtonLink, DaoMemberCard } from '../../../../components'
 import {
   useEncodedCwdProposalSinglePrefill,
   useVotingModule,
 } from '../../../../hooks'
 import { useVotingModuleAdapterOptions } from '../../../react/context'
+import { makeManageMembersAction } from '../actions'
 import { useVotingModule as useCw4VotingModule } from '../hooks/useVotingModule'
 
 export const MembersTab = () => {
@@ -26,7 +26,8 @@ export const MembersTab = () => {
     throw new Error(t('error.loadingData'))
   }
 
-  const manageMembersAction = useActionForKey(ActionKey.ManageMembers)
+  const options = useActionOptions()
+  const manageMembersAction = makeManageMembersAction(options)
   // Prefill URL only valid if action exists.
   const prefillValid = !!manageMembersAction
   const encodedProposalPrefill = useEncodedCwdProposalSinglePrefill({

--- a/packages/stateless/components/actions/ActionSelector.stories.tsx
+++ b/packages/stateless/components/actions/ActionSelector.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
-import { useActions } from '@dao-dao/stateful/actions'
+import { useCoreActions } from '@dao-dao/stateful/actions'
 
 import { ActionSelector } from './ActionSelector'
 
@@ -11,7 +11,7 @@ export default {
 } as ComponentMeta<typeof ActionSelector>
 
 const Template: ComponentStory<typeof ActionSelector> = (args) => {
-  const actions = useActions()
+  const actions = useCoreActions()
 
   return <ActionSelector {...args} actions={actions} />
 }

--- a/packages/stateless/pages/Wallet.stories.tsx
+++ b/packages/stateless/pages/Wallet.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
 import { SuspenseLoader } from '@dao-dao/stateful'
-import { useActions } from '@dao-dao/stateful/actions'
+import { useCoreActions } from '@dao-dao/stateful/actions'
 import {
   WalletProviderDecorator,
   makeActionsProviderDecorator,
@@ -39,7 +39,7 @@ export default {
 } as ComponentMeta<typeof Wallet>
 
 const Template: ComponentStory<typeof Wallet> = (args) => {
-  const actions = useActions()
+  const actions = useCoreActions()
   // Call relevant action hooks in the same order every time.
   const actionsWithData: Partial<
     Record<

--- a/packages/types/actions.ts
+++ b/packages/types/actions.ts
@@ -6,25 +6,33 @@ import { TFunction } from 'react-i18next'
 import { ContractVersion } from './chain'
 import { CosmosMsgFor_Empty } from './contracts/common'
 
-export enum ActionKey {
+// Actions defined in the core actions system (@dao-dao/stateful/actions). These
+// are provided in the top-level ActionsProvider.
+export enum CoreActionKey {
   Spend = 'spend',
-  Mint = 'mint',
   Stake = 'stake',
   AddCw20 = 'addCw20',
   RemoveCw20 = 'removeCw20',
   AddCw721 = 'addCw721',
   RemoveCw721 = 'removeCw721',
-  ManageMembers = 'manageMembers',
   ManageSubDaos = 'manageSubDaos',
   UpdateInfo = 'updateInfo',
-  UpdatePreProposeConfig = 'updatePreProposeConfig',
-  UpdateProposalConfig = 'updateProposalConfig',
   Instantiate = 'instantiate',
   Execute = 'execute',
   Migrate = 'migrate',
   UpdateAdmin = 'updateAdmin',
   Custom = 'custom',
 }
+
+// Actions defined in voting or proposal module adapters.
+export enum AdapterActionKey {
+  ManageMembers = 'manageMembers',
+  Mint = 'mint',
+  UpdatePreProposeConfig = 'updatePreProposeConfig',
+  UpdateProposalConfig = 'updateProposalConfig',
+}
+
+export type ActionKey = CoreActionKey | AdapterActionKey
 
 export interface ActionAndData {
   action: Action


### PR DESCRIPTION
Since the manage members action is defined in the voting module adapter, it cannot be accessed via the `useActionForKey` helper hook in the stateful actions system. It needs to be imported directly from the adapter's local action maker function.

Refactored the enum and hooks to be differentiate between core and adapter actions.