### PR TITLE
Fixed select input style and Stake action responsiveness

### DIFF
--- a/packages/stateful/actions/components/Stake.tsx
+++ b/packages/stateful/actions/components/Stake.tsx
@@ -233,9 +233,10 @@ export const StakeComponent: ActionComponent<StakeOptions, StakeData> = ({
       onRemove={onRemove}
       title={t('title.stake')}
     >
-      <div className="flex flex-row gap-2">
+      <div className="flex flex-col gap-2 xs:flex-row">
         {/* Choose type of stake operation. */}
         <SelectInput
+          containerClassName="shrink-0"
           defaultValue={stakeActions[0].type}
           disabled={!isCreating}
           error={errors?.stakeType}
@@ -265,7 +266,7 @@ export const StakeComponent: ActionComponent<StakeOptions, StakeData> = ({
 
         {/* Choose source validator. */}
         <ValidatorPicker
-          displayClassName="grow"
+          displayClassName="grow min-w-0"
           nativeDecimals={NATIVE_DECIMALS}
           nativeDenom={NATIVE_DENOM}
           onSelect={({ address }) =>
@@ -285,7 +286,7 @@ export const StakeComponent: ActionComponent<StakeOptions, StakeData> = ({
 
       {/* If not claiming (i.e. withdrawing reward), show amount input. */}
       {stakeType !== StakeType.WithdrawDelegatorReward && (
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-col gap-2 xs:flex-row">
           <NumberInput
             containerClassName="grow"
             disabled={!isCreating}

--- a/packages/stateful/actions/components/ValidatorPicker.tsx
+++ b/packages/stateful/actions/components/ValidatorPicker.tsx
@@ -85,7 +85,7 @@ export const ValidatorPicker = ({
       Trigger={({ open, ...props }) => (
         <div className={clsx('flex', displayClassName)}>
           {selectedAddress ? (
-            <InputThemedText className="flex min-w-0 grow flex-row items-center justify-between gap-10">
+            <InputThemedText className="flex min-w-0 grow flex-row items-center justify-between gap-2">
               <CopyToClipboard
                 label={selectedValidator?.moniker}
                 tooltip={t('button.clickToCopyAddress')}

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/daoCreation/QuorumVotingConfigItem.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/daoCreation/QuorumVotingConfigItem.tsx
@@ -49,7 +49,7 @@ export const QuorumInput = ({
           )}
 
           <SelectInput
-            className={majority ? 'grow' : undefined}
+            containerClassName={majority ? 'grow' : undefined}
             onChange={(value) => setValue('quorum.majority', value === '1')}
             validation={[validateRequired]}
             value={majority ? '1' : '0'}

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/daoCreation/ThresholdVotingConfigItem.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/daoCreation/ThresholdVotingConfigItem.tsx
@@ -45,7 +45,7 @@ export const ThresholdInput = ({
       )}
 
       <SelectInput
-        className={majority ? 'grow' : undefined}
+        containerClassName={majority ? 'grow' : undefined}
         onChange={(value) => setValue('threshold.majority', value === '1')}
         validation={[validateRequired]}
         value={majority ? '1' : '0'}

--- a/packages/stateless/components/inputs/SelectInput.tsx
+++ b/packages/stateless/components/inputs/SelectInput.tsx
@@ -1,3 +1,4 @@
+import { ArrowDropDown } from '@mui/icons-material'
 import clsx from 'clsx'
 import { ComponentPropsWithoutRef } from 'react'
 import {
@@ -19,6 +20,8 @@ export interface SelectInputProps<
   error?: FieldError
   required?: boolean
   onChange?: (value: string) => void
+  containerClassName?: string
+  iconClassName?: string
 }
 
 export const SelectInput = <
@@ -33,6 +36,9 @@ export const SelectInput = <
   required,
   className,
   onChange,
+  containerClassName,
+  iconClassName,
+  disabled,
   ...props
 }: SelectInputProps<FV, FieldName>) => {
   const validate = validation?.reduce(
@@ -41,27 +47,38 @@ export const SelectInput = <
   )
 
   return (
-    <select
-      className={clsx(
-        'secondary-text rounded-md bg-transparent py-3 px-4 text-text-body ring-1 transition placeholder:text-text-tertiary focus:outline-none focus:ring-2',
-        error
-          ? 'ring-border-interactive-error'
-          : 'ring-border-primary focus:ring-border-interactive-focus',
-        props.disabled && 'appearance-none',
-        className
+    <div className={clsx('relative', containerClassName)}>
+      <select
+        className={clsx(
+          'secondary-text h-full w-full appearance-none truncate rounded-md bg-transparent py-3 pl-4 text-text-body !outline-none ring-1 transition placeholder:text-text-tertiary focus:ring-2',
+          error
+            ? 'ring-border-interactive-error'
+            : 'ring-border-primary focus:ring-border-interactive-focus',
+          disabled
+            ? 'pointer-events-none pr-4'
+            : 'cursor-pointer pr-10 hover:bg-background-interactive-hover active:bg-background-interactive-pressed',
+          className
+        )}
+        disabled={disabled}
+        {...props}
+        {...(register &&
+          fieldName &&
+          register(fieldName, {
+            required: required && 'Required',
+            validate,
+            ...(onChange && {
+              onChange: (e: any) => onChange(e.target.value),
+            }),
+          }))}
+      >
+        {children}
+      </select>
+
+      {!disabled && (
+        <div className="pointer-events-none absolute top-0 bottom-0 right-2 flex flex-row items-center">
+          <ArrowDropDown className={clsx('!h-5 !w-5', iconClassName)} />
+        </div>
       )}
-      {...props}
-      {...(register &&
-        fieldName &&
-        register(fieldName, {
-          required: required && 'Required',
-          validate,
-          ...(onChange && {
-            onChange: (e: any) => onChange(e.target.value),
-          }),
-        }))}
-    >
-      {children}
-    </select>
+    </div>
   )
 }

--- a/packages/stateless/components/inputs/SelectInput.tsx
+++ b/packages/stateless/components/inputs/SelectInput.tsx
@@ -61,15 +61,18 @@ export const SelectInput = <
         )}
         disabled={disabled}
         {...props}
-        {...(register &&
-          fieldName &&
-          register(fieldName, {
-            required: required && 'Required',
-            validate,
-            ...(onChange && {
-              onChange: (e: any) => onChange(e.target.value),
-            }),
-          }))}
+        {...(register && fieldName
+          ? register(fieldName, {
+              required: required && 'Required',
+              validate,
+              ...(onChange && {
+                onChange: (e: any) => onChange(e.target.value),
+              }),
+            })
+          : {
+              required,
+              onChange: onChange && ((e: any) => onChange(e.target.value)),
+            })}
       >
         {children}
       </select>


### PR DESCRIPTION
The Stake action was not very responsiveness, elements overflowing on small screens. This fixes that:

<img width="262" alt="Screenshot 2022-11-13 at 12 00 53 PM" src="https://user-images.githubusercontent.com/6721426/201541815-121b20a5-ed1a-4f04-9cdd-93f91b16f127.png">
<img width="293" alt="Screenshot 2022-11-13 at 12 01 13 PM" src="https://user-images.githubusercontent.com/6721426/201541826-0659c9b5-0fba-46d0-99d6-707196c61b62.png">

The select input was not highlighting on hover or anything like the other clickable input elements (like buttons), and also the dropdown arrow was weirdly positioned because of its default browser appearance. This hides that arrow and uses a new one:

<img width="169" alt="Screenshot 2022-11-13 at 12 02 30 PM" src="https://user-images.githubusercontent.com/6721426/201541882-2d7ee0a6-b03a-4d44-bd72-9a7ac357571a.png">
<img width="174" alt="Screenshot 2022-11-13 at 12 02 36 PM" src="https://user-images.githubusercontent.com/6721426/201541891-1fc5733c-51d5-478f-8d84-740b586bbfda.png">
<img width="202" alt="Screenshot 2022-11-13 at 12 02 43 PM" src="https://user-images.githubusercontent.com/6721426/201541895-b191c907-45a4-418c-b325-1978cbc39a16.png">

I also found a recently introduced bug where the select input would not register the `onChange` handler when not registered in a form. This is now fixed.