### PR TITLE
Fixed mint action input sizing.

### DIFF
--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/MintComponent.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/MintComponent.tsx
@@ -39,7 +39,7 @@ export const MintComponent: ActionComponent<MintOptions> = ({
     <ActionCard Icon={HerbEmoji} onRemove={onRemove} title={t('title.mint')}>
       <div className="flex flex-col items-stretch gap-x-3 gap-y-2 sm:flex-row">
         <NumberInput
-          containerClassName="grow"
+          containerClassName="w-full sm:w-auto"
           disabled={!isCreating}
           error={errors?.amount}
           fieldName={fieldNamePrefix + 'amount'}
@@ -56,7 +56,7 @@ export const MintComponent: ActionComponent<MintOptions> = ({
             )
           }
           register={register}
-          sizing="fill"
+          sizing="none"
           unit={`$${govTokenSymbol}`}
           validation={[validateRequired, validatePositive]}
         />

--- a/packages/stateless/components/inputs/NumberInput.tsx
+++ b/packages/stateless/components/inputs/NumberInput.tsx
@@ -23,7 +23,7 @@ export interface NumberInputProps<
   onMinus?: () => void
   onPlus?: () => void
   containerClassName?: string
-  sizing?: 'sm' | 'md' | 'auto' | 'fill'
+  sizing?: 'sm' | 'md' | 'auto' | 'fill' | 'none'
   required?: boolean
   setValueAs?: (value: any) => any
   ghost?: boolean


### PR DESCRIPTION
Address should not be so small.

## Before

<img width="706" alt="Screenshot 2022-11-15 at 10 14 45 AM" src="https://user-images.githubusercontent.com/6721426/201995200-02a1722d-3a79-4260-9b6a-53f0b8e9d27c.png">
<img width="462" alt="Screenshot 2022-11-15 at 10 14 55 AM" src="https://user-images.githubusercontent.com/6721426/201995227-2c3a04f8-15dd-48ea-ad7b-568a38e6d2e3.png">

## After

<img width="629" alt="Screenshot 2022-11-15 at 10 15 36 AM" src="https://user-images.githubusercontent.com/6721426/201995343-6de02b8c-ffc5-467e-876c-adf80b8b8eb5.png">
<img width="399" alt="Screenshot 2022-11-15 at 10 15 45 AM" src="https://user-images.githubusercontent.com/6721426/201995373-276fe244-d152-47cd-98e3-fd1a1a81d4ad.png">
