### PR TITLE
Improved member card address responsiveness

### DIFF
--- a/packages/stateless/components/dao/DaoMemberCard.tsx
+++ b/packages/stateless/components/dao/DaoMemberCard.tsx
@@ -17,7 +17,7 @@ export const DaoMemberCard = ({
 
   return (
     <div className="flex flex-col justify-between rounded-md border border-border-primary">
-      <div className="flex flex-col items-center px-4 pt-10 pb-8">
+      <div className="flex flex-col items-center px-6 pt-10 pb-8">
         {/* Image */}
         <ProfileImage
           imageUrl={profile.loading ? undefined : profile.data.imageUrl}
@@ -34,15 +34,12 @@ export const DaoMemberCard = ({
           {profile.loading ? '...' : profile.data.name}
         </p>
         {/* Address */}
-        <div className="flex flex-row items-center gap-1">
+        <div className="flex w-full min-w-0 flex-row items-center justify-center gap-1">
           <Tag className="!h-5 !w-5 text-icon-tertiary" />
 
           <CopyToClipboardUnderline
             className="text-sm !text-text-tertiary"
-            takeStartEnd={{
-              start: 12,
-              end: 8,
-            }}
+            takeAll
             value={address}
           />
         </div>


### PR DESCRIPTION
Member card addresses were not properly being truncated based on available space.

## Before
![image](https://user-images.githubusercontent.com/6721426/203013576-23c415d2-4403-42d5-b135-c628f89e53c4.png)

## After
<img width="751" alt="Screenshot 2022-11-21 at 1 24 21 AM" src="https://user-images.githubusercontent.com/6721426/203013605-d3443c1a-78fb-4931-aa91-387ae8d0518e.png">
<img width="1060" alt="Screenshot 2022-11-21 at 1 24 27 AM" src="https://user-images.githubusercontent.com/6721426/203013637-42de178f-db24-4028-9205-83e4e9914d8a.png">
