### PR TITLE
Remove legacy unstake validation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - development
+      - legacy
   pull_request:
     branches:
       - main
       - development
+      - legacy
 
 env:
   NEXT_PUBLIC_CHAIN_ID: NEXT_PUBLIC_CHAIN_ID

--- a/apps/dapp/templates/stake.tsx
+++ b/apps/dapp/templates/stake.tsx
@@ -91,7 +91,7 @@ export const StakeComponent: TemplateComponent = ({
     amount: string
   ): string | boolean => {
     // If we are redelegating, don't validate the undelegated treasury amount.
-    if (stakeType === 'redelegate') {
+    if (stakeType === 'redelegate' || stakeType === 'undelegate') {
       return true
     }
     const native = nativeBalances.find((coin) => coin.denom == denom)


### PR DESCRIPTION
The legacy stake template has validation issues when unstaking. This removes the validation so people can unstake successfully on legacy.