### PR TITLE
Improved v2 versioning distinction

### DIFF
--- a/packages/stateful/actions/actions/ManageSubDaos.tsx
+++ b/packages/stateful/actions/actions/ManageSubDaos.tsx
@@ -37,7 +37,7 @@ export const makeManageSubDaosAction: ActionMaker<ManageSubDaosData> = ({
   // v1 DAOS don't support SubDAOs.
   if (
     context.type !== ActionOptionsContextType.Dao ||
-    context.coreVersion === ContractVersion.V0_1_0
+    context.coreVersion === ContractVersion.V1
   ) {
     return null
   }

--- a/packages/stateful/actions/actions/UpdateInfo.tsx
+++ b/packages/stateful/actions/actions/UpdateInfo.tsx
@@ -76,7 +76,7 @@ export const makeUpdateInfoAction: ActionMaker<UpdateInfoData> = ({
   }
 
   const configSelector =
-    context.coreVersion === ContractVersion.V0_1_0
+    context.coreVersion === ContractVersion.V1
       ? CwCoreV1Selectors.configSelector({
           contractAddress: address,
         })

--- a/packages/stateful/actions/components/MigrateContract.stories.tsx
+++ b/packages/stateful/actions/components/MigrateContract.stories.tsx
@@ -20,7 +20,7 @@ export default {
       bech32Prefix: 'juno',
       context: {
         type: ActionOptionsContextType.Dao,
-        coreVersion: ContractVersion.V0_2_0,
+        coreVersion: ContractVersion.V2Alpha,
       },
     }),
   ],

--- a/packages/stateful/actions/components/Spend.stories.tsx
+++ b/packages/stateful/actions/components/Spend.stories.tsx
@@ -24,7 +24,7 @@ export default {
       bech32Prefix: 'juno',
       context: {
         type: ActionOptionsContextType.Dao,
-        coreVersion: ContractVersion.V0_2_0,
+        coreVersion: ContractVersion.V2Alpha,
       },
     }),
   ],

--- a/packages/stateful/actions/components/UpdateAdmin.stories.tsx
+++ b/packages/stateful/actions/components/UpdateAdmin.stories.tsx
@@ -19,7 +19,7 @@ export default {
       bech32Prefix: 'juno',
       context: {
         type: ActionOptionsContextType.Dao,
-        coreVersion: ContractVersion.V0_2_0,
+        coreVersion: ContractVersion.V2Alpha,
       },
     }),
   ],

--- a/packages/stateful/actions/components/UpdateInfo.stories.tsx
+++ b/packages/stateful/actions/components/UpdateInfo.stories.tsx
@@ -19,7 +19,7 @@ export default {
       bech32Prefix: 'juno',
       context: {
         type: ActionOptionsContextType.Dao,
-        coreVersion: ContractVersion.V0_2_0,
+        coreVersion: ContractVersion.V2Alpha,
       },
     }),
   ],

--- a/packages/stateful/components/dao/tabs/SubDaosTab.tsx
+++ b/packages/stateful/components/dao/tabs/SubDaosTab.tsx
@@ -21,7 +21,7 @@ export const SubDaosTab = () => {
   })
 
   const subDaoCardInfosLoadable = useRecoilValueLoadable(
-    daoInfo.coreVersion === ContractVersion.V0_1_0
+    daoInfo.coreVersion === ContractVersion.V1
       ? constSelector([])
       : subDaoCardInfosSelector({ coreAddress: daoInfo.coreAddress })
   )

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV1Action/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV1Action/index.tsx
@@ -211,7 +211,7 @@ export const makeUpdateProposalConfigV1Action: ActionMaker<
   { proposalModule: ProposalModule }
 > = ({ t, proposalModule: { version, address: proposalModuleAddress } }) => {
   // Only v1.
-  if (version !== ContractVersion.V0_1_0) {
+  if (version !== ContractVersion.V1) {
     return null
   }
 

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV2Action/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/actions/makeUpdateProposalConfigV2Action/index.tsx
@@ -165,7 +165,7 @@ export const makeUpdateProposalConfigV2Action: ActionMaker<
   { proposalModule: ProposalModule }
 > = ({ t, proposalModule: { version, address: proposalModuleAddress } }) => {
   // Only v2.
-  if (version === ContractVersion.V0_1_0) {
+  if (version === ContractVersion.V1) {
     return null
   }
 

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/components/NewProposal.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/components/NewProposal.tsx
@@ -312,7 +312,7 @@ export const NewProposal = ({
         try {
           let response
           //! V1
-          if (proposalModule.version === ContractVersion.V0_1_0) {
+          if (proposalModule.version === ContractVersion.V1) {
             response = await doProposeV1(
               newProposalData,
               'auto',

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/selectors.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/common/selectors.ts
@@ -85,7 +85,7 @@ export const makeDepositInfoSelector: (
     ({ get }) => {
       let depositInfo: CheckedDepositInfo | undefined
       //! V1
-      if (version === ContractVersion.V0_1_0) {
+      if (version === ContractVersion.V1) {
         const config = get(
           configV1Selector({
             contractAddress: proposalModuleAddress,

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/components/ProposalStatusAndInfo.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/components/ProposalStatusAndInfo.tsx
@@ -187,9 +187,7 @@ export const ProposalStatusAndInfo = ({
         })
 
   const executeProposal = (
-    proposalModule.version === ContractVersion.V1
-      ? useExecuteV1
-      : useExecuteV2
+    proposalModule.version === ContractVersion.V1 ? useExecuteV1 : useExecuteV2
   )({
     contractAddress: proposalModule.address,
     sender: walletAddress,

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/components/ProposalStatusAndInfo.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/components/ProposalStatusAndInfo.tsx
@@ -187,7 +187,7 @@ export const ProposalStatusAndInfo = ({
         })
 
   const executeProposal = (
-    proposalModule.version === ContractVersion.V0_1_0
+    proposalModule.version === ContractVersion.V1
       ? useExecuteV1
       : useExecuteV2
   )({
@@ -195,7 +195,7 @@ export const ProposalStatusAndInfo = ({
     sender: walletAddress,
   })
   const closeProposal = (
-    proposalModule.version === ContractVersion.V0_1_0 ? useCloseV1 : useCloseV2
+    proposalModule.version === ContractVersion.V1 ? useCloseV1 : useCloseV2
   )({
     contractAddress: proposalModule.address,
     sender: walletAddress,

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/contracts/CwdProposalSingle.common.recoil.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/contracts/CwdProposalSingle.common.recoil.ts
@@ -58,7 +58,7 @@ export const getVoteSelector = selectorFamily<
         })
       )
       const selector =
-        proposalModuleVersion === ContractVersion.V0_1_0
+        proposalModuleVersion === ContractVersion.V1
           ? getVoteV1Selector
           : getVoteV2Selector
 
@@ -89,7 +89,7 @@ export const listVotesSelector = selectorFamily<
         })
       )
       const selector =
-        proposalModuleVersion === ContractVersion.V0_1_0
+        proposalModuleVersion === ContractVersion.V1
           ? listVotesV1Selector
           : listVotesV2Selector
 
@@ -118,7 +118,7 @@ export const proposalSelector = selectorFamily<
         })
       )
       const selector =
-        proposalModuleVersion === ContractVersion.V0_1_0
+        proposalModuleVersion === ContractVersion.V1
           ? proposalV1Selector
           : proposalV2Selector
 
@@ -141,7 +141,7 @@ export const configSelector = selectorFamily<
         })
       )
       const selector =
-        proposalModuleVersion === ContractVersion.V0_1_0
+        proposalModuleVersion === ContractVersion.V1
           ? configV1Selector
           : configV2Selector
 
@@ -171,7 +171,7 @@ export const reverseProposalsSelector = selectorFamily<
         })
       )
       const selector =
-        proposalModuleVersion === ContractVersion.V0_1_0
+        proposalModuleVersion === ContractVersion.V1
           ? reverseProposalsV1Selector
           : reverseProposalsV2Selector
 

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/functions/fetchPreProposeAddress.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/functions/fetchPreProposeAddress.ts
@@ -7,8 +7,8 @@ export const fetchPreProposeAddress: FetchPreProposeAddressFunction = async (
   proposalModuleAddress,
   version
 ) => {
-  // Only v2 supports pre-propose.
-  if (version !== ContractVersion.V0_2_0) {
+  // v1 does not support pre-propose.
+  if (version === ContractVersion.V1) {
     return null
   }
 

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/functions/makeGetProposalInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/functions/makeGetProposalInfo.ts
@@ -40,7 +40,7 @@ export const makeGetProposalInfo =
       const version = parseContractVersion(info.version)
 
       const queryClient =
-        version === ContractVersion.V0_1_0
+        version === ContractVersion.V1
           ? new CwProposalSingleV1QueryClient(
               cosmWasmClient,
               proposalModule.address

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/hooks/useCastVote.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/hooks/useCastVote.ts
@@ -15,7 +15,7 @@ export const useCastVote = (onSuccess?: () => void | Promise<void>) => {
   const { connected, address: walletAddress = '' } = useWallet()
 
   const castVote = (
-    proposalModule.version === ContractVersion.V0_1_0 ? useVoteV1 : useVoteV2
+    proposalModule.version === ContractVersion.V1 ? useVoteV1 : useVoteV2
   )({
     contractAddress: proposalModule.address,
     sender: walletAddress ?? '',

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/hooks/useDepositInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/hooks/useDepositInfo.ts
@@ -52,8 +52,7 @@ export const useDepositInfo = (): CheckedDepositInfo | undefined => {
 
   const depositInfo: CheckedDepositInfo | undefined =
     //! V1
-    version === ContractVersion.V1 &&
-    proposalResponse?.proposal?.deposit_info
+    version === ContractVersion.V1 && proposalResponse?.proposal?.deposit_info
       ? {
           amount: proposalResponse.proposal.deposit_info.deposit,
           denom: {

--- a/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/hooks/useDepositInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/CwdProposalSingle/hooks/useDepositInfo.ts
@@ -22,7 +22,7 @@ export const useDepositInfo = (): CheckedDepositInfo | undefined => {
     ProposalV1Response | DepositInfoPreProposeResponse | undefined
   >(
     //! V1
-    version === ContractVersion.V0_1_0
+    version === ContractVersion.V1
       ? proposalV1Selector({
           contractAddress: address,
           params: [
@@ -52,7 +52,7 @@ export const useDepositInfo = (): CheckedDepositInfo | undefined => {
 
   const depositInfo: CheckedDepositInfo | undefined =
     //! V1
-    version === ContractVersion.V0_1_0 &&
+    version === ContractVersion.V1 &&
     proposalResponse?.proposal?.deposit_info
       ? {
           amount: proposalResponse.proposal.deposit_info.deposit,

--- a/packages/stateful/recoil/selectors/dao/cards.ts
+++ b/packages/stateful/recoil/selectors/dao/cards.ts
@@ -238,7 +238,7 @@ export const daoDropdownInfoSelector: (
         })
       )
       const config =
-        version === ContractVersion.V0_1_0
+        version === ContractVersion.V1
           ? get(
               CwCoreV1Selectors.configSelector({
                 contractAddress: coreAddress,
@@ -254,7 +254,7 @@ export const daoDropdownInfoSelector: (
             )
 
       const subDaoAddresses: string[] =
-        version === ContractVersion.V0_1_0
+        version === ContractVersion.V1
           ? []
           : get(
               CwdCoreV2Selectors.listAllSubDaosSelector({

--- a/packages/stateful/utils/fetchProposalModules.ts
+++ b/packages/stateful/utils/fetchProposalModules.ts
@@ -91,7 +91,7 @@ export const fetchProposalModules = async (
 
   while (true) {
     const _proposalModules = await Promise.all(
-      coreVersion === ContractVersion.V0_1_0
+      coreVersion === ContractVersion.V1
         ? await getV0_1_0ProposalModules()
         : await getV0_2_0ProposalModules()
     )

--- a/packages/stateless/components/dao/tabs/SubDaosTab.tsx
+++ b/packages/stateless/components/dao/tabs/SubDaosTab.tsx
@@ -48,7 +48,7 @@ export const SubDaosTab = ({
         <ButtonLink
           className="shrink-0"
           // Disabled for v1 DAOs, not supported.
-          disabled={!isMember || daoInfo.coreVersion === ContractVersion.V0_1_0}
+          disabled={!isMember || daoInfo.coreVersion === ContractVersion.V1}
           href={`/dao/${daoInfo.coreAddress}/create`}
         >
           <Add className="!h-4 !w-4" />
@@ -56,7 +56,7 @@ export const SubDaosTab = ({
         </ButtonLink>
       </div>
 
-      {daoInfo.coreVersion === ContractVersion.V0_1_0 ? (
+      {daoInfo.coreVersion === ContractVersion.V1 ? (
         <NoContent
           Icon={Upgrade}
           actionNudge={t('info.submitUpgradeProposal')}

--- a/packages/storybook/decorators/DaoPageWrapperDecorator.tsx
+++ b/packages/storybook/decorators/DaoPageWrapperDecorator.tsx
@@ -13,13 +13,13 @@ export const DaoPageWrapperDecorator: DecoratorFn = (Story) => {
       chainId: CHAIN_ID,
       bech32Prefix: CHAIN_BECH32_PREFIX,
       coreAddress: CHAIN_BECH32_PREFIX + 'DaoCoreAddress',
-      coreVersion: ContractVersion.V0_2_0,
+      coreVersion: ContractVersion.V2Alpha,
       votingModuleAddress: 'votingModuleAddress',
       votingModuleContractName: 'crates.io:cwd-voting-cw20-staked',
       proposalModules: [
         {
           contractName: 'crates.io:cwd-proposal-single',
-          version: ContractVersion.V0_2_0,
+          version: ContractVersion.V2Alpha,
           address: 'proposalModuleAddress',
           prefix: 'A',
           preProposeAddress: 'preProposeModuleAddress',

--- a/packages/types/chain.ts
+++ b/packages/types/chain.ts
@@ -29,6 +29,7 @@ export interface NativeDelegationInfo {
 }
 
 export enum ContractVersion {
-  V0_1_0 = '0.1.0',
-  V0_2_0 = '0.2.0',
+  V1 = '0.1.0',
+  V2Alpha = '0.2.0',
+  V2Beta = '2.0.0-beta',
 }

--- a/packages/utils/contracts.ts
+++ b/packages/utils/contracts.ts
@@ -1,13 +1,13 @@
 import { ContractVersion } from '@dao-dao/types'
 
+const CONTRACT_VERSIONS = Object.values(ContractVersion)
+
+// If version is defined, returns it. Otherwise, returns `undefined`.
+// Essentially just filters version by its presence in the `ContractVersion`
+// enum.
 export const parseContractVersion = (
   version: string
-): ContractVersion | undefined =>
-  version === ContractVersion.V0_1_0
-    ? ContractVersion.V0_1_0
-    : version === ContractVersion.V0_2_0
-    ? ContractVersion.V0_2_0
-    : undefined
+): ContractVersion | undefined => CONTRACT_VERSIONS.find((v) => v === version)
 
 export const indexToProposalModulePrefix = (index: number) => {
   index += 1


### PR DESCRIPTION
The `ContractVersion` enum values were unnecessarily hard to read, so I renamed them.

I also added a distinction between v2-alpha, which is currently deployed on testnet, and v2-beta, which is undergoing the audit. There is a breaking change in the `set_item` execute variant between v2-alpha and v2-beta, which this distinction will rectify (commit: https://github.com/DA0-DA0/dao-dao-ui/pull/921/commits/d8002fc7ba2b60410f69e253d1e71567584e822a).

I foresee us removing support for v2-alpha and -beta when the final v2 contracts are deployed, but for now (and in the instance that we just leave the current v2-alpha DAOs on testnet alone) it serves us to match the `dao-contracts` repo.