### PR TITLE
Avoid cyclic dependency manifestation

### DIFF
--- a/packages/stateful/components/dao/CreateDaoForm.tsx
+++ b/packages/stateful/components/dao/CreateDaoForm.tsx
@@ -53,8 +53,8 @@ import {
 } from '../../hooks'
 import { getAdapterById as getProposalModuleAdapterById } from '../../proposal-module-adapter'
 import {
-  DefaultNewDao,
   daoCreatedCardPropsAtom,
+  makeDefaultNewDao,
   newDaoAtom,
 } from '../../recoil/atoms/newDao'
 import {
@@ -131,7 +131,7 @@ export const CreateDaoForm = ({
     // If created DAO, clear saved data and don't update.
     if (daoCreatedCardProps) {
       // Clear saved form data.
-      setNewDaoAtom(DefaultNewDao)
+      setNewDaoAtom(makeDefaultNewDao())
       return
     }
 
@@ -436,7 +436,7 @@ export const CreateDaoForm = ({
             })
 
             // Clear saved form data.
-            setNewDaoAtom(DefaultNewDao)
+            setNewDaoAtom(makeDefaultNewDao())
 
             // Navigate to DAO page (underneath the creation modal).
             router.push(`/dao/${coreAddress}`)

--- a/packages/stateful/recoil/atoms/newDao.ts
+++ b/packages/stateful/recoil/atoms/newDao.ts
@@ -6,7 +6,9 @@ import { DaoCreatedCardProps, NewDao } from '@dao-dao/types'
 import { CwdProposalSingleAdapter } from '../../proposal-module-adapter/adapters/CwdProposalSingle'
 import { CwdVotingCw4Adapter } from '../../voting-module-adapter'
 
-export const DefaultNewDao: NewDao = {
+// Avoid cyclic dependencies issues with the adapter modules by using a lazy
+// maker function.
+export const makeDefaultNewDao = (): NewDao => ({
   name: '',
   description: '',
   imageUrl: undefined,
@@ -22,13 +24,13 @@ export const DefaultNewDao: NewDao = {
     },
   ],
   advancedVotingConfigEnabled: false,
-}
+})
 
 // Store each subDAO creation state separately. Main DAO creation state uses an
 // empty string.
 export const newDaoAtom = atomFamily<NewDao, string>({
   key: 'newDao',
-  default: DefaultNewDao,
+  default: makeDefaultNewDao,
   effects: [localStorageEffectJSON],
 })
 

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/daoCreation/TierCard.stories.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/daoCreation/TierCard.stories.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 
 import { NewDao } from '@dao-dao/types'
 
-import { DefaultNewDao } from '../../../../recoil/atoms'
+import { makeDefaultNewDao } from '../../../../recoil/atoms'
 import { CwdVotingCw20StakedAdapter } from '../../../index'
 import { DaoCreationConfig } from '../types'
 import { TierCard } from './TierCard'
@@ -23,7 +23,7 @@ const Template: ComponentStory<typeof TierCard> = (args) => {
     watch,
   } = useForm<NewDao<DaoCreationConfig>>({
     defaultValues: {
-      ...DefaultNewDao,
+      ...makeDefaultNewDao(),
       votingModuleAdapter: {
         id: CwdVotingCw20StakedAdapter.id,
         data: CwdVotingCw20StakedAdapter.daoCreation!.defaultConfig,

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/daoCreation/TierCard.stories.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/daoCreation/TierCard.stories.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 
 import { NewDao } from '@dao-dao/types'
 
-import { DefaultNewDao } from '../../../../recoil/atoms'
+import { makeDefaultNewDao } from '../../../../recoil/atoms'
 import { CwdVotingCw4Adapter } from '../../../index'
 import { DaoCreationConfig } from '../types'
 import { TierCard } from './TierCard'
@@ -23,7 +23,7 @@ const Template: ComponentStory<typeof TierCard> = (args) => {
     watch,
   } = useForm<NewDao<DaoCreationConfig>>({
     defaultValues: {
-      ...DefaultNewDao,
+      ...makeDefaultNewDao(),
       votingModuleAdapter: {
         id: CwdVotingCw4Adapter.id,
         data: CwdVotingCw4Adapter.daoCreation!.defaultConfig,

--- a/packages/stateless/components/dao/create/DaoCreateConfigInputCard.stories.tsx
+++ b/packages/stateless/components/dao/create/DaoCreateConfigInputCard.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
-import { DefaultNewDao, SuspenseLoader } from '@dao-dao/stateful'
+import { SuspenseLoader, makeDefaultNewDao } from '@dao-dao/stateful'
 import { VotingDurationInput } from '@dao-dao/stateful/proposal-module-adapter/adapters/CwdProposalSingle/daoCreation'
 import { NewDao } from '@dao-dao/types'
 
@@ -17,7 +17,7 @@ export default {
 
 const Template: ComponentStory<typeof DaoCreateConfigInputCard> = (args) => {
   const { register, watch, setValue } = useForm<NewDao>({
-    defaultValues: DefaultNewDao,
+    defaultValues: makeDefaultNewDao(),
     mode: 'onChange',
   })
 

--- a/packages/stateless/components/dao/create/DaoCreateConfigReviewCard.stories.tsx
+++ b/packages/stateless/components/dao/create/DaoCreateConfigReviewCard.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
-import { DefaultNewDao } from '@dao-dao/stateful'
+import { makeDefaultNewDao } from '@dao-dao/stateful'
 import { VotingDurationReview } from '@dao-dao/stateful/proposal-module-adapter/adapters/CwdProposalSingle/daoCreation'
 import { NewDao } from '@dao-dao/types'
 
@@ -17,7 +17,7 @@ export default {
 
 const Template: ComponentStory<typeof DaoCreateConfigReviewCard> = (args) => {
   const { watch } = useForm<NewDao>({
-    defaultValues: DefaultNewDao,
+    defaultValues: makeDefaultNewDao(),
     mode: 'onChange',
   })
 


### PR DESCRIPTION
The default new DAO object used in the form for creating a new DAO depends on proposal and voting module adapters being loaded. It is currently defined as a constant and exported, which allows cyclic dependency issues to manifest. This PR avoids this by changing it into a maker function, which lazily evaluates only when needed.

This is a workaround because we have many complex interrelated systems, and not all imports are specific enough to avoid this situation. After the large v2 restructure, all explicit cyclic dependencies were solved by creating a types package and merging the stateful packages into one. However, cyclic dependencies can be created by importing from a folder's index file, since index files group together a bunch of files.

I believe it is better to avoid using dependencies in the root of files (e.g. exporting a constant which depends on another exported constant, like `DefaultNewDao`) as much as possible to avoid these situations, so that we don't have to police import statements as heavily. Policing import statements too much will lead to tedious PR reviews and slow down development.