### PR TITLE
use pfpk address display if showing a disabled address input.

### DIFF
--- a/packages/stateless/components/inputs/AddressInput.tsx
+++ b/packages/stateless/components/inputs/AddressInput.tsx
@@ -8,8 +8,11 @@ import {
   Path,
   UseFormRegister,
   Validate,
+  useFormContext,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+
+import { ProfileDisplay } from '@dao-dao/stateful'
 
 export interface AddressInputProps<
   FV extends FieldValues,
@@ -52,33 +55,41 @@ export const AddressInput = <
 
   const Icon = iconType === 'wallet' ? Wallet : Code
 
-  return (
-    <div
-      className={clsx(
-        'secondary-text flex items-center gap-2 rounded-md bg-transparent py-3 px-4 font-mono text-sm ring-1 transition focus-within:outline-none focus-within:ring-2',
-        error
-          ? 'ring-border-interactive-error'
-          : 'ring-border-primary focus:ring-border-interactive-focus',
-        containerClassName
-      )}
-    >
-      <Icon className="!h-5 !w-5" />
-      <input
+  // 🫡
+  const { watch } = useFormContext()
+  const self = watch(fieldName)
+
+  if (!disabled) {
+    return (
+      <div
         className={clsx(
-          'ring-none body-text w-full border-none bg-transparent outline-none',
-          className
+          'secondary-text flex items-center gap-2 rounded-md bg-transparent py-3 px-4 font-mono text-sm ring-1 transition focus-within:outline-none focus-within:ring-2',
+          error
+            ? 'ring-border-interactive-error'
+            : 'ring-border-primary focus:ring-border-interactive-focus',
+          containerClassName
         )}
-        disabled={disabled}
-        placeholder={t('form.address')}
-        type="text"
-        {...rest}
-        {...register(fieldName, {
-          required: required && 'Required',
-          validate,
-          onChange,
-        })}
-      />
-      {rightNode}
-    </div>
-  )
+      >
+        <Icon className="!h-5 !w-5" />
+        <input
+          className={clsx(
+            'ring-none body-text w-full border-none bg-transparent outline-none',
+            className
+          )}
+          disabled={disabled}
+          placeholder={t('form.address')}
+          type="text"
+          {...rest}
+          {...register(fieldName, {
+            required: required && 'Required',
+            validate,
+            onChange,
+          })}
+        />
+        {rightNode}
+      </div>
+    )
+  } else {
+    return <ProfileDisplay address={self} />
+  }
 }


### PR DESCRIPTION
if we're rendering a disabled `AddressInput` display the addresses' pfpk profile.

if the address has a pfpk profile:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/30676292/205212083-1fc1fc70-1479-49ee-aa93-3b957aaa6474.png">

if the address has no pfpk profile:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/30676292/205211880-c9a874db-2d3d-4388-b278-74d695a79d4e.png">
