### PR TITLE
Show profiles when displaying address inputs 🌞

### DIFF
--- a/packages/stateful/actions/actions/ManageSubDaos.tsx
+++ b/packages/stateful/actions/actions/ManageSubDaos.tsx
@@ -15,6 +15,7 @@ import {
 } from '@dao-dao/types'
 import { makeWasmMessage } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../components'
 import {
   ManageSubDaosData,
   ManageSubDaosComponent as StatelessManageSubDaosComponent,
@@ -106,6 +107,7 @@ export const makeManageSubDaosAction: ActionMaker<ManageSubDaosData> = ({
             address,
             name,
           })),
+          ProfileDisplay,
         }}
       />
     )

--- a/packages/stateful/actions/actions/Spend.tsx
+++ b/packages/stateful/actions/actions/Spend.tsx
@@ -31,7 +31,7 @@ import {
   nativeTokenDecimals,
 } from '@dao-dao/utils'
 
-import { SuspenseLoader } from '../../components'
+import { ProfileDisplay, SuspenseLoader } from '../../components'
 import { useCw20GovernanceTokenInfoResponseIfExists } from '../../voting-module-adapter'
 import {
   SpendData,
@@ -113,6 +113,7 @@ export const makeSpendAction: ActionMaker<SpendData> = ({
               ? []
               : nativeBalancesLoadable.data,
             cw20Balances: cw20LoadingBalances ?? [],
+            ProfileDisplay: ProfileDisplay,
           }}
         />
       </SuspenseLoader>

--- a/packages/stateful/actions/components/ManageSubDaos.stories.tsx
+++ b/packages/stateful/actions/components/ManageSubDaos.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 
 import { ReactHookFormDecorator } from '@dao-dao/storybook/decorators'
 
+import { ProfileDisplay } from '../../components'
 import { ManageSubDaosComponent } from './ManageSubDaos'
 
 export default {
@@ -25,5 +26,6 @@ Default.args = {
   errors: {},
   options: {
     currentSubDaos: [],
+    ProfileDisplay: ProfileDisplay,
   },
 }

--- a/packages/stateful/actions/components/ManageSubDaos.tsx
+++ b/packages/stateful/actions/components/ManageSubDaos.tsx
@@ -1,4 +1,5 @@
 import { Add, Close } from '@mui/icons-material'
+import { ComponentType } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -11,6 +12,7 @@ import {
   InputErrorMessage,
   InputLabel,
 } from '@dao-dao/stateless'
+import { StatefulProfileDisplayProps } from '@dao-dao/types'
 import { ActionComponent } from '@dao-dao/types/actions'
 import { SubDao } from '@dao-dao/types/contracts/CwdCore.v2'
 import { validateContractAddress, validateRequired } from '@dao-dao/utils'
@@ -27,6 +29,8 @@ export interface ManageSubDaosOptions {
     name: string
     address: string
   }[]
+  // Used to render pfpk or DAO profiles when selecting addresses.
+  ProfileDisplay?: ComponentType<StatefulProfileDisplayProps>
 }
 
 export const ManageSubDaosComponent: ActionComponent<ManageSubDaosOptions> = ({
@@ -34,7 +38,7 @@ export const ManageSubDaosComponent: ActionComponent<ManageSubDaosOptions> = ({
   onRemove,
   errors,
   isCreating,
-  options: { currentSubDaos },
+  options: { currentSubDaos, ProfileDisplay },
 }) => {
   const { t } = useTranslation()
   const { register, watch, control } = useFormContext<ManageSubDaosData>()
@@ -68,6 +72,7 @@ export const ManageSubDaosComponent: ActionComponent<ManageSubDaosOptions> = ({
           <div key={id} className="flex flex-row items-center gap-2">
             <div className="grow">
               <AddressInput
+                ProfileDisplay={ProfileDisplay}
                 disabled={!isCreating}
                 error={errors?.toAdd?.[index]?.addr}
                 fieldName={

--- a/packages/stateful/actions/components/Spend.stories.tsx
+++ b/packages/stateful/actions/components/Spend.stories.tsx
@@ -7,6 +7,7 @@ import {
 import { ActionOptionsContextType, ContractVersion } from '@dao-dao/types'
 import { NATIVE_DENOM } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../components'
 import { SpendComponent, SpendData } from './Spend'
 
 export default {
@@ -46,6 +47,7 @@ Default.args = {
         amount: '46252349169321',
       },
     ],
+    ProfileDisplay: ProfileDisplay,
     cw20Balances: [
       {
         address: 'cw20_1',

--- a/packages/stateful/actions/components/Spend.tsx
+++ b/packages/stateful/actions/components/Spend.tsx
@@ -3,7 +3,7 @@ import {
   ArrowRightAltRounded,
   SubdirectoryArrowRightRounded,
 } from '@mui/icons-material'
-import { useCallback, useEffect, useMemo } from 'react'
+import { ComponentType, useCallback, useEffect, useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -14,6 +14,7 @@ import {
   NumberInput,
   SelectInput,
 } from '@dao-dao/stateless'
+import { StatefulProfileDisplayProps } from '@dao-dao/types'
 import {
   ActionComponent,
   ActionOptionsContextType,
@@ -46,6 +47,8 @@ export interface SpendOptions {
     balance: string
     info: TokenInfoResponse
   }[]
+  // Used to render pfpk or DAO profiles when selecting addresses.
+  ProfileDisplay?: ComponentType<StatefulProfileDisplayProps>
 }
 
 export const SpendComponent: ActionComponent<SpendOptions> = ({
@@ -53,7 +56,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
   onRemove,
   errors,
   isCreating,
-  options: { nativeBalances, cw20Balances },
+  options: { nativeBalances, cw20Balances, ProfileDisplay },
 }) => {
   const { t } = useTranslation()
   const { register, watch, setValue, setError, clearErrors } = useFormContext()
@@ -228,6 +231,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
           </div>
 
           <AddressInput
+            ProfileDisplay={ProfileDisplay}
             containerClassName="grow"
             disabled={!isCreating}
             error={errors?.to}

--- a/packages/stateful/actions/components/token_swap/InstantiateTokenSwap.tsx
+++ b/packages/stateful/actions/components/token_swap/InstantiateTokenSwap.tsx
@@ -182,16 +182,10 @@ export const InstantiateTokenSwap: ActionComponent<
         <InputLabel name={t('form.counterparty')} />
 
         <AddressInput
+          ProfileDisplay={ProfileDisplay}
           error={errors?.counterparty?.address}
           fieldName={fieldNamePrefix + 'counterparty.address'}
           register={register}
-          rightNode={
-            counterpartyAddressValid ? (
-              <div className="pl-4">
-                <ProfileDisplay address={counterparty.address} />
-              </div>
-            ) : undefined
-          }
           validation={[validateRequired, validateAddress]}
         />
 

--- a/packages/stateful/components/ProfileDisplay.tsx
+++ b/packages/stateful/components/ProfileDisplay.tsx
@@ -1,11 +1,9 @@
 import { ProfileDisplay as StatelessProfileDisplay } from '@dao-dao/stateless'
-import { ProfileDisplayProps } from '@dao-dao/types'
+import { StatefulProfileDisplayProps } from '@dao-dao/types'
 
 import { useProfile } from '../hooks'
 
-export const ProfileDisplay = (
-  props: Omit<ProfileDisplayProps, 'loadingProfile'>
-) => {
+export const ProfileDisplay = (props: StatefulProfileDisplayProps) => {
   const profile = useProfile({
     address: props.address,
   })

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/MintComponent.stories.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/MintComponent.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { makeReactHookFormDecorator } from '@dao-dao/storybook'
 
 import { MintData } from '.'
+import { ProfileDisplay } from '../../../../../components'
 import { MintComponent } from './MintComponent'
 
 export default {
@@ -30,5 +31,6 @@ Default.args = {
   isCreating: true,
   options: {
     govTokenSymbol: 'GOV',
+    ProfileDisplay: ProfileDisplay,
   },
 }

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/MintComponent.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/MintComponent.tsx
@@ -2,6 +2,7 @@ import {
   ArrowRightAltRounded,
   SubdirectoryArrowRightRounded,
 } from '@mui/icons-material'
+import { ComponentType } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -11,7 +12,7 @@ import {
   InputErrorMessage,
   NumberInput,
 } from '@dao-dao/stateless'
-import { ActionComponent } from '@dao-dao/types'
+import { ActionComponent, StatefulProfileDisplayProps } from '@dao-dao/types'
 import {
   validateAddress,
   validatePositive,
@@ -22,6 +23,8 @@ import { ActionCard } from '../../../../../actions'
 
 export interface MintOptions {
   govTokenSymbol: string
+  // Used to display the profile of the address receiving minted tokens.
+  ProfileDisplay: ComponentType<StatefulProfileDisplayProps>
 }
 
 export const MintComponent: ActionComponent<MintOptions> = ({
@@ -29,7 +32,7 @@ export const MintComponent: ActionComponent<MintOptions> = ({
   onRemove,
   errors,
   isCreating,
-  options: { govTokenSymbol },
+  options: { govTokenSymbol, ProfileDisplay },
 }) => {
   const { t } = useTranslation()
   const { register, watch, setValue } = useFormContext()
@@ -68,6 +71,7 @@ export const MintComponent: ActionComponent<MintOptions> = ({
           </div>
 
           <AddressInput
+            ProfileDisplay={ProfileDisplay}
             containerClassName="grow"
             disabled={!isCreating}
             error={errors?.to}

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/index.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw20Staked/actions/makeMintAction/index.tsx
@@ -16,6 +16,7 @@ import {
   makeMintMessage,
 } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../../../../components'
 import { useGovernanceTokenInfo } from '../../hooks'
 import { MintComponent as StatelessMintComponent } from './MintComponent'
 
@@ -85,6 +86,7 @@ const Component: ActionComponent = (props) => {
       {...props}
       options={{
         govTokenSymbol: governanceTokenInfo.symbol ?? 'gov tokens',
+        ProfileDisplay: ProfileDisplay,
       }}
     />
   )

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/ManageMembersComponent.stories.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/ManageMembersComponent.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 
 import { makeReactHookFormDecorator } from '@dao-dao/storybook'
 
+import { ProfileDisplay } from '../../../../../components'
 import {
   ManageMembersComponent,
   ManageMembersData,
@@ -32,5 +33,6 @@ Default.args = {
   isCreating: true,
   options: {
     currentMembers: ['member1', 'member2'],
+    ProfileDisplay: ProfileDisplay,
   },
 }

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/ManageMembersComponent.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/ManageMembersComponent.tsx
@@ -4,6 +4,7 @@ import {
   Close,
   SubdirectoryArrowRightRounded,
 } from '@mui/icons-material'
+import { ComponentType } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
@@ -16,6 +17,7 @@ import {
   NumberInput,
   PeopleEmoji,
 } from '@dao-dao/stateless'
+import { StatefulProfileDisplayProps } from '@dao-dao/types'
 import { ActionComponent } from '@dao-dao/types/actions'
 import { Member } from '@dao-dao/types/contracts/Cw4Group'
 import {
@@ -33,6 +35,8 @@ export interface ManageMembersData {
 
 export interface ManageMembersOptions {
   currentMembers: string[]
+  // Used to show the profiles of the members being updated.
+  ProfileDisplay: ComponentType<StatefulProfileDisplayProps>
 }
 
 export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
@@ -40,7 +44,7 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
   onRemove,
   errors,
   isCreating,
-  options: { currentMembers },
+  options: { currentMembers, ProfileDisplay },
 }) => {
   const { t } = useTranslation()
   const { register, setValue, watch, control } =
@@ -116,6 +120,7 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
 
                   <div className="flex grow flex-col">
                     <AddressInput
+                      ProfileDisplay={ProfileDisplay}
                       containerClassName="h-full"
                       disabled={!isCreating}
                       error={errors?.toAdd?.[index]?.addr}
@@ -170,6 +175,7 @@ export const ManageMembersComponent: ActionComponent<ManageMembersOptions> = ({
           >
             <div className="grow">
               <AddressInput
+                ProfileDisplay={ProfileDisplay}
                 disabled={!isCreating}
                 error={errors?.toRemove?.[index]?.addr}
                 fieldName={

--- a/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/index.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/CwdVotingCw4/actions/makeManageMembersAction/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@dao-dao/types/actions'
 import { makeWasmMessage } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../../../../components'
 import { useVotingModule as useCw4VotingModule } from '../../hooks/useVotingModule'
 import {
   ManageMembersData,
@@ -95,6 +96,7 @@ export const makeManageMembersAction: ActionMaker<ManageMembersData> = ({
         {...props}
         options={{
           currentMembers: members.map(({ addr }) => addr),
+          ProfileDisplay: ProfileDisplay,
         }}
       />
     )

--- a/packages/stateless/components/inputs/AddressInput.stories.tsx
+++ b/packages/stateless/components/inputs/AddressInput.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { useFormContext } from 'react-hook-form'
 
+import { ProfileDisplay } from '@dao-dao/stateful'
 import { ReactHookFormDecorator } from '@dao-dao/storybook/decorators'
 
 import { AddressInput } from './AddressInput'
@@ -10,12 +12,15 @@ export default {
   decorators: [ReactHookFormDecorator],
 } as ComponentMeta<typeof AddressInput>
 
-const Template: ComponentStory<typeof AddressInput> = (args) => (
-  <AddressInput {...args} />
-)
+const Template: ComponentStory<typeof AddressInput> = (args) => {
+  const { register } = useFormContext()
+  args.register = register
+  return <AddressInput {...args} />
+}
 
 export const Default = Template.bind({})
 Default.args = {
   fieldName: 'fieldName' as any,
   placeholder: 'juno...',
+  ProfileDisplay,
 }

--- a/packages/stateless/components/inputs/AddressInput.tsx
+++ b/packages/stateless/components/inputs/AddressInput.tsx
@@ -1,6 +1,10 @@
 import { Code, Wallet } from '@mui/icons-material'
 import clsx from 'clsx'
-import { ChangeEventHandler, ComponentPropsWithoutRef, ReactNode } from 'react'
+import {
+  ChangeEventHandler,
+  ComponentPropsWithoutRef,
+  ComponentType,
+} from 'react'
 import {
   FieldError,
   FieldPathValue,
@@ -8,8 +12,12 @@ import {
   Path,
   UseFormRegister,
   Validate,
+  useFormContext,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+
+import { StatefulProfileDisplayProps } from '@dao-dao/types'
+import { validateAddress } from '@dao-dao/utils'
 
 export interface AddressInputProps<
   FV extends FieldValues,
@@ -24,7 +32,7 @@ export interface AddressInputProps<
   required?: boolean
   containerClassName?: string
   iconType?: 'wallet' | 'contract'
-  rightNode?: ReactNode
+  ProfileDisplay?: ComponentType<StatefulProfileDisplayProps>
 }
 
 export const AddressInput = <
@@ -41,7 +49,7 @@ export const AddressInput = <
   className,
   containerClassName,
   iconType = 'wallet',
-  rightNode,
+  ProfileDisplay,
   ...rest
 }: AddressInputProps<FV, FieldName>) => {
   const { t } = useTranslation()
@@ -51,6 +59,9 @@ export const AddressInput = <
   )
 
   const Icon = iconType === 'wallet' ? Wallet : Code
+
+  const { watch } = useFormContext()
+  const self = watch(fieldName)
 
   return (
     <div
@@ -62,23 +73,31 @@ export const AddressInput = <
         containerClassName
       )}
     >
-      <Icon className="!h-5 !w-5" />
-      <input
-        className={clsx(
-          'ring-none body-text w-full border-none bg-transparent outline-none',
-          className
-        )}
-        disabled={disabled}
-        placeholder={t('form.address')}
-        type="text"
-        {...rest}
-        {...register(fieldName, {
-          required: required && 'Required',
-          validate,
-          onChange,
-        })}
-      />
-      {rightNode}
+      {disabled || (
+        <>
+          <Icon className="!h-5 !w-5" />
+          <input
+            className={clsx(
+              'ring-none body-text w-full border-none bg-transparent outline-none',
+              className
+            )}
+            disabled={disabled}
+            placeholder={t('form.address')}
+            type="text"
+            {...rest}
+            {...register(fieldName, {
+              required: required && 'Required',
+              validate,
+              onChange,
+            })}
+          />
+        </>
+      )}
+      {ProfileDisplay && self && validateAddress(self) === true && (
+        <div className={clsx(disabled || 'pl-4')}>
+          <ProfileDisplay address={self} />
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/stateless/components/inputs/AddressInput.tsx
+++ b/packages/stateless/components/inputs/AddressInput.tsx
@@ -63,6 +63,8 @@ export const AddressInput = <
   const { watch } = useFormContext()
   const self = watch(fieldName)
 
+  const showProfile = ProfileDisplay && !!self && validateAddress(self) === true
+
   return (
     <div
       className={clsx(
@@ -73,7 +75,7 @@ export const AddressInput = <
         containerClassName
       )}
     >
-      {disabled || (
+      {(disabled && showProfile) || (
         <>
           <Icon className="!h-5 !w-5" />
           <input
@@ -93,7 +95,7 @@ export const AddressInput = <
           />
         </>
       )}
-      {ProfileDisplay && self && validateAddress(self) === true && (
+      {showProfile && (
         <div className={clsx(disabled || 'pl-4')}>
           <ProfileDisplay address={self} />
         </div>

--- a/packages/storybook/.env
+++ b/packages/storybook/.env
@@ -11,7 +11,7 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_SITE_IMAGE=/social.jpg
 NEXT_PUBLIC_WC_ICON_PATH=/walletconnect.png
 NEXT_PUBLIC_DAO_DAO_VERSION=$npm_package_version
-NEXT_PUBLIC_CHAIN_TXN_URL_PREFIX=https://testnet.ping.pub/juno/tx/
+NEXT_PUBLIC_CHAIN_TXN_URL_PREFIX=https://testnet.mintscan.io/juno-testnet/txs/
 NEXT_PUBLIC_LEGACY_URL_PREFIX=https://daodao.zone
 
 # Contract Names
@@ -19,13 +19,17 @@ NEXT_PUBLIC_CWCOREV1_CONTRACT_NAME=cw-core
 NEXT_PUBLIC_CWDCOREV2_CONTRACT_NAME=cwd-core
 
 # Contract Addresses
-NEXT_PUBLIC_V1_FACTORY_CONTRACT_ADDRESS=juno1a4ups3462sscvdk5ydw3mf56690n6n3cwaju0jllh52cnes4mdhspl5gp6
-#NEXT_PUBLIC_USDC_SWAP_ADDRESS=
+NEXT_PUBLIC_V1_FACTORY_CONTRACT_ADDRESS=juno143quaa25ynh6j5chhqh8w6lj647l4kpu5r6aqxvzul8du0mwyvns2g6u45
 
-# Pool info
+# Junoswap mainnet info
 NEXT_PUBLIC_POOLS_LIST_URL=https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/pools_list.json
+NEXT_PUBLIC_USDC_SWAP_ADDRESS=juno1ctsmp54v79x7ea970zejlyws50cj9pkrmw49x46085fn80znjmpqz2n642
 
-# Search configuration.
-NEXT_PUBLIC_SEARCH_URL=https://dao-search.withoutdoing.com
-NEXT_PUBLIC_SEARCH_API_KEY=geDQZEly47de425b96a1ae8ee53917e75fc8ea27b09afb4dbaec202b91e6ac59f341c568
-NEXT_PUBLIC_SEARCH_INDEX=v1-testnet-daos
+# Stargaze
+NEXT_PUBLIC_STARGAZE_RPC_ENDPOINT=https://rpc.stargaze-apis.com
+NEXT_PUBLIC_STARGAZE_REST_ENDPOINT=https://rest.stargaze-apis.com
+NEXT_PUBLIC_STARGAZE_PROFILE_API_TEMPLATE=https://nft-api.stargaze-apis.com/api/v1beta/profile/ADDRESS/nfts
+NEXT_PUBLIC_STARGAZE_URL_BASE=https://stargaze.zone
+
+# Wallet profiles
+NEXT_PUBLIC_PFPK_API_BASE=https://pfpk.daodao.zone

--- a/packages/types/stateless/ProfileDisplay.tsx
+++ b/packages/types/stateless/ProfileDisplay.tsx
@@ -10,3 +10,8 @@ export interface ProfileDisplayProps {
   copyToClipboardProps?: Partial<Omit<CopyToClipboardProps, 'label' | 'value'>>
   size?: 'default' | 'lg'
 }
+
+export type StatefulProfileDisplayProps = Omit<
+  ProfileDisplayProps,
+  'loadingProfile'
+>


### PR DESCRIPTION
while editing an address, shows a preview of the profile of the address. while viewing an address input which is disabled, a profile is shown.

for example, while viewing a proposal to manage multisig membership:

<img width="626" alt="image" src="https://user-images.githubusercontent.com/30676292/205417733-6c00474e-e693-4709-94d1-3446357ca9fe.png">

and while editing an address input:

<img width="406" alt="image" src="https://user-images.githubusercontent.com/30676292/205417806-77e250a3-c752-4d36-93ac-6c34e0f0b0f5.png">