### PR TITLE
Moved average color fetch to recoil selector to take advantage of cache

### DIFF
--- a/packages/state/recoil/selectors/index.ts
+++ b/packages/state/recoil/selectors/index.ts
@@ -2,6 +2,7 @@ export * from './contracts'
 
 export * from './chain'
 export * from './contract'
+export * from './misc'
 export * from './nft'
 export * from './pools'
 export * from './price'

--- a/packages/state/recoil/selectors/misc.ts
+++ b/packages/state/recoil/selectors/misc.ts
@@ -1,0 +1,23 @@
+import { selectorFamily } from 'recoil'
+
+export const averageColorSelector = selectorFamily({
+  key: 'averageColor',
+  get: (url: string) => async () => {
+    if (!url || url.startsWith('http://localhost')) {
+      return undefined
+    }
+
+    try {
+      const response = await fetch(`https://fac.withoutdoing.com/${url}`)
+      const color = await response.text()
+      // Validate color format.
+      if (!color.startsWith('#')) {
+        return undefined
+      }
+
+      return color
+    } catch (err) {
+      console.error(err)
+    }
+  },
+})

--- a/packages/stateless/components/profile/ProfileCardWrapper.tsx
+++ b/packages/stateless/components/profile/ProfileCardWrapper.tsx
@@ -1,12 +1,14 @@
 import { Check, Close, Edit } from '@mui/icons-material'
 import clsx from 'clsx'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
 
+import { averageColorSelector } from '@dao-dao/state/recoil'
 import { ProfileCardWrapperProps } from '@dao-dao/types/stateless/ProfileCardWrapper'
 import { formatDate, processError } from '@dao-dao/utils'
 
+import { useCachedLoadable } from '../../hooks'
 import { Button } from '../buttons'
 import { CornerGradient } from '../CornerGradient'
 import { IconButton } from '../icon_buttons'
@@ -28,32 +30,19 @@ export const ProfileCardWrapper = ({
 }: ProfileCardWrapperProps) => {
   const { t } = useTranslation()
 
-  const [averageImgColor, setAverageImgColor] = useState<string>()
-  // Get average color of image URL.
-  useEffect(() => {
-    // Only need this in compact mode.
-    if (!compact || walletProfile.loading) {
-      return
-    }
-
-    const absoluteUrl = new URL(walletProfile.data.imageUrl, document.baseURI)
-      .href
-    fetch(`https://fac.withoutdoing.com/${absoluteUrl}`)
-      .then((response) => response.text())
-      // Only set color if appears to be valid color string.
-      .then((value) => {
-        const color = value.trim()
-        if (!color.startsWith('#')) {
-          return
-        }
-
-        setAverageImgColor(
-          color +
-            // If in #RRGGBB format, add ~20% opacity.
-            (color.length === 7 ? '33' : '')
-        )
-      })
-  }, [compact, walletProfile])
+  // Get average color of image URL if in compact mode.
+  const averageImgColorLoadable = useCachedLoadable(
+    !compact || walletProfile.loading
+      ? undefined
+      : averageColorSelector(walletProfile.data.imageUrl)
+  )
+  const averageImgColor =
+    averageImgColorLoadable.state === 'hasValue' &&
+    averageImgColorLoadable.contents
+      ? // If in #RRGGBB format, add ~20% opacity (0x33 = 51, 51/255 = 0.2).
+        averageImgColorLoadable.contents +
+        (averageImgColorLoadable.contents.length === 7 ? '33' : '')
+      : undefined
 
   const canEdit = !walletProfile.loading && walletProfile.data.nonce >= 0
 


### PR DESCRIPTION
Average color was being fetched in `useEffect`s which triggered on every render, constantly asking for the same request. This moves that request into a Recoil selector so it caches based on input.