### PR TITLE
Trim average color API response to fix profile card accent opacity

### DIFF
--- a/packages/state/recoil/selectors/misc.ts
+++ b/packages/state/recoil/selectors/misc.ts
@@ -14,7 +14,8 @@ export const averageColorSelector = selectorFamily({
       const response = await fetch(
         FAST_AVERAGE_COLOR_API_TEMPLATE.replace('URL', url)
       )
-      const color = await response.text()
+      // Trim newline at the end.
+      const color = (await response.text()).trim()
       // Validate color format.
       if (!color.startsWith('#')) {
         return undefined


### PR DESCRIPTION
The average color API returns text with a newline at the end. This was disrupting the logic used in compact profile cards, such as the one displayed on the proposal page, when adding opacity to the color, since the logic checks to ensure the length of the string is 7 to validate #RRGGBB format before making it #RRGGBBAA.

This trims the API response so the selector just returns the color string, as one would expect, and fixes the opacity logic.