### PR TITLE
Remove established from profile cards

### DIFF
--- a/apps/dapp/pages/dao/[address]/index.tsx
+++ b/apps/dapp/pages/dao/[address]/index.tsx
@@ -224,7 +224,6 @@ const InnerDaoHome = () => {
           ) : (
             <ProfileNotMemberCard
               daoName={daoInfo.name}
-              established={new Date()}
               membershipInfo={
                 <ProfileCardMemberInfo
                   deposit={

--- a/packages/stateless/components/profile/ProfileCardWrapper.tsx
+++ b/packages/stateless/components/profile/ProfileCardWrapper.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 
 import { averageColorSelector } from '@dao-dao/state/recoil'
 import { ProfileCardWrapperProps } from '@dao-dao/types/stateless/ProfileCardWrapper'
-import { formatDate, processError } from '@dao-dao/utils'
+import { processError } from '@dao-dao/utils'
 
 import { useCachedLoadable } from '../../hooks'
 import { Button } from '../buttons'
@@ -23,13 +23,10 @@ export const ProfileCardWrapper = ({
   walletProfile,
   showUpdateProfileNft,
   updateProfileName,
-  established,
-  compact,
+  compact = false,
   underHeaderComponent,
   childContainerClassName,
 }: ProfileCardWrapperProps) => {
-  const { t } = useTranslation()
-
   // Get average color of image URL if in compact mode.
   const averageImgColorLoadable = useCachedLoadable(
     !compact || walletProfile.loading
@@ -93,11 +90,6 @@ export const ProfileCardWrapper = ({
               updateProfileName={updateProfileName}
               walletProfile={walletProfile}
             />
-            {established && (
-              <div className="caption-text -mt-3 mb-5 font-mono">
-                {t('info.establishedAbbr')} {formatDate(established)}
-              </div>
-            )}
             {underHeaderComponent}
           </div>
         )}

--- a/packages/stateless/components/profile/ProfileHomeCard.stories.tsx
+++ b/packages/stateless/components/profile/ProfileHomeCard.stories.tsx
@@ -27,7 +27,6 @@ Default.args = {
       nft: null,
     },
   },
-  established: new Date(),
   tokenSymbol: 'JUNO',
   inboxProposalCount: 5,
   lazyData: {

--- a/packages/stateless/components/profile/ProfileHomeCard.tsx
+++ b/packages/stateless/components/profile/ProfileHomeCard.tsx
@@ -31,7 +31,6 @@ export interface ProfileHomeCardProps
 }
 
 export const ProfileHomeCard = ({
-  established,
   tokenSymbol,
   tokenDecimals,
   inboxProposalCount,
@@ -44,7 +43,6 @@ export const ProfileHomeCard = ({
   return (
     <ProfileCardWrapper
       childContainerClassName="p-0"
-      established={established}
       underHeaderComponent={
         <div className="mt-3 grid grid-cols-[1fr_1px_1fr] items-center justify-items-center gap-2 self-stretch">
           <div className="flex flex-col items-stretch text-center">

--- a/packages/stateless/components/profile/ProfileMemberCard.stories.tsx
+++ b/packages/stateless/components/profile/ProfileMemberCard.stories.tsx
@@ -33,7 +33,6 @@ const makeProps = (
     },
   },
   openProposals: true,
-  established: new Date(),
   membershipInfo: (
     <ProfileCardMemberInfoTokens
       {...makeProfileCardMemberInfoTokensProps(...args)}

--- a/packages/stateless/components/profile/ProfileMemberCard.tsx
+++ b/packages/stateless/components/profile/ProfileMemberCard.tsx
@@ -33,7 +33,6 @@ export const ProfileMemberCard = ({
   loadingManaging,
   daoName,
   openProposals,
-  established,
   membershipInfo,
   ...wrapperProps
 }: ProfileMemberCardProps) => {
@@ -42,7 +41,6 @@ export const ProfileMemberCard = ({
   return (
     <ProfileCardWrapper
       childContainerClassName="p-0 border-t-0"
-      established={established}
       underHeaderComponent={<MembershipPill daoName={daoName} isMember />}
       {...wrapperProps}
     >

--- a/packages/stateless/components/profile/ProfileNotMemberCard.stories.tsx
+++ b/packages/stateless/components/profile/ProfileNotMemberCard.stories.tsx
@@ -29,7 +29,6 @@ Default.args = {
       nft: null,
     },
   },
-  established: new Date(),
   membershipInfo: (
     <ProfileCardMemberInfoTokens {...makeProfileCardMemberInfoTokensProps()} />
   ),

--- a/packages/stateless/components/profile/ProfileNotMemberCard.tsx
+++ b/packages/stateless/components/profile/ProfileNotMemberCard.tsx
@@ -10,20 +10,14 @@ import {
 export interface ProfileNotMemberCardProps
   extends Omit<
     ProfileCardWrapperProps,
-    | 'children'
-    | 'underHeaderComponent'
-    | 'childContainerClassName'
-    | 'established'
-    | 'compact'
+    'children' | 'underHeaderComponent' | 'childContainerClassName' | 'compact'
   > {
   daoName: string
-  established: Date
   membershipInfo: ReactNode
 }
 
 export const ProfileNotMemberCard = ({
   daoName,
-  established,
   membershipInfo,
   ...wrapperProps
 }: ProfileNotMemberCardProps) => {
@@ -31,7 +25,6 @@ export const ProfileNotMemberCard = ({
 
   return (
     <ProfileCardWrapper
-      established={established}
       underHeaderComponent={
         <MembershipPill daoName={daoName} isMember={false} />
       }

--- a/packages/types/stateless/ProfileCardWrapper.ts
+++ b/packages/types/stateless/ProfileCardWrapper.ts
@@ -10,13 +10,5 @@ export type ProfileCardWrapperProps = {
   updateProfileName: (name: string | null) => Promise<void>
   underHeaderComponent: ReactNode
   childContainerClassName?: string
-} & (
-  | {
-      established?: Date
-      compact?: false
-    }
-  | {
-      established?: never
-      compact: true
-    }
-)
+  compact?: boolean
+}


### PR DESCRIPTION
The v2 profile card designs contained an "established" date display, which we don't currently use. There isn't a clear use for this date, which indicates that it may not be a very meaningful piece of information. It could mean when you first joined a DAO, when you performed your first transaction, or when you first set your profile name.

This PR removes that code. No need to keep it in until we decide we want it.