### PR TITLE
Save latest proposal form state to localStorage

### DIFF
--- a/packages/state/recoil/atoms/proposals.ts
+++ b/packages/state/recoil/atoms/proposals.ts
@@ -32,6 +32,13 @@ export const proposalDraftsAtom = atomFamily<ProposalDraft[], string>({
   effects: [localStorageEffectJSON],
 })
 
+// Store latest proposal form state per DAO.
+export const latestProposalSaveAtom = atomFamily<any, string>({
+  key: 'latestProposalSave',
+  default: {},
+  effects: [localStorageEffectJSON],
+})
+
 // When set, shows proposal created modal with these props for the ProposalCard
 // shown.
 export const proposalCreatedCardPropsAtom = atom<


### PR DESCRIPTION
The Create DAO form automatically saves to the browser's local cache to prevent loss of data. Proposals don't have this; instead, they use drafts which let users save incomplete proposals for later.

This PR mimics the create DAO form's behavior of automatically saving the latest state, to prevent accidental data loss. It is scoped by DAO, so there will be a different latest save state per DAO. The save state will get cleared once the proposal is created.

Drafts still exist, though are a slightly different use case. It doesn't hurt to have both.