### PR TITLE
Add fallback for error in burn NFT action.

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -527,6 +527,7 @@
     "tierMemberGovTokenAllocationTooltip": "This member will receive {{tokens}} ${{tokenSymbol}} when the DAO is created.",
     "today": "today",
     "token": "token",
+    "tokenBurned": "NFT with ID {{tokenId}} has been burned.",
     "tokenDaoNotMemberInfoProposal": "You were not a member of {{daoName}} when this proposal was created, so you cannot vote on it. You will be able to vote on future proposals as long as you have ${{tokenSymbol}} staked at the time those proposals are created.",
     "tokenSwapDescription": "Create a new token swap that completes when both parties have paid their tokens or fund an existing one.",
     "tokenSwapExplanation": "To perform a token swap, one DAO must first create it, configuring the number of tokens each party must contribute. Then, both DAOs must add their funds. Once both DAOs have added their funds to the swap, the swap will be performed immediately.",

--- a/packages/stateful/actions/actions/nft/BurnNft.tsx
+++ b/packages/stateful/actions/actions/nft/BurnNft.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
-import { constSelector, useRecoilValue } from 'recoil'
+import { constSelector } from 'recoil'
 
 import { FireEmoji, useCachedLoadable } from '@dao-dao/stateless'
 import {
@@ -90,13 +90,21 @@ const Component: ActionComponent = (props) => {
         : constSelector([])
     )
   )
-  const nftInfo = useRecoilValue(
+  const nftInfoLoadable = useCachedLoadable(
     !!tokenId && !!collection
       ? nftCardInfoSelector({ chainId, collection, tokenId })
       : constSelector(undefined)
   )
 
-  return <BurnNft {...props} options={{ options, nftInfo }} />
+  return (
+    <BurnNft
+      {...props}
+      options={{
+        options,
+        nftInfo: loadableToLoadingDataWithError(nftInfoLoadable),
+      }}
+    />
+  )
 }
 
 export const makeBurnNftAction: ActionMaker<BurnNftData> = ({ t }) => ({

--- a/packages/stateful/actions/components/nft/BurnNft.stories.tsx
+++ b/packages/stateful/actions/components/nft/BurnNft.stories.tsx
@@ -44,7 +44,11 @@ Default.args = {
   onRemove: () => alert('remove'),
   errors: {},
   options: {
-    nftInfo: selected,
+    nftInfo: {
+      loading: false,
+      errored: false,
+      data: selected,
+    },
     options: {
       loading: false,
       errored: false,

--- a/packages/stateful/actions/components/nft/types.ts
+++ b/packages/stateful/actions/components/nft/types.ts
@@ -64,8 +64,8 @@ export interface TransferNftOptions {
 export interface BurnNftOptions {
   // The set of NFTs that may be burned as part of this action.
   options: LoadingDataWithError<NftCardInfo[]>
-  // Information about the NFT currently selected.
-  nftInfo: NftCardInfo | undefined
+  // Information about the NFT currently selected. If errored, it may be burnt.
+  nftInfo: LoadingDataWithError<NftCardInfo | undefined>
 }
 
 export interface InstantiateNftCollectionOptions {


### PR DESCRIPTION
Right now, when you execute a proposal with a burn NFT action, the action displays an error since the token no longer exists:
![Screenshot 2022-12-20 at 11 55 46 AM](https://user-images.githubusercontent.com/6721426/208755017-1cbc51c6-c580-401c-bbf8-5d253a2f8b34.png)

When you burn an NFT, the data no longer exists in the collection, so we cannot access its metadata/image.

This PR fixes the error by replacing it with a fallback sentence:
![Screenshot 2022-12-20 at 11 56 37 AM](https://user-images.githubusercontent.com/6721426/208755164-e04284a9-cab7-43da-ae9f-e0323dcc94bf.png)
