### PR TITLE
Added env variable to disable actions

### DIFF
--- a/apps/dapp/.env.development
+++ b/apps/dapp/.env.development
@@ -38,3 +38,6 @@ NEXT_PUBLIC_RETROACTIVE_COMPENSATION_API_BASE=https://retroactive-compensation-c
 
 NEXT_PUBLIC_FAST_AVERAGE_COLOR_API_TEMPLATE=https://fac.withoutdoing.com/URL
 NEXT_PUBLIC_IPFS_GATEWAY_TEMPLATE=https://nftstorage.link/ipfs/PATH
+
+# Comma separated list of action keys to disable.
+NEXT_PUBLIC_DISABLED_ACTIONS=

--- a/apps/dapp/.env.localhost
+++ b/apps/dapp/.env.localhost
@@ -33,3 +33,6 @@ NEXT_PUBLIC_RETROACTIVE_COMPENSATION_API_BASE=https://retroactive-compensation-c
 
 NEXT_PUBLIC_FAST_AVERAGE_COLOR_API_TEMPLATE=https://fac.withoutdoing.com/URL
 NEXT_PUBLIC_IPFS_GATEWAY_TEMPLATE=https://nftstorage.link/ipfs/PATH
+
+# Comma separated list of action keys to disable.
+NEXT_PUBLIC_DISABLED_ACTIONS=

--- a/apps/dapp/.env.mainnet
+++ b/apps/dapp/.env.mainnet
@@ -38,3 +38,6 @@ NEXT_PUBLIC_RETROACTIVE_COMPENSATION_API_BASE=https://retroactive-compensation-c
 
 NEXT_PUBLIC_FAST_AVERAGE_COLOR_API_TEMPLATE=https://fac.withoutdoing.com/URL
 NEXT_PUBLIC_IPFS_GATEWAY_TEMPLATE=https://nftstorage.link/ipfs/PATH
+
+# Comma separated list of action keys to disable.
+NEXT_PUBLIC_DISABLED_ACTIONS=

--- a/packages/stateful/actions/actions/index.tsx
+++ b/packages/stateful/actions/actions/index.tsx
@@ -1,4 +1,5 @@
 import { Action, ActionOptions } from '@dao-dao/types/actions'
+import { DISABLED_ACTIONS } from '@dao-dao/utils'
 
 import { makeAddCw20Action } from './AddCw20'
 import { makeAddCw721Action } from './AddCw721'
@@ -50,11 +51,15 @@ export const getActions = (options: ActionOptions): Action[] => {
     makeRemoveItemAction,
   ]
 
-  return (
-    actionMakers
-      .map((makeAction) => makeAction(options))
-      // Remove null values, since maker functions return null if they don't
-      // make sense in the context (like a DAO-only action in a wallet context).
-      .filter(Boolean) as Action[]
-  )
+  return actionMakers
+    .map((makeAction) => makeAction(options))
+    .filter(
+      (action): action is Action =>
+        // Remove null values, since maker functions return null if they don't
+        // make sense in the context (like a DAO-only action in a wallet
+        // context).
+        action !== null &&
+        // Remove disabled actions.
+        !DISABLED_ACTIONS.includes(action.key)
+    )
 }

--- a/packages/utils/constants/index.ts
+++ b/packages/utils/constants/index.ts
@@ -119,3 +119,7 @@ export const FAST_AVERAGE_COLOR_API_TEMPLATE = process.env
   .NEXT_PUBLIC_FAST_AVERAGE_COLOR_API_TEMPLATE as string
 export const IPFS_GATEWAY_TEMPLATE = process.env
   .NEXT_PUBLIC_IPFS_GATEWAY_TEMPLATE as string
+
+export const DISABLED_ACTIONS = (
+  process.env.NEXT_PUBLIC_DISABLED_ACTIONS || ''
+).split(',')


### PR DESCRIPTION
This PR adds a `NEXT_PUBLIC_DISABLED_ACTIONS` environment variable, a comma-separated list of action keys to disable.