### PR TITLE
Make space for Discord icon in header.

### DIFF
--- a/packages/stateless/components/layout/PageHeader.tsx
+++ b/packages/stateless/components/layout/PageHeader.tsx
@@ -75,7 +75,7 @@ export const PageHeader = ({
             // text instead of just its icon. On these larger views, add more
             // padding to compensate.
             (title || breadcrumbs) && {
-              'px-16 sm:px-28': true,
+              'px-24 sm:px-48': true,
               // Centered on small screen or if forceCenter is true. If not
               // centered, no left padding.
               'sm:!pl-0': !forceCenter,


### PR DESCRIPTION
This PR makes more space in the header by increasing the padding around the title; this is needed because we added an icon for the Discord Notifier feature.

<img width="735" alt="Screenshot 2023-01-08 at 6 00 06 PM" src="https://user-images.githubusercontent.com/6721426/211230673-640a23a0-bd2c-4155-83c0-016db24b6b13.png">
<img width="452" alt="Screenshot 2023-01-08 at 6 00 26 PM" src="https://user-images.githubusercontent.com/6721426/211230694-50c2619f-aa3c-4ef9-865b-0153af07b1cc.png">
