### PR TITLE
Fix error on creation.

### DIFF
--- a/packages/stateful/components/dao/CreateDaoForm.tsx
+++ b/packages/stateful/components/dao/CreateDaoForm.tsx
@@ -158,10 +158,8 @@ export const CreateDaoForm = ({
 
   // Debounce saving latest data to atom and thus localStorage every 10 seconds.
   useEffect(() => {
-    // If created DAO, clear saved data and don't update.
+    // If created DAO, don't update.
     if (daoCreatedCardProps) {
-      // Clear saved form data.
-      setNewDaoAtom(makeDefaultNewDao())
       return
     }
 


### PR DESCRIPTION
A `useEffect` was looping infinitely between when a DAO is created and when it navigates to the new DAO's page, which caused an error. This fixes that.