### PR TITLE
Only search DAOs with at least one proposal

### DIFF
--- a/apps/dapp/.env.development
+++ b/apps/dapp/.env.development
@@ -33,7 +33,7 @@ NEXT_PUBLIC_PFPK_API_BASE=https://pfpk.daodao.zone
 # Search
 NEXT_PUBLIC_SEARCH_HOST=https://search.daodao.zone
 NEXT_PUBLIC_SEARCH_API_KEY=613511c001942ea974f72dde06647428d1ae3f42cb13fcf71e88e4317d73f2cf
-NEXT_PUBLIC_SEARCH_DAOS_INDEX=daos
+NEXT_PUBLIC_SEARCH_DAOS_INDEX=testnet_daos
 
 # https://nft.storage/docs/#get-an-api-token
 NEXT_PUBLIC_NFT_STORAGE_API_KEY=

--- a/packages/state/indexer/search.ts
+++ b/packages/state/indexer/search.ts
@@ -34,12 +34,16 @@ export const searchDaos = async (
 
   const results = await index.search<DaoSearchResult>(query, {
     limit,
-    filter: exclude?.length
-      ? // Only show DAOs with proposals to reduce clutter/spam.
-        `((NOT value.proposalCount EXISTS) OR (value.proposalCount > 0)) AND NOT contractAddress IN ["${exclude.join(
-          '", "'
-        )}"]`
-      : undefined,
+    filter: [
+      // Only show DAOs with proposals to reduce clutter/spam.
+      `(NOT value.proposalCount EXISTS) OR (value.proposalCount > 0)`,
+      ...(exclude?.length
+        ? // Exclude DAOs that are in the exclude list.
+          [`NOT contractAddress IN ["${exclude.join('", "')}"]`]
+        : []),
+    ]
+      .map((filter) => `(${filter})`)
+      .join(' AND '),
     // Most recent at the top.
     sort: ['blockHeight:desc'],
   })

--- a/packages/state/indexer/search.ts
+++ b/packages/state/indexer/search.ts
@@ -1,5 +1,6 @@
 import MeiliSearch from 'meilisearch'
 
+import { IndexerDumpState } from '@dao-dao/types'
 import { SEARCH_API_KEY, SEARCH_DAOS_INDEX, SEARCH_HOST } from '@dao-dao/utils'
 
 let _client: MeiliSearch | undefined
@@ -20,11 +21,7 @@ export interface DaoSearchResult {
   codeId: number
   blockHeight: number
   blockTimeUnixMicro: number
-  value: {
-    name: string
-    description: string
-    image_url: string | null
-  }
+  value: IndexerDumpState
 }
 
 export const searchDaos = async (
@@ -38,7 +35,10 @@ export const searchDaos = async (
   const results = await index.search<DaoSearchResult>(query, {
     limit,
     filter: exclude?.length
-      ? `NOT contractAddress IN ["${exclude.join('", "')}"]`
+      ? // Only show DAOs with proposals to reduce clutter/spam.
+        `((NOT value.proposalCount EXISTS) OR (value.proposalCount > 0)) AND NOT contractAddress IN ["${exclude.join(
+          '", "'
+        )}"]`
       : undefined,
     // Most recent at the top.
     sort: ['blockHeight:desc'],

--- a/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
+++ b/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
@@ -48,11 +48,13 @@ export const usePinnedAndFilteredDaosSections = ({
   // Use query results if filter is present.
   const daos = options.filter
     ? (queryResults.state !== 'hasValue' ? [] : queryResults.contents)
-        .filter(({ value }) => !!value)
+        .filter(({ value }) => !!value?.config)
         .map(
           ({
             contractAddress,
-            value: { name, image_url },
+            value: {
+              config: { name, image_url },
+            },
           }): CommandModalDaoInfo => ({
             // Nothing specific to set here yet, just uses default.
             chainId: undefined,

--- a/packages/types/indexer.ts
+++ b/packages/types/indexer.ts
@@ -11,4 +11,5 @@ export interface IndexerDumpState
   votingModuleInfo: ContractVersionInfo
   createdAt: string // UTC string
   adminConfig?: Config | null
+  proposalCount?: number
 }


### PR DESCRIPTION
The old search mechanism filtered by DAOs that have at least one proposal, to reduce duplicates/clutter/spam. This adds that back in.