### PR TITLE
Clean up inbox

### DIFF
--- a/apps/dapp/pages/inbox.tsx
+++ b/apps/dapp/pages/inbox.tsx
@@ -30,26 +30,26 @@ const InnerInbox = () => {
   const pinnedDaoDropdownInfos = useRecoilValue(pinnedDaoDropdownInfosSelector)
 
   const {
-    inbox: { loading, refetching, refetch, daosWithOpenUnvotedProposals },
+    inbox: { loading, refetching, refetch, daosWithOpenProposals },
   } = useAppLayoutContext()
 
-  const daosWithProposals = daosWithOpenUnvotedProposals
+  const daosWithProposals = daosWithOpenProposals
     .map(
       ({
         coreAddress,
         proposalModules,
-        openUnvotedProposals,
+        openProposals,
       }): DaoWithProposals<ProposalLineProps> | undefined => {
         const daoDropdownInfo = pinnedDaoDropdownInfos.find(
           (dao) => dao.coreAddress === coreAddress
         )
-        if (!daoDropdownInfo || !openUnvotedProposals) {
+        if (!daoDropdownInfo || !openProposals) {
           return undefined
         }
 
         return {
           dao: daoDropdownInfo,
-          proposals: openUnvotedProposals.map(
+          proposals: openProposals.map(
             ({ proposalModule: { prefix }, proposalNumber }) => ({
               chainId: CHAIN_ID,
               coreAddress,

--- a/packages/state/recoil/selectors/indexer.ts
+++ b/packages/state/recoil/selectors/indexer.ts
@@ -105,7 +105,7 @@ export const searchDaosSelector = selectorFamily<
 export const openProposalsSelector = selectorFamily<
   {
     proposalModuleAddress: string
-    proposals: { id: number }[]
+    proposals: { id: number; voted?: boolean }[]
   }[],
   WithChainId<{ coreAddress: string; address?: string }>
 >({

--- a/packages/stateful/hooks/useInbox.ts
+++ b/packages/stateful/hooks/useInbox.ts
@@ -6,18 +6,18 @@ import { refreshOpenProposalsAtom } from '@dao-dao/state'
 import { useCachedLoadable } from '@dao-dao/stateless'
 import { UseInboxReturn } from '@dao-dao/types'
 
-import { pinnedDaosWithOpenUnvotedProposalsSelector } from '../recoil'
+import { pinnedDaosWithOpenProposalsSelector } from '../recoil'
 
 export const useInbox = (): UseInboxReturn => {
   const { address: walletAddress, status: walletConnectionStatus } = useWallet()
 
-  const daosWithOpenUnvotedProposalsLoadable = useCachedLoadable(
+  const daosWithOpenProposalsLoadable = useCachedLoadable(
     // Don't load without a wallet until we're no longer initializing. This
     // prevents duplicate queries when the page is first loading.
     walletConnectionStatus === WalletConnectionStatus.Initializing ||
       walletConnectionStatus === WalletConnectionStatus.AttemptingAutoConnection
       ? undefined
-      : pinnedDaosWithOpenUnvotedProposalsSelector({
+      : pinnedDaosWithOpenProposalsSelector({
           walletAddress,
         })
   )
@@ -35,22 +35,22 @@ export const useInbox = (): UseInboxReturn => {
   }, [refreshOpenProposals])
 
   const proposalCount =
-    daosWithOpenUnvotedProposalsLoadable.state === 'hasValue'
-      ? daosWithOpenUnvotedProposalsLoadable.contents.reduce(
-          (acc, { openUnvotedProposals }) =>
+    daosWithOpenProposalsLoadable.state === 'hasValue'
+      ? daosWithOpenProposalsLoadable.contents.reduce(
+          (acc, { openProposals: openUnvotedProposals }) =>
             acc + (openUnvotedProposals?.length ?? 0),
           0
         )
       : 0
 
   return {
-    loading: daosWithOpenUnvotedProposalsLoadable.state === 'loading',
+    loading: daosWithOpenProposalsLoadable.state === 'loading',
     refetching:
-      daosWithOpenUnvotedProposalsLoadable.state === 'hasValue' &&
-      daosWithOpenUnvotedProposalsLoadable.updating,
-    daosWithOpenUnvotedProposals:
-      daosWithOpenUnvotedProposalsLoadable.state === 'hasValue'
-        ? daosWithOpenUnvotedProposalsLoadable.contents
+      daosWithOpenProposalsLoadable.state === 'hasValue' &&
+      daosWithOpenProposalsLoadable.updating,
+    daosWithOpenProposals:
+      daosWithOpenProposalsLoadable.state === 'hasValue'
+        ? daosWithOpenProposalsLoadable.contents
         : [],
     proposalCount,
     refetch: refreshOpenProposals,

--- a/packages/stateful/recoil/selectors/dao/pinned.ts
+++ b/packages/stateful/recoil/selectors/dao/pinned.ts
@@ -2,7 +2,7 @@ import { selector, selectorFamily, waitForAll } from 'recoil'
 
 import { openProposalsSelector, pinnedAddressesAtom } from '@dao-dao/state'
 import { DaoDropdownInfo } from '@dao-dao/stateless'
-import { DaoWithOpenUnvotedProposals, WithChainId } from '@dao-dao/types'
+import { DaoWithOpenProposals, WithChainId } from '@dao-dao/types'
 
 import { daoDropdownInfoSelector } from './cards'
 import { daoCoreProposalModulesSelector } from './misc'
@@ -39,11 +39,11 @@ export const pinnedDaosWithProposalModulesSelector = selector({
   },
 })
 
-export const pinnedDaosWithOpenUnvotedProposalsSelector = selectorFamily<
-  DaoWithOpenUnvotedProposals[],
+export const pinnedDaosWithOpenProposalsSelector = selectorFamily<
+  DaoWithOpenProposals[],
   WithChainId<{ walletAddress?: string }>
 >({
-  key: 'pinnedDaosWithOpenUnvotedProposals',
+  key: 'pinnedDaosWithOpenProposals',
   get:
     ({ walletAddress, chainId }) =>
     ({ get }) => {
@@ -64,25 +64,23 @@ export const pinnedDaosWithOpenUnvotedProposalsSelector = selectorFamily<
       )
 
       return pinnedDaosWithProposalModules.map(
-        (
-          { coreAddress, proposalModules },
-          index
-        ): DaoWithOpenUnvotedProposals => {
+        ({ coreAddress, proposalModules }, index): DaoWithOpenProposals => {
           const proposalModulesWithOpenProposals = openProposalsPerDao[index]
 
           return {
             coreAddress,
             proposalModules,
-            openUnvotedProposals: proposalModules.flatMap(
+            openProposals: proposalModules.flatMap(
               (proposalModule) =>
                 proposalModulesWithOpenProposals
                   .find(
                     ({ proposalModuleAddress }) =>
                       proposalModuleAddress === proposalModule.address
                   )
-                  ?.proposals.map(({ id }) => ({
+                  ?.proposals.map(({ id, voted }) => ({
                     proposalModule,
                     proposalNumber: id,
+                    voted,
                   })) ?? []
             ),
           }

--- a/packages/stateless/pages/Inbox.tsx
+++ b/packages/stateless/pages/Inbox.tsx
@@ -4,7 +4,7 @@ import {
   WhereToVoteOutlined,
 } from '@mui/icons-material'
 import clsx from 'clsx'
-import { ComponentType, ReactNode, useEffect, useMemo, useState } from 'react'
+import { ComponentType, ReactNode, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { LinkWrapperProps, LoadingData } from '@dao-dao/types'
@@ -44,16 +44,12 @@ export const Inbox = <T extends {}>({
   const { t } = useTranslation()
   const { RightSidebarContent, PageHeader } = useAppLayoutContext()
 
-  const numOpenProposals = useMemo(
-    () =>
-      daosWithProposals.loading
-        ? 0
-        : daosWithProposals.data.reduce(
-            (acc, { proposals }) => acc + proposals.length,
-            0
-          ),
-    [daosWithProposals]
-  )
+  const numOpenProposals = daosWithProposals.loading
+    ? 0
+    : daosWithProposals.data.reduce(
+        (acc, { proposals }) => acc + proposals.length,
+        0
+      )
 
   const [refreshSpinning, setRefreshSpinning] = useState(false)
   // Start spinning refresh icon if refreshing sets to true. Turn off once the
@@ -113,24 +109,26 @@ export const Inbox = <T extends {}>({
             </p>
 
             <div className="mt-6 grow space-y-4">
-              {daosWithProposals.data.map(({ dao, proposals }, index) => (
-                <DaoDropdown
-                  key={index}
-                  LinkWrapper={LinkWrapper}
-                  dao={{
-                    ...dao,
-                    content: proposals.length ? (
-                      <ProposalContainer className="mt-4 px-2">
-                        {proposals.map((props, index) => (
-                          <ProposalLine key={index} {...props} />
-                        ))}
-                      </ProposalContainer>
-                    ) : undefined,
-                  }}
-                  defaultExpanded
-                  showSubdaos={false}
-                />
-              ))}
+              {daosWithProposals.data
+                .filter(({ proposals }) => proposals.length > 0)
+                .map(({ dao, proposals }, index) => (
+                  <DaoDropdown
+                    key={index}
+                    LinkWrapper={LinkWrapper}
+                    dao={{
+                      ...dao,
+                      content: proposals.length ? (
+                        <ProposalContainer className="mt-4 px-2">
+                          {proposals.map((props, index) => (
+                            <ProposalLine key={index} {...props} />
+                          ))}
+                        </ProposalContainer>
+                      ) : undefined,
+                    }}
+                    defaultExpanded
+                    showSubdaos={false}
+                  />
+                ))}
             </div>
           </>
         )}

--- a/packages/storybook/decorators/makeAppLayoutContextDecorator.tsx
+++ b/packages/storybook/decorators/makeAppLayoutContextDecorator.tsx
@@ -52,7 +52,7 @@ export const makeAppLayoutContextDecorator: (
 export const EMPTY_INBOX: UseInboxReturn = {
   loading: false,
   refetching: false,
-  daosWithOpenUnvotedProposals: [],
+  daosWithOpenProposals: [],
   proposalCount: 0,
   refetch: async () => alert('refetch inbox'),
 }

--- a/packages/types/inbox.ts
+++ b/packages/types/inbox.ts
@@ -1,20 +1,19 @@
 import { ProposalModule } from './dao'
 
-export interface DaoWithOpenUnvotedProposals {
+export interface DaoWithOpenProposals {
   coreAddress: string
   proposalModules: ProposalModule[]
-  openUnvotedProposals:
-    | {
-        proposalModule: ProposalModule
-        proposalNumber: number
-      }[]
-    | undefined
+  openProposals: {
+    proposalModule: ProposalModule
+    proposalNumber: number
+    voted?: boolean
+  }[]
 }
 
 export interface UseInboxReturn {
   loading: boolean
   refetching: boolean
-  daosWithOpenUnvotedProposals: DaoWithOpenUnvotedProposals[]
+  daosWithOpenProposals: DaoWithOpenProposals[]
   proposalCount: number
   refetch: () => void
 }


### PR DESCRIPTION
Resolves #993 
Resolves #994 

This PR hides DAOs which have no open proposals from showing in the inbox, even if they're followed. It also unhides proposals that the user has voted on; before they were hidden, but that was confusing because they're still open. It's clear from the badge if the user needs to vote, so it's fine to leave them in.

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/6721426/211687099-dd7f6610-5685-48e8-813c-754df7fb52f7.png">