### PR TITLE
Show profiles in DAO creation flow

### DIFF
--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/daoCreation/GovernanceConfigurationReview.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/daoCreation/GovernanceConfigurationReview.tsx
@@ -14,6 +14,7 @@ import {
 import { DaoCreationGovernanceConfigReviewProps } from '@dao-dao/types'
 import { formatPercentOf100 } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../../../components'
 import { DaoCreationConfig, GovernanceTokenType } from '../types'
 
 export const GovernanceConfigurationReview = ({
@@ -124,6 +125,7 @@ export const GovernanceConfigurationReview = ({
 
   return (
     <DaoCreateVotingPowerDistributionReviewCard
+      ProfileDisplay={ProfileDisplay}
       distributionPrefix={'$' + symbol + ' '}
       pieData={pieData}
       tierData={tierData}

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/daoCreation/TierCard.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/daoCreation/TierCard.tsx
@@ -29,6 +29,7 @@ import {
   validateRequired,
 } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../../../components/ProfileDisplay'
 import { DaoCreationConfig } from '../types'
 
 export interface TierCardProps {
@@ -204,6 +205,7 @@ export const TierCard = ({
                   )}
 
                   <AddressInput
+                    ProfileDisplay={ProfileDisplay}
                     containerClassName="grow"
                     error={
                       errors.votingModuleAdapter?.data?.tiers?.[tierIndex]

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw4/daoCreation/GovernanceConfigurationReview.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw4/daoCreation/GovernanceConfigurationReview.tsx
@@ -7,6 +7,7 @@ import {
 import { DaoCreationGovernanceConfigReviewProps } from '@dao-dao/types'
 import { formatPercentOf100 } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../../../components/ProfileDisplay'
 import { DaoCreationConfig } from '../types'
 
 export const GovernanceConfigurationReview = ({
@@ -67,6 +68,7 @@ export const GovernanceConfigurationReview = ({
 
   return (
     <DaoCreateVotingPowerDistributionReviewCard
+      ProfileDisplay={ProfileDisplay}
       pieData={pieData}
       tierData={tierData}
     />

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw4/daoCreation/TierCard.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw4/daoCreation/TierCard.tsx
@@ -26,6 +26,7 @@ import {
   validateRequired,
 } from '@dao-dao/utils'
 
+import { ProfileDisplay } from '../../../../components/ProfileDisplay'
 import { DaoCreationConfig } from '../types'
 
 export interface TierCardProps {
@@ -189,6 +190,7 @@ export const TierCard = ({
                   )}
 
                   <AddressInput
+                    ProfileDisplay={ProfileDisplay}
                     containerClassName="grow"
                     error={
                       errors.votingModuleAdapter?.data?.tiers?.[tierIndex]

--- a/packages/stateless/components/dao/create/DaoCreateVotingPowerDistribution.DaoCreateVotingPowerDistributionReviewCard.stories.tsx
+++ b/packages/stateless/components/dao/create/DaoCreateVotingPowerDistribution.DaoCreateVotingPowerDistributionReviewCard.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
+import { ProfileDisplay } from '@dao-dao/stateful/components/ProfileDisplay'
+
 import {
   DaoCreateVotingPowerDistributionReviewCard,
   VOTING_POWER_DISTRIBUTION_COLORS,
@@ -21,6 +23,7 @@ const Template: ComponentStory<
 
 export const Default = Template.bind({})
 Default.args = {
+  ProfileDisplay,
   pieData: [
     {
       value: 15,

--- a/packages/stateless/components/dao/create/DaoCreateVotingPowerDistribution.tsx
+++ b/packages/stateless/components/dao/create/DaoCreateVotingPowerDistribution.tsx
@@ -7,11 +7,13 @@ import {
   Tooltip,
 } from 'chart.js'
 import clsx from 'clsx'
+import { ComponentType } from 'react'
 import { Bar, Pie } from 'react-chartjs-2'
 import { useTranslation } from 'react-i18next'
 
+import { StatefulProfileDisplayProps } from '@dao-dao/types'
+
 import { useNamedThemeColor } from '../../../theme'
-import { CopyToClipboard } from '../../CopyToClipboard'
 
 declare module 'chart.js' {
   interface TooltipPositionerMap {
@@ -55,12 +57,14 @@ export interface DaoCreateVotingPowerDistributionReviewCardProps {
   pieData: ChartDataEntry[]
   tierData: TierDataEntry[]
   distributionPrefix?: string
+  ProfileDisplay: ComponentType<StatefulProfileDisplayProps>
 }
 
 export const DaoCreateVotingPowerDistributionReviewCard = ({
   pieData,
   tierData,
   distributionPrefix,
+  ProfileDisplay,
 }: DaoCreateVotingPowerDistributionReviewCardProps) => {
   const { t } = useTranslation()
 
@@ -113,10 +117,7 @@ export const DaoCreateVotingPowerDistributionReviewCard = ({
                       style={{ backgroundColor: color }}
                     ></div>
                   )}
-                  <CopyToClipboard
-                    takeStartEnd={{ start: address.length, end: 0 }}
-                    value={address}
-                  />
+                  <ProfileDisplay address={address} />
                 </div>
 
                 <p className="caption-text text-right font-mono text-text-tertiary">


### PR DESCRIPTION
Resolves #990 

The DAO creation flow was missing profiles! This adds them in.

<img width="898" alt="image" src="https://user-images.githubusercontent.com/6721426/211689567-0643f70e-3a05-47a0-86de-ecd88ffcfd85.png">
<img width="910" alt="Screenshot 2023-01-10 at 4 26 27 PM" src="https://user-images.githubusercontent.com/6721426/211689904-c9b0d0af-9558-4d05-b349-8f116ecf4856.png">
