### PR TITLE
Fix failed build when featured DAOs fail to pre-cache.

### DIFF
--- a/apps/dapp/pages/_app.tsx
+++ b/apps/dapp/pages/_app.tsx
@@ -170,6 +170,7 @@ const DApp = (props: DappProps) => {
         initializeState={(snapshot) => {
           if (
             'featuredDaoDumpStates' in props.pageProps &&
+            props.pageProps.featuredDaoDumpStates &&
             Array.isArray(props.pageProps.featuredDaoDumpStates)
           ) {
             snapshot.set(

--- a/apps/dapp/pages/home.tsx
+++ b/apps/dapp/pages/home.tsx
@@ -51,7 +51,7 @@ export default HomePage
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     featuredDaoDumpStates: await queryFeaturedDaoDumpStatesFromIndexer().catch(
-      () => undefined
+      () => null
     ),
     ...(await serverSideTranslations(locale, ['translation'])),
   },

--- a/apps/dapp/pages/index.tsx
+++ b/apps/dapp/pages/index.tsx
@@ -170,7 +170,7 @@ export default SplashPage
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     featuredDaoDumpStates: await queryFeaturedDaoDumpStatesFromIndexer().catch(
-      () => undefined
+      () => null
     ),
     ...(await serverSideTranslations(locale, ['translation'])),
   },


### PR DESCRIPTION
Right now we try to pre-cache featured DAOs. When they fail to pre-cache, the build fails. It's fine if they fail to pre-cache; it should happen rarely and only as a result of a network failure.

This PR makes it so the build won't fail in that case.