### PR TITLE
Make private env vars private

### DIFF
--- a/apps/dapp/.env.development
+++ b/apps/dapp/.env.development
@@ -39,7 +39,7 @@ NEXT_PUBLIC_SEARCH_API_KEY=613511c001942ea974f72dde06647428d1ae3f42cb13fcf71e88e
 NEXT_PUBLIC_SEARCH_DAOS_INDEX=testnet_daos
 
 # https://nft.storage/docs/#get-an-api-token
-NEXT_PUBLIC_NFT_STORAGE_API_KEY=
+NFT_STORAGE_API_KEY=
 
 # Payroll
 NEXT_PUBLIC_RETROACTIVE_COMPENSATION_API_BASE=https://retroactive-compensation-cf-worker.dao-dao.workers.dev

--- a/apps/dapp/.env.development
+++ b/apps/dapp/.env.development
@@ -31,7 +31,7 @@ NEXT_PUBLIC_STARGAZE_URL_BASE=https://stargaze.zone
 NEXT_PUBLIC_PFPK_API_BASE=https://pfpk.daodao.zone
 
 # Indexer
-# NEXT_PUBLIC_INDEXER_API_KEY=
+# INDEXER_API_KEY=
 
 # Search
 NEXT_PUBLIC_SEARCH_HOST=https://search.daodao.zone

--- a/apps/dapp/.env.localhost
+++ b/apps/dapp/.env.localhost
@@ -29,7 +29,7 @@ NEXT_PUBLIC_STARGAZE_URL_BASE=https://testnet.publicawesome.dev
 NEXT_PUBLIC_PFPK_API_BASE=https://pfpk.daodao.zone
 
 # Indexer
-# NEXT_PUBLIC_INDEXER_API_KEY=
+# INDEXER_API_KEY=
 
 # Search
 NEXT_PUBLIC_SEARCH_HOST=https://search.daodao.zone

--- a/apps/dapp/.env.mainnet
+++ b/apps/dapp/.env.mainnet
@@ -39,7 +39,7 @@ NEXT_PUBLIC_SEARCH_API_KEY=613511c001942ea974f72dde06647428d1ae3f42cb13fcf71e88e
 NEXT_PUBLIC_SEARCH_DAOS_INDEX=daos
 
 # https://nft.storage/docs/#get-an-api-token
-NEXT_PUBLIC_NFT_STORAGE_API_KEY=
+NFT_STORAGE_API_KEY=
 
 # Payroll
 NEXT_PUBLIC_RETROACTIVE_COMPENSATION_API_BASE=https://retroactive-compensation-cf-worker.dao-dao.workers.dev

--- a/apps/dapp/.env.mainnet
+++ b/apps/dapp/.env.mainnet
@@ -31,7 +31,7 @@ NEXT_PUBLIC_STARGAZE_URL_BASE=https://stargaze.zone
 NEXT_PUBLIC_PFPK_API_BASE=https://pfpk.daodao.zone
 
 # Indexer
-# NEXT_PUBLIC_INDEXER_API_KEY=
+# INDEXER_API_KEY=
 
 # Search
 NEXT_PUBLIC_SEARCH_HOST=https://search.daodao.zone

--- a/packages/storybook/.env
+++ b/packages/storybook/.env
@@ -30,9 +30,6 @@ NEXT_PUBLIC_STARGAZE_URL_BASE=https://stargaze.zone
 # Wallet profiles
 NEXT_PUBLIC_PFPK_API_BASE=https://pfpk.daodao.zone
 
-# Indexer
-NEXT_PUBLIC_INDEXER_API_KEY=
-
 # Search
 NEXT_PUBLIC_SEARCH_HOST=https://search.daodao.zone
 NEXT_PUBLIC_SEARCH_API_KEY=613511c001942ea974f72dde06647428d1ae3f42cb13fcf71e88e4317d73f2cf

--- a/packages/storybook/.env
+++ b/packages/storybook/.env
@@ -36,7 +36,7 @@ NEXT_PUBLIC_SEARCH_API_KEY=613511c001942ea974f72dde06647428d1ae3f42cb13fcf71e88e
 NEXT_PUBLIC_SEARCH_DAOS_INDEX=testnet_daos
 
 # https://nft.storage/docs/#get-an-api-token
-NEXT_PUBLIC_NFT_STORAGE_API_KEY=
+NFT_STORAGE_API_KEY=
 
 # Payroll
 NEXT_PUBLIC_RETROACTIVE_COMPENSATION_API_BASE=https://retroactive-compensation-cf-worker.dao-dao.workers.dev

--- a/packages/utils/constants/index.ts
+++ b/packages/utils/constants/index.ts
@@ -113,7 +113,7 @@ export const STARGAZE_URL_BASE = process.env
 export const PFPK_API_BASE = process.env.NEXT_PUBLIC_PFPK_API_BASE as string
 
 // Indexer
-export const INDEXER_API_KEY = process.env.NEXT_PUBLIC_INDEXER_API_KEY
+export const INDEXER_API_KEY = process.env.INDEXER_API_KEY
 
 // Search
 export const SEARCH_HOST = process.env.NEXT_PUBLIC_SEARCH_HOST as string

--- a/packages/utils/constants/index.ts
+++ b/packages/utils/constants/index.ts
@@ -121,8 +121,7 @@ export const SEARCH_API_KEY = process.env.NEXT_PUBLIC_SEARCH_API_KEY as string
 export const SEARCH_DAOS_INDEX = process.env
   .NEXT_PUBLIC_SEARCH_DAOS_INDEX as string
 
-export const NFT_STORAGE_API_KEY = process.env
-  .NEXT_PUBLIC_NFT_STORAGE_API_KEY as string
+export const NFT_STORAGE_API_KEY = process.env.NFT_STORAGE_API_KEY as string
 
 export const FAST_AVERAGE_COLOR_API_TEMPLATE = process.env
   .NEXT_PUBLIC_FAST_AVERAGE_COLOR_API_TEMPLATE as string


### PR DESCRIPTION
The `NEXT_PUBLIC_` prefix for Next.js environment variables means they are available to the browser code during build time. Variables without that prefix are still accessible in Node contexts (such as the serverless `api` functions).

Since variables are inlined during build time, none of these keys were exposed because they are not used anywhere in the browser code, but there's no reason to leave them public. This PR removes the prefix from these non-public keys.