### PR TITLE
Improve indexer timeout and fix server side indexer queries

### DIFF
--- a/packages/state/indexer/query.ts
+++ b/packages/state/indexer/query.ts
@@ -10,28 +10,33 @@ export type QueryIndexerOptions = WithChainId<{
     // Most formulas do not need the time, so make it optional.
     timeUnixMs?: number
   }
+  baseUrl?: string
 }>
 
 export const queryIndexer = async <T = any>(
   type: 'contract' | 'wallet' | 'generic',
   address: string,
   formula: string,
-  { args, block, chainId }: QueryIndexerOptions = {}
+  { args, block, chainId, baseUrl }: QueryIndexerOptions = {}
 ): Promise<T | undefined> => {
-  const response = await fetchWithTimeout(3000, '/api/indexer', {
-    method: 'POST',
-    body: JSON.stringify({
-      chainId: chainId ?? CHAIN_ID,
-      type,
-      address,
-      formula,
-      args,
-      block: block ? `${block.height}:${block.timeUnixMs ?? 1}` : undefined,
-    }),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
+  const response = await fetchWithTimeout(
+    3000,
+    (baseUrl || '') + '/api/indexer',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        chainId: chainId ?? CHAIN_ID,
+        type,
+        address,
+        formula,
+        args,
+        block: block ? `${block.height}:${block.timeUnixMs ?? 1}` : undefined,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  )
 
   if (!response.ok) {
     const errorResponse = await response.text().catch(() => undefined)

--- a/packages/state/indexer/query.ts
+++ b/packages/state/indexer/query.ts
@@ -20,8 +20,8 @@ export const queryIndexer = async <T = any>(
   { args, block, chainId, baseUrl }: QueryIndexerOptions = {}
 ): Promise<T | undefined> => {
   const response = await fetchWithTimeout(
-    // Timeout after 3 seconds.
-    3000,
+    // Timeout after 5 seconds.
+    5000,
     (baseUrl || '') + '/api/indexer',
     {
       method: 'POST',

--- a/packages/state/indexer/query.ts
+++ b/packages/state/indexer/query.ts
@@ -20,6 +20,7 @@ export const queryIndexer = async <T = any>(
   { args, block, chainId, baseUrl }: QueryIndexerOptions = {}
 ): Promise<T | undefined> => {
   const response = await fetchWithTimeout(
+    // Timeout after 3 seconds.
     3000,
     (baseUrl || '') + '/api/indexer',
     {

--- a/packages/state/indexer/query.ts
+++ b/packages/state/indexer/query.ts
@@ -1,7 +1,7 @@
 import { ChainInfoID } from '@noahsaso/cosmodal'
 
 import { WithChainId } from '@dao-dao/types'
-import { CHAIN_ID, fetchWithTimeout } from '@dao-dao/utils'
+import { CHAIN_ID, SITE_URL, fetchWithTimeout } from '@dao-dao/utils'
 
 export type QueryIndexerOptions = WithChainId<{
   args?: Record<string, any>
@@ -55,4 +55,6 @@ export const queryIndexer = async <T = any>(
 export const queryFeaturedDaoDumpStatesFromIndexer = () =>
   queryIndexer('generic', '_', 'featuredDaos', {
     chainId: ChainInfoID.Juno1,
+    // Needed for server-side queries.
+    baseUrl: SITE_URL,
   })

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/fetchPreProposeAddress.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/fetchPreProposeAddress.ts
@@ -1,6 +1,10 @@
 import { queryIndexer } from '@dao-dao/state/indexer'
 import { ContractVersion, FetchPreProposeAddressFunction } from '@dao-dao/types'
-import { cosmWasmClientRouter, getRpcForChainId } from '@dao-dao/utils'
+import {
+  SITE_URL,
+  cosmWasmClientRouter,
+  getRpcForChainId,
+} from '@dao-dao/utils'
 
 import { DaoProposalSingleV2QueryClient } from '../contracts/DaoProposalSingle.v2.client'
 
@@ -20,7 +24,11 @@ export const fetchPreProposeAddress: FetchPreProposeAddressFunction = async (
     creationPolicy = await queryIndexer(
       'contract',
       proposalModuleAddress,
-      'daoProposalSingle/creationPolicy'
+      'daoProposalSingle/creationPolicy',
+      {
+        // Needed for server-side queries.
+        baseUrl: SITE_URL,
+      }
     )
   } catch (err) {
     // Ignore error.

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/fetchPreProposeAddress.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/fetchPreProposeAddress.ts
@@ -33,16 +33,16 @@ export const fetchPreProposeAddress: FetchPreProposeAddressFunction = async (
   } catch (err) {
     // Ignore error.
     console.error(err)
+  }
 
-    // If indexer fails, fallback to querying chain.
-    if (!creationPolicy) {
-      const client = new DaoProposalSingleV2QueryClient(
-        await cosmWasmClientRouter.connect(getRpcForChainId(chainId)),
-        proposalModuleAddress
-      )
+  // If indexer fails, fallback to querying chain.
+  if (!creationPolicy) {
+    const client = new DaoProposalSingleV2QueryClient(
+      await cosmWasmClientRouter.connect(getRpcForChainId(chainId)),
+      proposalModuleAddress
+    )
 
-      creationPolicy = await client.proposalCreationPolicy()
-    }
+    creationPolicy = await client.proposalCreationPolicy()
   }
 
   return creationPolicy &&

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/makeGetProposalInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/makeGetProposalInfo.ts
@@ -11,6 +11,7 @@ import {
 import { ProposalResponse as ProposalV1Response } from '@dao-dao/types/contracts/CwProposalSingle.v1'
 import { ProposalResponse as ProposalV2Response } from '@dao-dao/types/contracts/DaoProposalSingle.v2'
 import {
+  SITE_URL,
   cosmWasmClientRouter,
   getRpcForChainId,
   parseContractVersion,
@@ -72,6 +73,8 @@ export const makeGetProposalInfo =
             args: {
               id: proposalNumber,
             },
+            // Needed for server-side queries.
+            baseUrl: SITE_URL,
           }
         )
       } catch (err) {

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/makeGetProposalInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/functions/makeGetProposalInfo.ts
@@ -46,7 +46,11 @@ export const makeGetProposalInfo =
         info = await queryIndexer<ContractVersionInfo>(
           'contract',
           proposalModule.address,
-          'info'
+          'info',
+          {
+            // Needed for server-side queries.
+            baseUrl: SITE_URL,
+          }
         )
       } catch (err) {
         // Ignore error.
@@ -130,6 +134,8 @@ export const makeGetProposalInfo =
           args: {
             id,
           },
+          // Needed for server-side queries.
+          baseUrl: SITE_URL,
         }
       )
       // If indexer returned a value, assume it's a date.

--- a/packages/stateful/server/makeGetDaoStaticProps.ts
+++ b/packages/stateful/server/makeGetDaoStaticProps.ts
@@ -481,6 +481,7 @@ const daoCoreDumpState = async (
       coreAddress,
       'daoCore/dumpState',
       {
+        // Needed for server-side queries.
         baseUrl: SITE_URL,
       }
     )

--- a/packages/stateful/server/makeGetDaoStaticProps.ts
+++ b/packages/stateful/server/makeGetDaoStaticProps.ts
@@ -35,7 +35,10 @@ import {
   toAccessibleImageUrl,
   validateContractAddress,
 } from '@dao-dao/utils'
-import { FAST_AVERAGE_COLOR_API_TEMPLATE } from '@dao-dao/utils/constants'
+import {
+  FAST_AVERAGE_COLOR_API_TEMPLATE,
+  SITE_URL,
+} from '@dao-dao/utils/constants'
 
 import { DaoPageWrapperProps } from '../components'
 import {
@@ -476,7 +479,10 @@ const daoCoreDumpState = async (
     indexerDumpedState = await queryIndexer<IndexerDumpState>(
       'contract',
       coreAddress,
-      'daoCore/dumpState'
+      'daoCore/dumpState',
+      {
+        baseUrl: SITE_URL,
+      }
     )
   } catch (error) {
     // Ignore error. Fallback to querying chain below.
@@ -522,8 +528,6 @@ const daoCoreDumpState = async (
         : null,
     }
   }
-
-  // If indexer failed, fallback to querying chain.
 
   const cwClient = await cosmWasmClientRouter.connect(getRpcForChainId(chainId))
   const daoCoreClient = new DaoCoreV2QueryClient(cwClient, coreAddress)

--- a/packages/stateful/server/makeGetDaoStaticProps.ts
+++ b/packages/stateful/server/makeGetDaoStaticProps.ts
@@ -491,8 +491,6 @@ const daoCoreDumpState = async (
 
   // Use data from indexer if present.
   if (indexerDumpedState) {
-    console.log('got le indexer', indexerDumpedState)
-
     const coreVersion = parseContractVersion(indexerDumpedState.version.version)
     if (!coreVersion) {
       throw new Error(serverT('error.failedParsingCoreVersion'))

--- a/packages/stateful/server/makeGetDaoStaticProps.ts
+++ b/packages/stateful/server/makeGetDaoStaticProps.ts
@@ -491,6 +491,8 @@ const daoCoreDumpState = async (
 
   // Use data from indexer if present.
   if (indexerDumpedState) {
+    console.log('got le indexer', indexerDumpedState)
+
     const coreVersion = parseContractVersion(indexerDumpedState.version.version)
     if (!coreVersion) {
       throw new Error(serverT('error.failedParsingCoreVersion'))

--- a/packages/stateful/utils/fetchProposalModules.ts
+++ b/packages/stateful/utils/fetchProposalModules.ts
@@ -11,6 +11,7 @@ import {
 import { InfoResponse } from '@dao-dao/types/contracts/common'
 import { ProposalModuleWithInfo } from '@dao-dao/types/contracts/DaoCore.v2'
 import {
+  SITE_URL,
   cosmWasmClientRouter,
   getRpcForChainId,
   indexToProposalModulePrefix,
@@ -32,7 +33,11 @@ export const fetchProposalModules = async (
       activeProposalModules = await queryIndexer(
         'contract',
         coreAddress,
-        'daoCore/activeProposalModules'
+        'daoCore/activeProposalModules',
+        {
+          // Needed for server-side queries.
+          baseUrl: SITE_URL,
+        }
       )
     } catch (err) {
       // Ignore error.

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -1,15 +1,37 @@
 export const fetchWithTimeout = async (
   timeout: number,
   ...params: Parameters<typeof fetch>
-) => {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeout)
-  try {
-    return await fetch(params[0], {
-      ...params[1],
-      signal: controller.signal,
-    })
-  } finally {
-    clearTimeout(timeoutId)
-  }
-}
+) =>
+  new Promise<Response>(async (resolve, reject) => {
+    const controller = new AbortController()
+
+    let rejected = false
+    const timeoutId = setTimeout(() => {
+      console.log('Aborting...')
+      controller.abort()
+
+      // In case abort controller does not work, reject manually.
+      setTimeout(() => {
+        if (!rejected) {
+          reject(new Error('Request timed out'))
+        }
+      }, 100)
+    }, timeout)
+
+    try {
+      const response = await fetch(params[0], {
+        ...params[1],
+        signal: controller.signal,
+      })
+      if (!rejected) {
+        resolve(response)
+      }
+    } catch (error) {
+      if (!rejected) {
+        rejected = true
+        reject(error)
+      }
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  })

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -1,37 +1,20 @@
 export const fetchWithTimeout = async (
   timeout: number,
   ...params: Parameters<typeof fetch>
-) =>
-  new Promise<Response>(async (resolve, reject) => {
-    const controller = new AbortController()
+) => {
+  const controller = new AbortController()
 
-    let rejected = false
-    const timeoutId = setTimeout(() => {
-      console.log(`Aborting request due to timeout (${params[0]})...`)
-      controller.abort()
+  const timeoutId = setTimeout(() => {
+    console.log('Aborting request...')
+    controller.abort()
+  }, timeout)
 
-      // In case abort controller does not work, reject manually.
-      setTimeout(() => {
-        if (!rejected) {
-          reject(new Error('Request timed out'))
-        }
-      }, 100)
-    }, timeout)
-
-    try {
-      const response = await fetch(params[0], {
-        ...params[1],
-        signal: controller.signal,
-      })
-      if (!rejected) {
-        resolve(response)
-      }
-    } catch (error) {
-      if (!rejected) {
-        rejected = true
-        reject(error)
-      }
-    } finally {
-      clearTimeout(timeoutId)
-    }
-  })
+  try {
+    return await fetch(params[0], {
+      ...params[1],
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -5,7 +5,7 @@ export const fetchWithTimeout = async (
   const controller = new AbortController()
 
   const timeoutId = setTimeout(() => {
-    console.log('Aborting request...')
+    console.log('Aborting request due to timeout...')
     controller.abort()
   }, timeout)
 

--- a/packages/utils/network.ts
+++ b/packages/utils/network.ts
@@ -7,7 +7,7 @@ export const fetchWithTimeout = async (
 
     let rejected = false
     const timeoutId = setTimeout(() => {
-      console.log('Aborting...')
+      console.log(`Aborting request due to timeout (${params[0]})...`)
       controller.abort()
 
       // In case abort controller does not work, reject manually.


### PR DESCRIPTION
This fixes indexer timeout on browsers that don't support the `AbortController`. It also fixes the indexer query during static props which broke when it became a serverless API call.