### PR TITLE
Minor UX fixes

### DIFF
--- a/packages/stateful/actions/components/ActionCard.tsx
+++ b/packages/stateful/actions/components/ActionCard.tsx
@@ -1,4 +1,5 @@
 import { Close } from '@mui/icons-material'
+import clsx from 'clsx'
 import { ComponentType, ReactNode } from 'react'
 
 import { IconButton } from '@dao-dao/stateless'
@@ -9,6 +10,7 @@ interface ActionCardProps extends Pick<ActionComponentProps, 'onRemove'> {
   Icon: ComponentType
   title: string
   footer?: ReactNode
+  childrenContainerClassName?: string
 }
 
 export const ActionCard = ({
@@ -17,6 +19,7 @@ export const ActionCard = ({
   onRemove,
   children,
   footer,
+  childrenContainerClassName,
 }: ActionCardProps) => (
   <div className="flex flex-col rounded-lg bg-background-tertiary">
     <div className="primary-text flex flex-row items-start justify-between gap-4 border-b border-border-base p-4 text-text-body">
@@ -33,7 +36,14 @@ export const ActionCard = ({
       )}
     </div>
 
-    <div className="flex flex-col gap-2 px-6 pt-4 pb-5">{children}</div>
+    <div
+      className={clsx(
+        'flex flex-col gap-2 px-6 pt-4 pb-5',
+        childrenContainerClassName
+      )}
+    >
+      {children}
+    </div>
 
     {footer && (
       <div className="flex flex-col gap-2 border-t border-border-secondary p-6 pt-5">

--- a/packages/stateful/actions/components/ValidatorActions.tsx
+++ b/packages/stateful/actions/components/ValidatorActions.tsx
@@ -55,11 +55,11 @@ export const ValidatorActionsComponent: ActionComponent = ({
   return (
     <ActionCard
       Icon={PickEmoji}
+      childrenContainerClassName="!gap-3"
       onRemove={onRemove}
       title={t('title.validatorActions')}
     >
       <SelectInput
-        containerClassName="mb-3"
         defaultValue={validatorActions[0].type}
         disabled={!isCreating}
         error={errors?.validatorActionType}

--- a/packages/stateless/components/token/TokenAmountDisplay.tsx
+++ b/packages/stateless/components/token/TokenAmountDisplay.tsx
@@ -29,8 +29,8 @@ import { Tooltip } from '../tooltip/Tooltip'
 // value estimates (i.e. USDC) (max 2) and ProfileHomeCard's unstaked and staked
 // balances (max 2).
 
-// Default maximum decimals to use in a USDC conversion.
-const USDC_CONVERSION_DEFAULT_MAX_DECIMALS = 2
+// Default maximum decimals to use in a USD estimate.
+const USD_ESTIMATE_DEFAULT_MAX_DECIMALS = 2
 // Maximum decimals to use in a large compacted value.
 const LARGE_COMPACT_MAX_DECIMALS = 2
 
@@ -119,7 +119,7 @@ export const TokenAmountDisplay = ({
 
   const maxCompactDecimals =
     maxDecimals ??
-    (estimatedUsdValue ? USDC_CONVERSION_DEFAULT_MAX_DECIMALS : decimals)
+    (estimatedUsdValue ? USD_ESTIMATE_DEFAULT_MAX_DECIMALS : decimals)
   const compactOptions: Intl.NumberFormatOptions & {
     roundingPriority: string
   } = {
@@ -193,20 +193,25 @@ export const TokenAmountDisplay = ({
     </p>
   )
 
+  // Show full value in tooltip if different from compact and not an
+  // estimated USD value.
+  const shouldShowFullTooltip =
+    !showFullAmount && wasCompacted && !estimatedUsdValue
+
   return (
     <Tooltip
       title={
-        !showFullAmount &&
-        (wasCompacted || dateFetched) && (
+        // Show tooltip with full value and fetch time.
+        shouldShowFullTooltip || dateFetched ? (
           <>
-            {/* Show full in tooltip if different from compact. */}
-            {wasCompacted &&
+            {shouldShowFullTooltip &&
               t('format.token', {
                 amount: full,
                 symbol,
               })}
-            {wasCompacted && dateFetched && <br />}
-            {/* Show date fetched if present. */}
+
+            {shouldShowFullTooltip && dateFetched && <br />}
+
             {dateFetched && (
               <span className="caption-text">
                 {t('info.fetchedAtTime', {
@@ -215,7 +220,7 @@ export const TokenAmountDisplay = ({
               </span>
             )}
           </>
-        )
+        ) : undefined
       }
     >
       {iconUrl ? (

--- a/packages/stateless/components/token/TokenCard.tsx
+++ b/packages/stateless/components/token/TokenCard.tsx
@@ -309,21 +309,30 @@ export const TokenCard = ({
                   symbol={tokenSymbol}
                 />
 
-                {!isJunoIbcUsdc(tokenDenom) && (
-                  <TokenAmountDisplay
-                    amount={
-                      lazyInfo.loading || !lazyInfo.data.usdcUnitPrice
-                        ? { loading: true }
-                        : unstakedBalance * lazyInfo.data.usdcUnitPrice.amount
-                    }
-                    dateFetched={
-                      lazyInfo.loading || !lazyInfo.data.usdcUnitPrice
-                        ? undefined
-                        : lazyInfo.data.usdcUnitPrice.timestamp
-                    }
-                    estimatedUsdValue
-                  />
-                )}
+                {!isJunoIbcUsdc(tokenDenom) &&
+                  (lazyInfo.loading || lazyInfo.data.usdcUnitPrice) && (
+                    <div className="flex flex-row items-center gap-1">
+                      <TokenAmountDisplay
+                        amount={
+                          lazyInfo.loading
+                            ? { loading: true }
+                            : unstakedBalance *
+                              lazyInfo.data.usdcUnitPrice!.amount
+                        }
+                        dateFetched={
+                          lazyInfo.loading
+                            ? undefined
+                            : lazyInfo.data.usdcUnitPrice!.timestamp
+                        }
+                        estimatedUsdValue
+                      />
+
+                      <TooltipInfoIcon
+                        size="xs"
+                        title={t('info.estimatedUsdValueTooltip')}
+                      />
+                    </div>
+                  )}
               </div>
             </div>
           )}


### PR DESCRIPTION
- Hides full (6 decimal USDC conversion) price in token amount tooltip when showing a USD estimated value. This value is insignificant as it's just an estimate.
- Added missing tooltip to token card.
- Adjusted spacing of validator action card.