### PR TITLE
Allow searching DAOs with no proposals

### DIFF
--- a/packages/state/indexer/search.ts
+++ b/packages/state/indexer/search.ts
@@ -36,7 +36,10 @@ export const searchDaos = async (
     limit,
     filter: [
       // Only show DAOs with proposals to reduce clutter/spam.
-      `(NOT value.proposalCount EXISTS) OR (value.proposalCount > 0)`,
+      //
+      // UPDATE: Commenting this out for now, since many DAOs have trouble
+      // finding themselves before they've made a proposal.
+      // `(NOT value.proposalCount EXISTS) OR (value.proposalCount > 0)`,
       ...(exclude?.length
         ? // Exclude DAOs that are in the exclude list.
           [`NOT contractAddress IN ["${exclude.join('", "')}"]`]


### PR DESCRIPTION
Some DAOs, such as Red DAO and Blue DAO, have no proposals and yet should be findable via search. This PR removes the search filter that hides DAOs with no proposals, until we find a better scheme for reducing noise/spam in the search (or a way to let DAOs hide themselves from search, so that people could remove duplicates on their own).