### PR TITLE
Minor UI tweaks

### DIFF
--- a/packages/stateful/actions/components/ActionCard.tsx
+++ b/packages/stateful/actions/components/ActionCard.tsx
@@ -21,7 +21,7 @@ export const ActionCard = ({
   footer,
   childrenContainerClassName,
 }: ActionCardProps) => (
-  <div className="flex flex-col rounded-lg bg-background-tertiary">
+  <div className="flex flex-col overflow-x-auto rounded-lg bg-background-tertiary">
     <div className="primary-text flex flex-row items-start justify-between gap-4 border-b border-border-base p-4 text-text-body">
       <div className="flex flex-row items-center gap-3">
         <p className="text-xl">

--- a/packages/stateful/actions/components/Spend.tsx
+++ b/packages/stateful/actions/components/Spend.tsx
@@ -171,7 +171,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
 
   return (
     <ActionCard Icon={MoneyEmoji} onRemove={onRemove} title={t('title.spend')}>
-      <div className="flex flex-col gap-x-3 gap-y-2 sm:flex-row sm:items-stretch">
+      <div className="flex min-w-0 flex-col flex-wrap gap-x-3 gap-y-2 sm:flex-row sm:items-stretch">
         <div className="flex grow flex-row items-stretch gap-2">
           <NumberInput
             containerClassName="grow"
@@ -223,7 +223,7 @@ export const SpendComponent: ActionComponent<SpendOptions> = ({
           </SelectInput>
         </div>
 
-        <div className="flex grow flex-row items-stretch gap-2 sm:gap-3">
+        <div className="flex min-w-0 grow flex-row items-stretch gap-2 sm:gap-3">
           <div className="flex flex-row items-center pl-1 sm:pl-0">
             <ArrowRightAltRounded className="!hidden !h-6 !w-6 text-text-secondary sm:!block" />
             <SubdirectoryArrowRightRounded className="!h-4 !w-4 text-text-secondary sm:!hidden" />

--- a/packages/stateless/components/EntityDisplay.tsx
+++ b/packages/stateless/components/EntityDisplay.tsx
@@ -23,10 +23,12 @@ export const EntityDisplay = ({
 }: EntityDisplayProps) => {
   const { t } = useTranslation()
 
-  imageSize ??= size === 'lg' ? 28 : 20
+  imageSize ??= size === 'lg' ? 28 : 24
 
   return (
-    <div className={clsx('flex flex-row items-center gap-2', className)}>
+    <div
+      className={clsx('flex min-w-0 flex-row items-center gap-2', className)}
+    >
       {!hideImage && (
         <Tooltip
           title={

--- a/packages/stateless/components/inputs/AddressInput.tsx
+++ b/packages/stateless/components/inputs/AddressInput.tsx
@@ -145,18 +145,26 @@ export const AddressInput = <
     return () => document.removeEventListener('keydown', handleKeyPress)
   }, [autofillProfiles, selectAutofillProfile, showProfileAutofill])
 
+  // Only display entity if input is disabled and we're showing the entity. This
+  // is probably showing in a readonly form with submitted data.
+  const onlyDisplayEntity = disabled && showEntity
+
   return (
     <div
       className={clsx(
-        'secondary-text group relative flex items-center gap-3 rounded-md bg-transparent py-3 px-4 font-mono text-sm ring-1 transition-all focus-within:ring-2',
-        error && !showProfileAutofill
-          ? 'ring-border-interactive-error'
-          : 'ring-border-primary focus:ring-border-interactive-focus',
+        'secondary-text group relative flex items-center gap-3 bg-transparent font-mono text-sm transition-all',
+        // If not only displaying entity, add padding and border.
+        !onlyDisplayEntity && [
+          'rounded-md py-3 px-4 ring-1 focus-within:ring-2',
+          error && !showProfileAutofill
+            ? 'ring-border-interactive-error'
+            : 'ring-border-primary focus:ring-border-interactive-focus',
+        ],
         showProfileAutofill && 'rounded-b-none',
         containerClassName
       )}
     >
-      {(disabled && showEntity) || (
+      {!onlyDisplayEntity && (
         <>
           {/* If profiles are loading, display loader. */}
           {autofillProfiles?.loading ? (
@@ -198,13 +206,14 @@ export const AddressInput = <
           />
         </>
       )}
+
       {showEntity && (
         <div className={clsx(disabled || 'pl-4')}>
           <EntityDisplay address={formValue} />
         </div>
       )}
 
-      {type === 'wallet' && !!autofillProfiles && (
+      {!disabled && type === 'wallet' && !!autofillProfiles && (
         <div
           className={clsx(
             'absolute top-full -left-[2px] -right-[2px] z-10 mt-[2px] overflow-hidden rounded-b-md border-2 border-t-0 border-border-primary bg-component-dropdown transition-all',

--- a/packages/stateless/components/inputs/AddressInput.tsx
+++ b/packages/stateless/components/inputs/AddressInput.tsx
@@ -152,14 +152,16 @@ export const AddressInput = <
   return (
     <div
       className={clsx(
-        'secondary-text group relative flex items-center gap-3 bg-transparent font-mono text-sm transition-all',
-        // If not only displaying entity, add padding and border.
-        !onlyDisplayEntity && [
-          'rounded-md py-3 px-4 ring-1 focus-within:ring-2',
-          error && !showProfileAutofill
-            ? 'ring-border-interactive-error'
-            : 'ring-border-primary focus:ring-border-interactive-focus',
-        ],
+        'secondary-text group relative flex min-w-0 items-center gap-3 bg-transparent font-mono text-sm transition-all',
+        // If not only displaying entity, add more border.
+        onlyDisplayEntity
+          ? 'p-2'
+          : [
+              'rounded-md py-3 px-4 ring-1 focus-within:ring-2 ',
+              error && !showProfileAutofill
+                ? 'ring-border-interactive-error'
+                : 'ring-border-primary focus:ring-border-interactive-focus',
+            ],
         showProfileAutofill && 'rounded-b-none',
         containerClassName
       )}
@@ -208,9 +210,10 @@ export const AddressInput = <
       )}
 
       {showEntity && (
-        <div className={clsx(disabled || 'pl-4')}>
-          <EntityDisplay address={formValue} />
-        </div>
+        <EntityDisplay
+          address={formValue}
+          className={clsx(disabled || 'pl-4')}
+        />
       )}
 
       {!disabled && type === 'wallet' && !!autofillProfiles && (


### PR DESCRIPTION
## Clean up entity display
This removes the border around `AddressInput` when it is disabled and displaying an entity. w0000000000ooott

Old:
<img width="550" alt="Screenshot 2023-01-17 at 1 08 36 AM" src="https://user-images.githubusercontent.com/6721426/212856038-3a091d0d-fb2b-45ce-8d03-8d0fc16bc9fb.png">

New:
<img width="577" alt="Screenshot 2023-01-17 at 1 09 39 AM" src="https://user-images.githubusercontent.com/6721426/212856312-dba8419f-af02-4f85-8389-f107694d7866.png">


## Fix Spend component wrapping

Problem:
<img width="265" alt="Screenshot 2023-01-17 at 1 07 38 AM" src="https://user-images.githubusercontent.com/6721426/212855760-49044b21-94cd-4539-9b2e-e3931e616028.png">

(Overflow increases parent scroll container and even more overflow wooooo)
<img width="622" alt="Screenshot 2023-01-17 at 1 07 49 AM" src="https://user-images.githubusercontent.com/6721426/212855801-93333bfd-6515-47cf-9270-6ba8b64b3fe0.png">

Solution:
<img width="261" alt="Screenshot 2023-01-17 at 1 06 32 AM" src="https://user-images.githubusercontent.com/6721426/212855461-88ca65e4-d6dc-4636-a8e1-87d7314401f9.png">
