### PR TITLE
Improve search by prioritizing those with proposals

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -518,6 +518,7 @@
     "noGovernanceProposalsOpenForVoting": "There are no governance proposals open for voting.",
     "noNftsYet": "No NFTs to appreciate yet.",
     "noProposalsAndAllCaughtUp": "You're all caught up! There are no open proposals in any of the DAOs you follow.",
+    "noProposalsTooltip": "This DAO has no proposals and may be inactive or a duplicate.",
     "noProposalsYet": "No proposals to vote on yet.",
     "noSubDaosYet": "No SubDAOs yet.",
     "noSubmission": "No submission",

--- a/packages/state/indexer/search.ts
+++ b/packages/state/indexer/search.ts
@@ -48,7 +48,7 @@ export const searchDaos = async (
       .map((filter) => `(${filter})`)
       .join(' AND '),
     // Most recent at the top.
-    sort: ['blockHeight:desc'],
+    sort: ['blockHeight:desc', 'value.proposalCount:desc'],
   })
 
   return results.hits

--- a/packages/stateful/command/components/CommandModalContextView.tsx
+++ b/packages/stateful/command/components/CommandModalContextView.tsx
@@ -56,11 +56,24 @@ export const InnerCommandModalContextView = ({
       itemsWithSection = fuse.search(filter).map((o) => o.item)
     }
 
-    // Sections ordered in the order one of their items first appears in list of
-    // all filtered items.
+    // Sections ordered by their `order` field if present, and then in the order
+    // one of their items first appears in list of all filtered items.
     const orderedSections = itemsWithSection.reduce(
       (acc, { section }) => (acc.includes(section) ? acc : [...acc, section]),
-      [] as CommandModalContextSection[]
+      // Start with the sections that have an order field, if a searched item
+      // exists for them.
+      filter
+        ? sections
+            .filter(
+              (section) =>
+                section.searchOrder !== undefined &&
+                itemsWithSection.some((o) => o.section === section)
+            )
+            .sort(
+              (a, b) =>
+                (a.searchOrder ?? Infinity) - (b.searchOrder ?? Infinity)
+            )
+        : []
     )
 
     // For each section, override the items with the sorted and filtered

--- a/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
+++ b/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
@@ -4,6 +4,7 @@ import { searchDaosSelector } from '@dao-dao/state/recoil'
 import { useCachedLoadable } from '@dao-dao/stateless'
 import {
   CommandModalContextSection,
+  CommandModalContextSectionItem,
   CommandModalContextUseSectionsOptions,
   CommandModalDaoInfo,
 } from '@dao-dao/types'
@@ -54,13 +55,19 @@ export const usePinnedAndFilteredDaosSections = ({
             contractAddress,
             value: {
               config: { name, image_url },
+              proposalCount,
             },
-          }): CommandModalDaoInfo => ({
+          }): CommandModalContextSectionItem<CommandModalDaoInfo> => ({
             // Nothing specific to set here yet, just uses default.
             chainId: undefined,
             coreAddress: contractAddress,
             name,
             imageUrl: image_url || getFallbackImage(contractAddress),
+            // If DAO has no proposals...
+            ...(proposalCount === 0 && {
+              className: 'opacity-50',
+              tooltip: t('info.noProposalsTooltip'),
+            }),
           })
         )
     : // Otherwise when filter is empty, display featured DAOs.

--- a/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
+++ b/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
@@ -63,7 +63,8 @@ export const usePinnedAndFilteredDaosSections = ({
             coreAddress: contractAddress,
             name,
             imageUrl: image_url || getFallbackImage(contractAddress),
-            // If DAO has no proposals...
+            // If DAO has no proposals, make it less visible and give it a
+            // tooltip to indicate that it may not be active.
             ...(proposalCount === 0 && {
               className: 'opacity-50',
               tooltip: t('info.noProposalsTooltip'),

--- a/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
+++ b/packages/stateful/command/hooks/usePinnedAndFilteredDaosSections.ts
@@ -79,6 +79,9 @@ export const usePinnedAndFilteredDaosSections = ({
     name: t('title.following'),
     onChoose,
     items: pinnedDaosLoading.loading ? [] : pinnedDaosLoading.data,
+    // When a search is active, show above all other sections. This serves to
+    // prioritize the DAOs you follow over all other DAOs you can search.
+    searchOrder: 1,
   }
 
   const daosSection: CommandModalContextSection<CommandModalDaoInfo> = {

--- a/packages/stateless/components/command/ItemRow.tsx
+++ b/packages/stateless/components/command/ItemRow.tsx
@@ -70,7 +70,24 @@ export const ItemRow = forwardRef<HTMLDivElement, ItemRowProps>(
           {item.name}
         </p>
 
-        {!!item.tooltip && <TooltipInfoIcon size="xs" title={item.tooltip} />}
+        {!!item.tooltip && (
+          <TooltipInfoIcon
+            key={
+              // Re-render when selected changes. This is because the underlying
+              // Material UI tooltip uses the initial state of the `open` prop
+              // to determine if the component should be controlled by the
+              // `open` prop or listen to touch events. We want to be able to
+              // force the tooltip open when this item is selected, and also
+              // allow hovering to open the tooltip when this item is not
+              // selected. Thus, we need to re-render this component when
+              // selected changes.
+              selected ? 'selected' : 'unselected'
+            }
+            open={selected || undefined}
+            size="xs"
+            title={item.tooltip}
+          />
+        )}
       </div>
     )
   }

--- a/packages/stateless/components/command/ItemRow.tsx
+++ b/packages/stateless/components/command/ItemRow.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next'
 import { CommandModalContextSectionItem } from '@dao-dao/types/command'
 import { toAccessibleImageUrl } from '@dao-dao/utils'
 
+import { TooltipInfoIcon } from '../tooltip'
+
 export interface ItemRowProps {
   item: CommandModalContextSectionItem
   selected: boolean
@@ -24,6 +26,7 @@ export const ItemRow = forwardRef<HTMLDivElement, ItemRowProps>(
             'cursor-pointer hover:bg-background-interactive-hover',
           !item.disabled && selected && 'bg-background-interactive-hover',
           item.loading && 'animate-pulse',
+          item.className,
           className
         )}
         onClick={item.disabled ? undefined : onClick}
@@ -60,12 +63,14 @@ export const ItemRow = forwardRef<HTMLDivElement, ItemRowProps>(
 
         <p
           className={clsx(
-            'link-text font-medium transition',
+            'link-text grow font-medium transition',
             item.disabled ? 'text-text-interactive-disabled' : 'text-text-body'
           )}
         >
           {item.name}
         </p>
+
+        {!!item.tooltip && <TooltipInfoIcon size="xs" title={item.tooltip} />}
       </div>
     )
   }

--- a/packages/types/command.ts
+++ b/packages/types/command.ts
@@ -33,6 +33,12 @@ export interface CommandModalContextSection<
   name: string
   items: CommandModalContextSectionItem<ExtraItemProperties>[]
   onChoose: (item: CommandModalContextSectionItem<ExtraItemProperties>) => void
+  // If present, will be used to order sections before sorting by search field.
+  // For example: following DAOs should always appear above searched DAOs. If
+  // not present, will be after those with an order set. Ascending by order, so
+  // lowest orders first. This only applies when a search is being applied.
+  // Otherwise, the section order is used.
+  searchOrder?: number
 }
 
 export interface CommandModalContextUseSectionsOptions {

--- a/packages/types/command.ts
+++ b/packages/types/command.ts
@@ -12,6 +12,8 @@ export type CommandModalContextSectionItem<
   ExtraItemProperties extends {} = {}
 > = ExtraItemProperties & {
   name: string
+  tooltip?: string
+  className?: string
   disabled?: boolean
   loading?: boolean
 } & (


### PR DESCRIPTION
This PR solves some of our current search issues with duplicates by making it clear what the status of a DAO is in relation to the DAOs around it. It also prioritizes DAOs you follow above the search results.

![image](https://user-images.githubusercontent.com/6721426/213312793-de07cc88-ee91-4c3f-bb11-3634673fea19.png)

![image](https://user-images.githubusercontent.com/6721426/213312801-68bf174b-27a0-4e78-b833-6e5a96793771.png)
