### PR TITLE
Hide inbox and following when not connected

### DIFF
--- a/packages/stateful/components/AppLayout.tsx
+++ b/packages/stateful/components/AppLayout.tsx
@@ -280,6 +280,7 @@ export const AppLayout = ({ children }: { children: ReactNode }) => {
         connected={connected}
         context={appLayoutContext}
         navigationProps={{
+          walletConnected: connected,
           LinkWrapper,
           inboxCount:
             inbox.loading ||

--- a/packages/stateless/components/layout/Navigation.stories.tsx
+++ b/packages/stateless/components/layout/Navigation.stories.tsx
@@ -22,6 +22,7 @@ const Template: ComponentStory<typeof Navigation> = (args) => {
 // Used in `makeAppLayoutDecorator` to provide a default layout for the page
 // stories. Ensure this has all props.
 export const DefaultArgs: NavigationProps = {
+  walletConnected: true,
   inboxCount: {
     loading: false,
     data: 5,

--- a/packages/stateless/components/layout/Navigation.tsx
+++ b/packages/stateless/components/layout/Navigation.tsx
@@ -55,7 +55,7 @@ export const Navigation = ({
   version,
   tokenPrices,
   followingDaos,
-  hideInbox = false,
+  walletConnected,
   compact,
   setCompact,
   mountedInBrowser,
@@ -202,67 +202,70 @@ export const Navigation = ({
             }
           />
 
-          {!hideInbox && (
-            <Row
-              Icon={InboxOutlined}
-              LinkWrapper={LinkWrapper}
-              compact={compact}
-              href="/inbox"
-              label={
-                !inboxCount.loading && inboxCount.data > 0
-                  ? t('title.inboxWithCount', { count: inboxCount.data })
-                  : t('title.inbox')
-              }
-              loading={inboxCount.loading}
-              showBadge={!inboxCount.loading && inboxCount.data > 0}
-            />
-          )}
+          {/* Only show inbox and following when connected. */}
+          {walletConnected && (
+            <>
+              <Row
+                Icon={InboxOutlined}
+                LinkWrapper={LinkWrapper}
+                compact={compact}
+                href="/inbox"
+                label={
+                  !inboxCount.loading && inboxCount.data > 0
+                    ? t('title.inboxWithCount', { count: inboxCount.data })
+                    : t('title.inbox')
+                }
+                loading={inboxCount.loading}
+                showBadge={!inboxCount.loading && inboxCount.data > 0}
+              />
 
-          <Row
-            Icon={CheckRounded}
-            LinkWrapper={LinkWrapper}
-            compact={compact}
-            defaultExpanded
-            label={t('title.following')}
-            loading={followingDaos.loading}
-          >
-            {!followingDaos.loading && (
-              <div
-                className={clsx(
-                  'relative sm:max-h-[50vh]',
-                  !followingDaos.loading && 'no-scrollbar overflow-y-auto',
-                  compact && 'mt-1 w-min'
-                )}
-                ref={scrollableFollowingContainerRef}
+              <Row
+                Icon={CheckRounded}
+                LinkWrapper={LinkWrapper}
+                compact={compact}
+                defaultExpanded
+                label={t('title.following')}
+                loading={followingDaos.loading}
               >
-                {/* Top border */}
-                <div
-                  className={clsx(
-                    'sticky top-0 right-0 left-0 h-[1px] bg-border-primary transition-opacity',
-                    showFollowingTopBorder ? 'opacity-100' : 'opacity-0'
-                  )}
-                ></div>
+                {!followingDaos.loading && (
+                  <div
+                    className={clsx(
+                      'relative sm:max-h-[50vh]',
+                      !followingDaos.loading && 'no-scrollbar overflow-y-auto',
+                      compact && 'mt-1 w-min'
+                    )}
+                    ref={scrollableFollowingContainerRef}
+                  >
+                    {/* Top border */}
+                    <div
+                      className={clsx(
+                        'sticky top-0 right-0 left-0 h-[1px] bg-border-primary transition-opacity',
+                        showFollowingTopBorder ? 'opacity-100' : 'opacity-0'
+                      )}
+                    ></div>
 
-                {/* DAOs */}
-                {followingDaos.data.map((dao, index) => (
-                  <DaoDropdown
-                    key={index}
-                    LinkWrapper={LinkWrapper}
-                    compact={compact}
-                    dao={dao}
-                  />
-                ))}
+                    {/* DAOs */}
+                    {followingDaos.data.map((dao, index) => (
+                      <DaoDropdown
+                        key={index}
+                        LinkWrapper={LinkWrapper}
+                        compact={compact}
+                        dao={dao}
+                      />
+                    ))}
 
-                {/* Bottom border */}
-                <div
-                  className={clsx(
-                    'sticky right-0 bottom-0 left-0 h-[1px] bg-border-primary transition-opacity',
-                    showFollowingBottomBorder ? 'opacity-100' : 'opacity-0'
-                  )}
-                ></div>
-              </div>
-            )}
-          </Row>
+                    {/* Bottom border */}
+                    <div
+                      className={clsx(
+                        'sticky right-0 bottom-0 left-0 h-[1px] bg-border-primary transition-opacity',
+                        showFollowingBottomBorder ? 'opacity-100' : 'opacity-0'
+                      )}
+                    ></div>
+                  </div>
+                )}
+              </Row>
+            </>
+          )}
 
           <Row
             Icon={Add}

--- a/packages/stateless/pages/Home.stories.tsx
+++ b/packages/stateless/pages/Home.stories.tsx
@@ -108,7 +108,7 @@ Disconnected.parameters = {
 Disconnected.decorators = [
   makeAppLayoutDecorator({
     navigationProps: {
-      hideInbox: true,
+      walletConnected: false,
     },
     rightSidebarProps: {
       wallet: (

--- a/packages/stateless/pages/Home.tsx
+++ b/packages/stateless/pages/Home.tsx
@@ -24,7 +24,8 @@ const widthOfSidePadding = 'w-[max((100%-64rem)/2,1.5rem)]'
 export const Home = ({
   featuredDaosProps,
   rightSidebarContent,
-  ...props
+  followingDaosProps,
+  connected,
 }: HomeProps) => {
   const { t } = useTranslation()
   const { RightSidebarContent, PageHeader } = useAppLayoutContext()
@@ -69,13 +70,19 @@ export const Home = ({
           ></div>
         </div>
 
-        {/* Divider */}
-        <div className={clsx('h-[1px] bg-border-secondary', maxWidth)}></div>
-
         {/* Following DAOs */}
-        <div className={clsx('flex flex-col gap-8', maxWidth)}>
-          <FollowingDaos {...props.followingDaosProps} />
-        </div>
+        {connected && (
+          <>
+            {/* Divider */}
+            <div
+              className={clsx('h-[1px] bg-border-secondary', maxWidth)}
+            ></div>
+
+            <div className={clsx('flex flex-col gap-8', maxWidth)}>
+              <FollowingDaos {...followingDaosProps} />
+            </div>
+          </>
+        )}
       </div>
     </>
   )

--- a/packages/types/stateless/Navigation.ts
+++ b/packages/types/stateless/Navigation.ts
@@ -17,7 +17,7 @@ export interface NavigationProps {
   version: string
   tokenPrices?: LoadingData<NavigationTokenPrice[]>
   followingDaos: LoadingData<DaoDropdownInfo[]>
-  hideInbox?: boolean
+  walletConnected: boolean
   compact: boolean
   setCompact: (compact: boolean) => void
   mountedInBrowser: boolean


### PR DESCRIPTION
Resolves #1056 

Since following is now attached to a wallet login, the inbox and following navigation items are always empty when disconnected. Let's just hide them until a wallet is connected.

It looks pretty bare now as a result. I think we'll want to fill in the space with documentation, guides, tutorials, instructions, etc.

<img width="2168" alt="Screenshot 2023-01-24 at 1 55 11 PM" src="https://user-images.githubusercontent.com/6721426/214429760-532f12e0-05e6-440d-830c-868a7768b82f.png">
