### PR TITLE
Fix actions refreshing unnecessarily

### DIFF
--- a/packages/stateful/actions/actions/Spend.tsx
+++ b/packages/stateful/actions/actions/Spend.tsx
@@ -92,14 +92,19 @@ const useCw20BalancesAndInfos = () => {
 }
 
 const Component: ActionComponent<undefined, SpendData> = (props) => {
-  const { address } = useActionOptions()
+  const { address, chainId } = useActionOptions()
 
-  // This needs to be loaded via a cached loadable to avoid displaying a
-  // loader when this data updates on a schedule. Manually trigger a suspense
-  // loader the first time when the initial data is still loading.
+  // This needs to be loaded via a cached loadable to avoid displaying a loader
+  // when this data updates on a schedule. Manually trigger a suspense loader
+  // the first time when the initial data is still loading.
   const nativeBalancesLoadable = loadableToLoadingData(
     useCachedLoadable(
-      address ? nativeBalancesSelector({ address }) : undefined
+      address
+        ? nativeBalancesSelector({
+            address,
+            chainId,
+          })
+        : undefined
     ),
     []
   )


### PR DESCRIPTION
The execute and instantiate actions use native balances to allow specifying funds to be included with the wasm message. Some time after these actions were created, we made the balances update every minute in the background. These actions were using the old way of accessing the balances (i.e. not using a loadable), which caused the components to suspend every minute when the refresh occurs. This is bad UX, and everywhere else we use loadables. This PR updates these actions to use loadables too.

This has bugged me for sooooo long and only on my 9000th time being annoyed by it did I decide to fix it... of course it was age-old tech debt :P