### PR TITLE
[legacy] Don't error if proposal message fails to decode

### DIFF
--- a/apps/dapp/components/ProposalDetails.tsx
+++ b/apps/dapp/components/ProposalDetails.tsx
@@ -182,28 +182,33 @@ export function ProposalDetails({
     <StatelessProposalDetails
       loading={loading}
       messageToDisplay={(message) => {
-        const data = messageTemplateAndValuesForDecodedCosmosMsg(
-          message,
-          fromCosmosMsgProps
-        )
-        if (data) {
-          const ThisIsAComponentBecauseReactIsAnnoying = () => {
-            // Can't call `useForm` in a callback.
-            const formMethods = useForm({ defaultValues: data.values })
-            return (
-              <FormProvider {...formMethods}>
-                <form>
-                  <data.template.component
-                    contractAddress={contractAddress}
-                    getLabel={(field: string) => field}
-                    multisig={multisig}
-                    readOnly
-                  />
-                </form>
-              </FormProvider>
-            )
+        // If message fails to decode, just display the JSON.
+        try {
+          const data = messageTemplateAndValuesForDecodedCosmosMsg(
+            message,
+            fromCosmosMsgProps
+          )
+          if (data) {
+            const ThisIsAComponentBecauseReactIsAnnoying = () => {
+              // Can't call `useForm` in a callback.
+              const formMethods = useForm({ defaultValues: data.values })
+              return (
+                <FormProvider {...formMethods}>
+                  <form>
+                    <data.template.component
+                      contractAddress={contractAddress}
+                      getLabel={(field: string) => field}
+                      multisig={multisig}
+                      readOnly
+                    />
+                  </form>
+                </FormProvider>
+              )
+            }
+            return <ThisIsAComponentBecauseReactIsAnnoying />
           }
-          return <ThisIsAComponentBecauseReactIsAnnoying />
+        } catch (e) {
+          console.error(e)
         }
         return (
           <CosmosMessageDisplay value={JSON.stringify(message, undefined, 2)} />


### PR DESCRIPTION
The WYND legacy multisig created a message that fails to properly decode. This causes the page to crash instead of just showing the raw JSON of the message. This PR fixes that.

https://legacy.daodao.zone/multisig/juno1hrs4jha85xmm56p5z80lq706ckq9zxpfhg3mcx5n7est4ffxykls82eaps/proposals/34