### PR TITLE
Remove DAO description max

### DIFF
--- a/packages/i18n/locales/dog/translation.json
+++ b/packages/i18n/locales/dog/translation.json
@@ -139,7 +139,6 @@
     "createProposalSubmitInvalid": "corect teh errurz above b4 previevin or publisshing",
     "daoFeatureUnsupported": "{{name}} don suport {{feature}} yet",
     "daoIsPaused": "u cannt cre8 a puppozal when da da0 iz pauzed",
-    "descriptionTooLong": "a da0s descripshon must bee lesss den er eqwal 2 {{max}} cherecterz lonng 🐶",
     "errorOccurredOnPage": "an errr ocoorrd on dis page",
     "failedParsingCoreVersion": "fayld 2 deternmin corr verzion",
     "failedToGetTokenInfo": "failb 2 git tokken info. pliz enter a valid {{tokenType}} contract adress",

--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -194,7 +194,6 @@
     "createProposalSubmitInvalid": "Correct the errors above before previewing or publishing.",
     "daoFeatureUnsupported": "{{name}} does not support {{feature}} yet.",
     "daoIsPaused": "You cannot create a proposal when the DAO is paused.",
-    "descriptionTooLong": "A DAO's description must be less than or equal to {{max}} characters long.",
     "discordAuthFailed": "Discord authentication unexpectedly failed. Try again or reach out to us for assistance.",
     "errorOccurredOnPage": "An error occurred on this page.",
     "failedParsingCoreVersion": "Failed to determine core version.",

--- a/packages/stateless/components/dao/create/pages/CreateDaoStart.tsx
+++ b/packages/stateless/components/dao/create/pages/CreateDaoStart.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next'
 
 import { CreateDaoContext } from '@dao-dao/types'
 import {
-  MAX_DAO_DESCRIPTION_LENGTH,
   MAX_DAO_NAME_LENGTH,
   MIN_DAO_NAME_LENGTH,
   validateRequired,
@@ -51,14 +50,7 @@ export const CreateDaoStart = ({
           </div>
         </div>
         <div className="flex flex-col gap-4 p-6 pt-5">
-          <p className="primary-text text-text-body">
-            {t('form.description')}
-            <span className="text-text-tertiary">
-              {/* eslint-disable-next-line i18next/no-literal-string */}
-              {' – '}
-              {t('form.maxCharacters', { max: MAX_DAO_DESCRIPTION_LENGTH })}
-            </span>
-          </p>
+          <p className="primary-text text-text-body">{t('form.description')}</p>
 
           <div className="flex flex-col">
             <TextAreaInput
@@ -67,14 +59,7 @@ export const CreateDaoStart = ({
               placeholder={t('form.daoDescriptionPlaceholder')}
               register={register}
               rows={5}
-              validation={[
-                validateRequired,
-                (value) =>
-                  value.length <= MAX_DAO_DESCRIPTION_LENGTH ||
-                  t('error.descriptionTooLong', {
-                    max: MAX_DAO_DESCRIPTION_LENGTH,
-                  }),
-              ]}
+              validation={[validateRequired]}
             />
             <InputErrorMessage error={errors.description} />
           </div>

--- a/packages/utils/constants/index.ts
+++ b/packages/utils/constants/index.ts
@@ -85,10 +85,6 @@ export const MAX_DAO_NAME_LENGTH = parseInt(
   process.env.NEXT_PUBLIC_MAX_DAO_NAME_LENGTH || '50',
   10
 )
-export const MAX_DAO_DESCRIPTION_LENGTH = parseInt(
-  process.env.NEXT_PUBLIC_MAX_DAO_DESCRIPTION_LENGTH || '130',
-  10
-)
 
 export const MAX_META_CHARS_PROPOSAL_DESCRIPTION = parseInt(
   process.env.NEXT_PUBLIC_MAX_META_CHARS_PROPOSAL_DESCRIPTION || '200',


### PR DESCRIPTION
The DAO descriptions were set at an arbitrary limit of 130 characters. This removes that limit because it's hard to predict wha the number will be (and it will change as gas fees change), but it's definitely not that low.