### PR TITLE
Fixed fiat modal height, scrolling, and address truncation

### DIFF
--- a/packages/stateless/components/modals/KadoModal.tsx
+++ b/packages/stateless/components/modals/KadoModal.tsx
@@ -38,28 +38,23 @@ export const KadoModal = ({
         </div>
       )}
 
-      <iframe
-        className={clsx(
-          'max-h-full min-h-[48rem] w-full shrink-0 grow rounded-md',
-          // iframe hijacks clicks on Safari even when pointer-events are set to
-          // none (which happens on the modal when visible=false), so we need to
-          // completely hide this.
-          //
-          // https://stackoverflow.com/questions/39533016/iframe-with-pointer-eventsnone-hijacks-clicks-in-safari-on-ios
-          !modalProps.visible && 'hidden'
-        )}
-        src={`https://app.kado.money/?${queryString.stringify({
-          apiKey: KADO_API_KEY,
-          onRevCurrency: 'USDC',
-          offPayCurrency: 'USDC',
-          offRevCurrency: 'USDC',
-          product: defaultMode?.toUpperCase(),
-          onToAddress: toAddress,
-          network: 'JUNO',
-          cryptoList: 'USDC',
-          networkList: 'JUNO',
-        })}`}
-      />
+      {/* iframe hijacks clicks on mobile Safari even when pointer-events are set to none (which happens on the modal when visible=false), so we need to completely hide the iframe when invisible. https://stackoverflow.com/questions/39533016/iframe-with-pointer-eventsnone-hijacks-clicks-in-safari-on-ios */}
+      {modalProps.visible && (
+        <iframe
+          className="max-h-full min-h-[48rem] w-full shrink-0 grow rounded-md"
+          src={`https://app.kado.money/?${queryString.stringify({
+            apiKey: KADO_API_KEY,
+            onRevCurrency: 'USDC',
+            offPayCurrency: 'USDC',
+            offRevCurrency: 'USDC',
+            product: defaultMode?.toUpperCase(),
+            onToAddress: toAddress,
+            network: 'JUNO',
+            cryptoList: 'USDC',
+            networkList: 'JUNO',
+          })}`}
+        />
+      )}
     </Modal>
   )
 }

--- a/packages/stateless/components/modals/KadoModal.tsx
+++ b/packages/stateless/components/modals/KadoModal.tsx
@@ -19,7 +19,7 @@ export const KadoModal = ({
 
   return (
     <Modal
-      containerClassName={clsx('!h-[90vh] !max-w-lg', containerClassName)}
+      containerClassName={clsx('!h-[80vh] !max-w-lg', containerClassName)}
       {...modalProps}
     >
       {toAddress && (
@@ -39,10 +39,7 @@ export const KadoModal = ({
       )}
 
       <iframe
-        className={clsx(
-          'min-h-[48rem] w-full shrink-0 grow rounded-md',
-          !modalProps.visible && 'pointer-events-none'
-        )}
+        className="max-h-full min-h-[48rem] w-full shrink-0 grow rounded-md"
         src={`https://app.kado.money/?${queryString.stringify({
           apiKey: KADO_API_KEY,
           onRevCurrency: 'USDC',

--- a/packages/stateless/components/modals/KadoModal.tsx
+++ b/packages/stateless/components/modals/KadoModal.tsx
@@ -30,7 +30,8 @@ export const KadoModal = ({
             <p>{t('info.verifyAddressMatches')}</p>
 
             <CopyToClipboard
-              takeStartEnd={{ start: 16, end: 16 }}
+              className="w-full"
+              takeStartEnd={{ start: 10, end: 8 }}
               value={toAddress}
             />
           </div>
@@ -38,8 +39,7 @@ export const KadoModal = ({
       )}
 
       <iframe
-        className="rounded-md"
-        height="100%"
+        className="min-h-[48rem] w-full shrink-0 grow rounded-md"
         src={`https://app.kado.money/?${queryString.stringify({
           apiKey: KADO_API_KEY,
           onRevCurrency: 'USDC',
@@ -51,7 +51,6 @@ export const KadoModal = ({
           cryptoList: 'USDC',
           networkList: 'JUNO',
         })}`}
-        width="100%"
       />
     </Modal>
   )

--- a/packages/stateless/components/modals/KadoModal.tsx
+++ b/packages/stateless/components/modals/KadoModal.tsx
@@ -39,7 +39,15 @@ export const KadoModal = ({
       )}
 
       <iframe
-        className="max-h-full min-h-[48rem] w-full shrink-0 grow rounded-md"
+        className={clsx(
+          'max-h-full min-h-[48rem] w-full shrink-0 grow rounded-md',
+          // iframe hijacks clicks on Safari even when pointer-events are set to
+          // none (which happens on the modal when visible=false), so we need to
+          // completely hide this.
+          //
+          // https://stackoverflow.com/questions/39533016/iframe-with-pointer-eventsnone-hijacks-clicks-in-safari-on-ios
+          !modalProps.visible && 'hidden'
+        )}
         src={`https://app.kado.money/?${queryString.stringify({
           apiKey: KADO_API_KEY,
           onRevCurrency: 'USDC',

--- a/packages/stateless/components/modals/KadoModal.tsx
+++ b/packages/stateless/components/modals/KadoModal.tsx
@@ -39,7 +39,10 @@ export const KadoModal = ({
       )}
 
       <iframe
-        className="min-h-[48rem] w-full shrink-0 grow rounded-md"
+        className={clsx(
+          'min-h-[48rem] w-full shrink-0 grow rounded-md',
+          !modalProps.visible && 'pointer-events-none'
+        )}
         src={`https://app.kado.money/?${queryString.stringify({
           apiKey: KADO_API_KEY,
           onRevCurrency: 'USDC',


### PR DESCRIPTION
Minor fixes to make scrolling the fiat modal better on mobile.

Also unrender the fiat iframe when it is not visible because iframe hijacks touches on mobile Safari even when hidden :////////////
huge bruh moment