### PR TITLE
Don't index cw721s (NFTs)

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -456,7 +456,7 @@
     "availableHistoryLoaded": "All available history has been loaded.",
     "burnNftDescription": "Burn an NFT.",
     "bypassSimulationExplanation": "Simulating the proposal failed. If you don't know what this means, one of the actions above is probably misconfigured. If you are sure you want to publish it anyway, click the button again.",
-    "chooseNftProfilePictureSubtitle": "Use one of your Stargaze NFTs to represent your identity on DAO DAO. Your Keplr profile image will be used as a backup if available.",
+    "chooseNftProfilePictureSubtitle": "Use one of your Juno or Stargaze NFTs to represent your identity on DAO DAO. Your Keplr profile image will be used as a backup if available.",
     "claimToReceiveUnstaked": "Claim them to receive your unstaked tokens.",
     "claimedRewards": "Claimed rewards",
     "closedAtDate": "Closed at {{date}}",

--- a/packages/state/recoil/selectors/contracts/Cw721Base.ts
+++ b/packages/state/recoil/selectors/contracts/Cw721Base.ts
@@ -24,7 +24,6 @@ import {
   signingCosmWasmClientAtom,
 } from '../../atoms'
 import { cosmWasmClientForChainSelector } from '../chain'
-import { queryContractIndexerSelector } from '../indexer'
 
 type QueryClientParams = WithChainId<{
   contractAddress: string
@@ -73,18 +72,9 @@ export const ownerOfSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const ownerOf = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/ownerOf',
-          args: params[0],
-        })
-      )
-      if (ownerOf) {
-        return ownerOf
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.ownerOf(...params)
     },
@@ -99,6 +89,9 @@ export const approvalSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.approval(...params)
     },
@@ -113,18 +106,9 @@ export const approvalsSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const approvals = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/approvals',
-          args: params[0],
-        })
-      )
-      if (approvals) {
-        return { approvals }
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.approvals(...params)
     },
@@ -139,18 +123,9 @@ export const allOperatorsSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const operators = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/allOperators',
-          args: params[0],
-        })
-      )
-      if (operators) {
-        return { operators }
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.allOperators(...params)
     },
@@ -165,17 +140,9 @@ export const numTokensSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const count = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/numTokens',
-        })
-      )
-      if (count) {
-        return { count }
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.numTokens(...params)
     },
@@ -190,17 +157,9 @@ export const contractInfoSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const contractInfo = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/contractInfo',
-        })
-      )
-      if (contractInfo) {
-        return contractInfo
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.contractInfo(...params)
     },
@@ -215,18 +174,9 @@ export const nftInfoSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const nftInfo = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/nftInfo',
-          args: params[0],
-        })
-      )
-      if (nftInfo) {
-        return nftInfo
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.nftInfo(...params)
     },
@@ -241,25 +191,15 @@ export const allNftInfoSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const allNftInfo = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/allNftInfo',
-          args: params[0],
-        })
-      )
-      if (allNftInfo) {
-        return allNftInfo
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.allNftInfo(...params)
     },
 })
 
-// Use allTokensForOwnerSelector as it uses the indexer and implements
-// pagination for chain queries.
+// Use allTokensForOwnerSelector as it implements pagination for chain queries.
 export const _tokensSelector = selectorFamily<
   TokensResponse,
   QueryClientParams & {
@@ -285,18 +225,9 @@ export const _allTokensSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const tokens = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/allTokens',
-          args: params[0],
-        })
-      )
-      if (tokens) {
-        return { tokens }
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.allTokens(...params)
     },
@@ -311,17 +242,9 @@ export const minterSelector = selectorFamily<
   get:
     ({ params, ...queryClientParams }) =>
     async ({ get }) => {
-      const minter = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/tokens',
-        })
-      )
-      if (minter) {
-        return { minter }
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
       const client = get(queryClient(queryClientParams))
       return await client.minter(...params)
     },
@@ -338,23 +261,11 @@ export const allTokensForOwnerSelector = selectorFamily<
   get:
     ({ owner, ...queryClientParams }) =>
     async ({ get }) => {
-      const id = get(refreshWalletBalancesIdAtom(owner))
+      get(refreshWalletBalancesIdAtom(owner))
 
-      const list = get(
-        queryContractIndexerSelector({
-          ...queryClientParams,
-          formulaName: 'cw721/tokens',
-          args: {
-            owner,
-          },
-          id,
-        })
-      )
-      if (list) {
-        return list
-      }
-
-      // If indexer query fails, fallback to contract query.
+      // Don't use the indexer for this since various NFT contracts have
+      // different methods of storing NFT info, and the indexer does not know
+      // about every different way.
 
       const tokens: TokensResponse['tokens'] = []
       while (true) {

--- a/packages/state/recoil/selectors/contracts/DaoCore.v2.ts
+++ b/packages/state/recoil/selectors/contracts/DaoCore.v2.ts
@@ -768,13 +768,15 @@ export const allCw721TokenListSelector = selectorFamily<
   get:
     ({ governanceCollectionAddress, ...queryClientParams }) =>
     async ({ get }) => {
-      const list = get(
+      let list = get(
         queryContractIndexerSelector({
           ...queryClientParams,
           formulaName: 'daoCore/cw721List',
         })
       )
       if (list && Array.isArray(list)) {
+        // Copy to new array so we can mutate it below.
+        list = [...list]
         // Add governance collection to beginning of list if not present.
         if (
           governanceCollectionAddress &&


### PR DESCRIPTION
Various NFT contracts have different methods of returning token info. Specifically, the Rekt Bulls used by [Rekt Gang DAO](https://daodao.zone/dao/juno13ww9gzsxvzcz2pl454jc6fwcf3dahzvh66hy8yw0s029duzeu07qg4p6uc#staked) seem to use a [contract](https://www.mintscan.io/juno/wasm/contract/juno1xwcwnfh9gjqvchl2danhvzsl0h94hrnvuptwajfd3kwx4q9es2gs5uvpj4) by [MintDAO](https://app.mintdao.io/minting/rekt-bulls) that takes a `token_uri_base` on instantiation and appends token IDs when queried for a token's info to generate its `token_uri` fields. The indexer can't possibly cover all of the scenarios, especially not without source code, so it doesn't make sense to index cw721s using our current state indexer.