### PR TITLE
Fix early button loading finish, and update revoting button text

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -15,6 +15,7 @@
     "cancel": "Cancel",
     "castYourVote": "Cast your vote",
     "change": "Change",
+    "changeYourVote": "Change your vote",
     "chooseImage": "Choose image",
     "claim": "Claim",
     "claimNumTokens": "Claim your {{amount}} ${{tokenSymbol}}",

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/components/ProposalStatusAndInfo.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/components/ProposalStatusAndInfo.tsx
@@ -261,6 +261,11 @@ const InnerProposalStatusAndInfo = ({
   })
 
   const [actionLoading, setActionLoading] = useState(false)
+  // On proposal status update, stop loading. This ensures the action button
+  // doesn't stop loading too early, before the status has refreshed.
+  useEffect(() => {
+    setActionLoading(false)
+  }, [proposal.status])
 
   const onExecute = useCallback(async () => {
     if (!connected) return
@@ -276,9 +281,12 @@ const InnerProposalStatusAndInfo = ({
     } catch (err) {
       console.error(err)
       toast.error(processError(err))
-    } finally {
+
+      // Stop loading if errored.
       setActionLoading(false)
     }
+
+    // Loading will stop on success when status refreshes.
   }, [connected, executeProposal, proposalNumber, onExecuteSuccess])
 
   const onClose = useCallback(async () => {
@@ -295,9 +303,12 @@ const InnerProposalStatusAndInfo = ({
     } catch (err) {
       console.error(err)
       toast.error(processError(err))
-    } finally {
+
+      // Stop loading if errored.
       setActionLoading(false)
     }
+
+    // Loading will stop on success when status refreshes.
   }, [connected, closeProposal, proposalNumber, onCloseSuccess])
 
   const awaitNextBlock = useAwaitNextBlock()

--- a/packages/stateless/components/proposal/ProposalStatusAndInfo.tsx
+++ b/packages/stateless/components/proposal/ProposalStatusAndInfo.tsx
@@ -130,7 +130,12 @@ export const ProposalStatusAndInfo = <Vote extends unknown = unknown>({
             contentContainerClassName={clsx('justify-center', {
               'primary-text': !selectedVote,
             })}
-            disabled={!selectedVote}
+            disabled={
+              // Disable when no vote selected, or selected vote is already the
+              // current vote. This is possible when revoting is allowed.
+              !selectedVote ||
+              (!!vote?.currentVote && selectedVote === vote.currentVote)
+            }
             loading={vote.loading}
             onClick={() => selectedVote && vote.onCastVote(selectedVote)}
             size="lg"

--- a/packages/stateless/components/proposal/ProposalStatusAndInfo.tsx
+++ b/packages/stateless/components/proposal/ProposalStatusAndInfo.tsx
@@ -46,6 +46,14 @@ export const ProposalStatusAndInfo = <Vote extends unknown = unknown>({
     vote?.currentVote
   )
 
+  const currentVote = vote?.currentVote
+    ? vote.options.find((option) => option.value === vote.currentVote)
+    : undefined
+  // If the wallet's current vote is the selected vote. This means revoting is
+  // allowed, and the current vote selected is the same vote as before.
+  const currentVoteSelected =
+    !!currentVote && selectedVote === currentVote.value
+
   return (
     <div
       className={clsx(
@@ -133,8 +141,7 @@ export const ProposalStatusAndInfo = <Vote extends unknown = unknown>({
             disabled={
               // Disable when no vote selected, or selected vote is already the
               // current vote. This is possible when revoting is allowed.
-              !selectedVote ||
-              (!!vote?.currentVote && selectedVote === vote.currentVote)
+              !selectedVote || currentVoteSelected
             }
             loading={vote.loading}
             onClick={() => selectedVote && vote.onCastVote(selectedVote)}
@@ -145,7 +152,9 @@ export const ProposalStatusAndInfo = <Vote extends unknown = unknown>({
               vote.currentVote ? 'secondary' : 'primary'
             }
           >
-            {t('button.castYourVote')}
+            {vote.currentVote
+              ? t('button.changeYourVote')
+              : t('button.castYourVote')}
           </Button>
         </div>
       )}


### PR DESCRIPTION
When voting on, executing, and closing a proposal, there is a small delay between when the UI detects the action occurred/shows an alert, and when the data is refreshed to display. This PR makes it so that the buttons keep loading until the data is refreshed, instead of just waiting until the TX completes.

It also prevents the user from re-casting a vote if they already voted, since that would lead to infinite loading per the system above. In doing so, I changed the button to `Change your vote` when revoting, so it's clear what's going on, and it's clear why the button is disabled when selecting your current vote.