### PR TITLE
Fixed overlapping DAO name in compact profile card

### DIFF
--- a/packages/stateless/components/profile/ProfileCardWrapper.tsx
+++ b/packages/stateless/components/profile/ProfileCardWrapper.tsx
@@ -62,7 +62,7 @@ export const ProfileCardWrapper = ({
               size="sm"
             />
 
-            <div className="flex flex-col gap-1">
+            <div className="flex min-w-0 flex-col gap-1">
               <ProfileNameDisplayAndEditor
                 canEdit={canEdit}
                 compact={compact}

--- a/packages/stateless/components/profile/ProfileImage.tsx
+++ b/packages/stateless/components/profile/ProfileImage.tsx
@@ -57,7 +57,7 @@ export const ProfileImage = forwardRef<HTMLDivElement, ProfileImageProps>(
       <div
         className={clsx(
           // Center icon.
-          'relative flex items-center justify-center',
+          'relative flex shrink-0 items-center justify-center',
           (!imageUrl || loadingImage) &&
             'border border-border-interactive-disabled',
           sizingRoundingClassNames,


### PR DESCRIPTION
Resolves #1103 

Old:
<img width="350" alt="Screenshot 2023-02-17 at 10 54 24 AM" src="https://user-images.githubusercontent.com/6721426/219759519-ddfe0f36-938b-440c-8e4d-b6b05a3186f4.png">

Fixed:
<img width="349" alt="Screenshot 2023-02-17 at 10 54 52 AM" src="https://user-images.githubusercontent.com/6721426/219759671-7832b7c6-b412-4892-8b06-e5e591234ca3.png">
