### PR TITLE
Clean up AppContext refs

### DIFF
--- a/packages/stateful/components/AppContextProvider.tsx
+++ b/packages/stateful/components/AppContextProvider.tsx
@@ -1,14 +1,9 @@
-import { useCallback, useState } from 'react'
+import { useRef, useState } from 'react'
 
-import {
-  AppContext,
-  makePageHeader,
-  makeRightSidebarContent,
-} from '@dao-dao/stateless'
+import { AppContext } from '@dao-dao/stateless'
 import {
   AppContextProviderProps,
   CommandModalContextMaker,
-  RightSidebarProps,
 } from '@dao-dao/types'
 
 import { makeGenericContext } from '../command'
@@ -27,30 +22,9 @@ export const AppContextProvider = ({
   const [updateProfileNftVisible, setUpdateProfileNftVisible] = useState(false)
 
   // Page header.
-  const [PageHeader, setPageHeader] = useState(() => makePageHeader(null))
-  const setPageHeaderRef = useCallback(
-    (ref: HTMLDivElement | null) =>
-      // Use state setting function since we want to return a function
-      // (component).
-      setPageHeader(() => makePageHeader(ref)),
-    []
-  )
-
+  const pageHeaderRef = useRef<HTMLDivElement | null>(null)
   // Right sidebar.
-  const [RightSidebarContent, setRightSidebarContent] = useState(() =>
-    makeRightSidebarContent(null)
-  )
-  // See comment on makeRightSidebarContent in RightSidebar.tsx for information
-  // on what this is and how it works and why it exists. Use state setting
-  // function since we want to return a function (component).
-  const setRightSidebarContentRef: RightSidebarProps['setContentRef'] =
-    useCallback(
-      (ref) =>
-        // Use state setting function since we want to return a function
-        // (component).
-        setRightSidebarContent(() => makeRightSidebarContent(ref)),
-      []
-    )
+  const rightSidebarRef = useRef<HTMLDivElement | null>(null)
 
   // Command modal.
   const [rootCommandContextMaker, _setRootCommandContextMaker] =
@@ -91,13 +65,10 @@ export const AppContextProvider = ({
           _setRootCommandContextMaker(() => maker),
         inbox,
         daoWebSocket,
-        // Include the page header and right sidebar portal renderers in the
-        // context to be accessed by pages, and the ref setters to be accessed
-        // by the layout component.
-        PageHeader,
-        setPageHeaderRef,
-        RightSidebarContent,
-        setRightSidebarContentRef,
+        // Include the page header and right sidebar portal refs in the context
+        // to be accessed by the component portals.
+        pageHeaderRef,
+        rightSidebarRef,
       }}
     >
       {children}

--- a/packages/stateful/components/dao/CreateDaoForm.tsx
+++ b/packages/stateful/components/dao/CreateDaoForm.tsx
@@ -18,6 +18,8 @@ import {
   DaoCreateSidebarCard,
   DaoHeader,
   ImageSelector,
+  PageHeaderContent,
+  RightSidebarContent,
   useAppContext,
   useCachedLoadable,
   useNavHelpers,
@@ -98,7 +100,7 @@ export const CreateDaoForm = ({
   const { goToDao } = useNavHelpers()
   const { setFollowing } = useFollowingDaos()
 
-  const { mode, RightSidebarContent, PageHeader } = useAppContext()
+  const { mode } = useAppContext()
 
   const [daoCreatedCardProps, setDaoCreatedCardProps] = useRecoilState(
     daoCreatedCardPropsAtom
@@ -604,7 +606,7 @@ export const CreateDaoForm = ({
           pageIndex={daoCreatedCardProps ? 4 : pageIndex}
         />
       </RightSidebarContent>
-      <PageHeader
+      <PageHeaderContent
         breadcrumbs={{
           // Use the SubDAOs tab as the home breadcrumb if making a SubDAO.
           homeTab: makingSubDao

--- a/packages/stateless/components/error/ErrorPage500.tsx
+++ b/packages/stateless/components/error/ErrorPage500.tsx
@@ -19,7 +19,7 @@ export const ErrorPage500 = ({ error }: ErrorPage500Props) => {
 
   return (
     <>
-      <PageHeaderContent title={t('title.500')} />
+      <PageHeaderContent forceCenter title={t('title.500')} />
 
       <ErrorPage>
         <p className="title-text">{t('error.errorOccurredOnPage')}</p>

--- a/packages/stateless/components/error/ErrorPage500.tsx
+++ b/packages/stateless/components/error/ErrorPage500.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from 'react-i18next'
 
 import { ButtonLink } from '@dao-dao/stateful'
 
-import { useAppContextIfAvailable } from '../layout/AppContext'
+import {
+  PageHeader,
+  PageHeaderContent,
+  useAppContextIfAvailable,
+} from '../layout'
 import { ErrorPage } from './ErrorPage'
 
 export interface ErrorPage500Props {
@@ -12,7 +16,11 @@ export interface ErrorPage500Props {
 
 export const ErrorPage500 = ({ error }: ErrorPage500Props) => {
   const { t } = useTranslation()
-  const PageHeader = useAppContextIfAvailable()?.PageHeader
+  const appContext = useAppContextIfAvailable()
+
+  // SDA does not have AppContext here, so if not available, just render
+  // component directly. Otherwise use portal.
+  const PageHeaderRenderer = appContext ? PageHeaderContent : PageHeader
 
   useEffect(() => {
     console.error(error)
@@ -20,8 +28,7 @@ export const ErrorPage500 = ({ error }: ErrorPage500Props) => {
 
   return (
     <>
-      {/* SDA does not have AppLayoutContext here. */}
-      {PageHeader && <PageHeader title={t('title.500')} />}
+      <PageHeaderRenderer title={t('title.500')} />
 
       <ErrorPage>
         <p className="title-text">{t('error.errorOccurredOnPage')}</p>

--- a/packages/stateless/components/error/ErrorPage500.tsx
+++ b/packages/stateless/components/error/ErrorPage500.tsx
@@ -3,11 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { ButtonLink } from '@dao-dao/stateful'
 
-import {
-  PageHeader,
-  PageHeaderContent,
-  useAppContextIfAvailable,
-} from '../layout'
+import { PageHeaderContent } from '../layout'
 import { ErrorPage } from './ErrorPage'
 
 export interface ErrorPage500Props {
@@ -16,11 +12,6 @@ export interface ErrorPage500Props {
 
 export const ErrorPage500 = ({ error }: ErrorPage500Props) => {
   const { t } = useTranslation()
-  const appContext = useAppContextIfAvailable()
-
-  // SDA does not have AppContext here, so if not available, just render
-  // component directly. Otherwise use portal.
-  const PageHeaderRenderer = appContext ? PageHeaderContent : PageHeader
 
   useEffect(() => {
     console.error(error)
@@ -28,7 +19,7 @@ export const ErrorPage500 = ({ error }: ErrorPage500Props) => {
 
   return (
     <>
-      <PageHeaderRenderer title={t('title.500')} />
+      <PageHeaderContent title={t('title.500')} />
 
       <ErrorPage>
         <p className="title-text">{t('error.errorOccurredOnPage')}</p>

--- a/packages/stateless/components/layout/DappLayout.tsx
+++ b/packages/stateless/components/layout/DappLayout.tsx
@@ -27,12 +27,8 @@ export const DappLayout = ({
 }: DappLayoutProps) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const {
-    responsiveNavigation,
-    responsiveRightSidebar,
-    setRightSidebarContentRef,
-    setPageHeaderRef,
-  } = useAppContext()
+  const { responsiveNavigation, responsiveRightSidebar, pageHeaderRef } =
+    useAppContext()
 
   const scrollableContainerRef = useRef<HTMLDivElement>(null)
 
@@ -133,7 +129,7 @@ export const DappLayout = ({
           )}
         </div>
 
-        <div className="shrink-0 px-6" ref={setPageHeaderRef}></div>
+        <div className="shrink-0 px-6" ref={pageHeaderRef}></div>
 
         {/* Make horizontal padding 1 unit more than page header so that the body is not touching the sides of the page header's bottom border when it scrolls. */}
         <div
@@ -149,10 +145,7 @@ export const DappLayout = ({
       </main>
 
       <ErrorBoundary>
-        <RightSidebar
-          {...rightSidebarProps}
-          setContentRef={setRightSidebarContentRef}
-        />
+        <RightSidebar {...rightSidebarProps} />
       </ErrorBoundary>
     </div>
   )

--- a/packages/stateless/components/layout/PageHeader.tsx
+++ b/packages/stateless/components/layout/PageHeader.tsx
@@ -112,10 +112,13 @@ export const PageHeader = ({
   )
 }
 
-// This is a function that generates a function component, used in pages to
-// render the page header. See the `makeRightSidebarContent` function comment in
-// `RightSidebar.tsx` for more information on how this works.
-export const makePageHeader = (container: HTMLDivElement | null) =>
-  function PageHeaderPortal(props: PageHeaderProps) {
-    return container ? createPortal(<PageHeader {...props} />, container) : null
-  }
+// This is a portal that inserts a PageHeader wherever the AppContext's
+// `pageHeaderRef` is placed. This is handled by the layout components. See the
+// `ReactSidebarContent` comment in `RightSidebar.tsx` for more information on
+// how this works.
+export const PageHeaderContent = (props: PageHeaderProps) => {
+  const container = useAppContext().pageHeaderRef
+  return container.current
+    ? createPortal(<PageHeader {...props} />, container.current)
+    : null
+}

--- a/packages/stateless/components/layout/PageHeader.tsx
+++ b/packages/stateless/components/layout/PageHeader.tsx
@@ -7,7 +7,7 @@ import { PageHeaderProps } from '@dao-dao/types/stateless/PageHeader'
 
 import { IconButton } from '../icon_buttons'
 import { TopGradient } from '../TopGradient'
-import { useAppContext } from './AppContext'
+import { useAppContext, useAppContextIfAvailable } from './AppContext'
 import { Breadcrumbs } from './Breadcrumbs'
 
 export const PAGE_HEADER_HEIGHT_CLASS_NAMES = 'h-20'
@@ -116,9 +116,14 @@ export const PageHeader = ({
 // `pageHeaderRef` is placed. This is handled by the layout components. See the
 // `ReactSidebarContent` comment in `RightSidebar.tsx` for more information on
 // how this works.
+//
+// If not in an AppContext, this component will render a PageHeader normally
+// instead of using the portal.
 export const PageHeaderContent = (props: PageHeaderProps) => {
-  const container = useAppContext().pageHeaderRef
-  return container.current
-    ? createPortal(<PageHeader {...props} />, container.current)
-    : null
+  const container = useAppContextIfAvailable()?.pageHeaderRef
+  return container?.current ? (
+    createPortal(<PageHeader {...props} />, container.current)
+  ) : (
+    <PageHeader {...props} />
+  )
 }

--- a/packages/stateless/components/layout/RightSidebar.stories.tsx
+++ b/packages/stateless/components/layout/RightSidebar.stories.tsx
@@ -24,7 +24,6 @@ export const DefaultArgs: RightSidebarProps = {
       {...(ConnectedSidebarWalletStory.args as SidebarWalletProps)}
     />
   ),
-  setContentRef: () => {},
   WalletFiatRampModal,
 }
 

--- a/packages/stateless/components/layout/RightSidebar.tsx
+++ b/packages/stateless/components/layout/RightSidebar.tsx
@@ -21,13 +21,17 @@ export * from '@dao-dao/types/stateless/RightSidebar'
 
 export const RightSidebar = ({
   wallet,
-  setContentRef,
   WalletFiatRampModal,
 }: RightSidebarProps) => {
   const { t } = useTranslation()
 
-  const { enabled: responsiveEnabled, toggle: toggleResponsive } =
-    useAppContext().responsiveRightSidebar
+  const {
+    rightSidebarRef,
+    responsiveRightSidebar: {
+      enabled: responsiveEnabled,
+      toggle: toggleResponsive,
+    },
+  } = useAppContext()
 
   // Set this to a value to show the fiat ramp modal defaulted to that option.
   const [fiatRampDefaultModeVisible, setFiatRampDefaultModeVisible] = useState<
@@ -72,7 +76,7 @@ export const RightSidebar = ({
 
         <div className="mt-1">
           {/* Content gets inserted here when the portal <RightSidebarContent> below is used. */}
-          <div ref={setContentRef}></div>
+          <div ref={rightSidebarRef}></div>
         </div>
 
         {/* Only show if defined, which indicates wallet connected. */}
@@ -112,48 +116,32 @@ export const RightSidebar = ({
   )
 }
 
-// This is a function that generates a function component, used in pages to
-// render content in the right sidebar (which is located in a separate React
-// tree due to the nature of `AppLayout` managing the layout of the navigation
-// bar, main page content, and right sidebar). This function uses a reference to
-// the container `div` (seen above with property `ref={setContentRef}`) and
-// provides a function component that will funnel its `children` into a React
-// portal (https://reactjs.org/docs/portals.html). More specifically,
-// `AppLayout` passes a ref callback to the `RightSidebar` component defined
-// above. In this callback, `AppLayout` calls this maker function and stores the
-// result (the `RightSidebarContent` function component) in a `useState` hook.
-// The `useState` hook is initialized to the result of this maker function with
-// an argument of `null`, which safely renders nothing before the ref callback
-// executes (letting the pages use consistent syntax and removing the need to
-// listen for any state/event updates). This state value is passed into the
-// `AppLayoutContext.Provider` so that descendants of the context provider (such
-// as page components) can retrieve the `RightSidebarContent` component via
-// `useAppLayoutContext` in `AppLayoutContext.tsx` and specify what renders in
-// the sidebar. When the `useState` hook is updated with the result of this
-// maker function called with a valid container element reference (which occurs
-// when the container `div` above renders), the `RightSidebarContent` value
-// located in the `useState` hook in `AppLayout` and retrieved via the context
-// hook in pages is updated with a component that is able to create the portal,
-// and the page re-renders, displaying the content. The API for a page is as
-// simple as:
+// This is a portal that teleports content, used in pages to render content in
+// the right sidebar (which is located in a separate React tree due to the
+// nature of `DappLayout`/`SdaLayout` managing the layout of the navigation bar,
+// main page content, and right sidebar). This component uses a reference to the
+// container `div` (seen above with property `ref={rightSidebarRef}`) and
+// provides a component that will funnel its `children` into a React portal
+// (https://reactjs.org/docs/portals.html). `AppContext` provides a ref which
+// the `RightSidebar` component above uses and the `RightSidebarContent` below
+// uses. This ref is accessible via the `useAppContext` hook so that descendants
+// of the context provider (such as page components) can use the
+// `RightSidebarContent` component below and specify what renders in the
+// sidebar. The API for a page is as simple as:
 //
-// export const Page = () => { const { RightSidebarContent } =
-//   useAppLayoutContext()
+// export const Page = () => (
+//   <>
+//     <RightSidebarContent>
+//       <ProfileCard title="@Modern-Edamame" />
+//     </RightSidebarContent>
 
-//   return (
-//     <>
-//       <RightSidebarContent>
-//         <ProfileCard title="@Modern-Edamame" />
-//       </RightSidebarContent>
-
-//       {/* ... Page content here ... */}
-//     </>
-//   )
-// }
+//     {/* ... Page content here ... */}
+//   </>
+// )
 //
 // See https://malcolmkee.com/blog/portal-to-subtree/ for an example using
 // portals to render components across subtrees with similar syntax.
-export const makeRightSidebarContent = (container: HTMLDivElement | null) =>
-  function RightSidebarContent({ children }: RightSidebarContentProps) {
-    return container ? createPortal(children, container) : null
-  }
+export const RightSidebarContent = ({ children }: RightSidebarContentProps) => {
+  const container = useAppContext().rightSidebarRef
+  return container.current ? createPortal(children, container.current) : null
+}

--- a/packages/stateless/components/layout/SdaLayout.tsx
+++ b/packages/stateless/components/layout/SdaLayout.tsx
@@ -25,12 +25,8 @@ export const SdaLayout = ({
 }: SdaLayoutProps) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const {
-    responsiveNavigation,
-    responsiveRightSidebar,
-    setRightSidebarContentRef,
-    setPageHeaderRef,
-  } = useAppContext()
+  const { responsiveNavigation, responsiveRightSidebar, pageHeaderRef } =
+    useAppContext()
 
   const scrollableContainerRef = useRef<HTMLDivElement>(null)
 
@@ -131,7 +127,7 @@ export const SdaLayout = ({
           )}
         </div>
 
-        <div className="shrink-0 px-6" ref={setPageHeaderRef}></div>
+        <div className="shrink-0 px-6" ref={pageHeaderRef}></div>
 
         {/* Make horizontal padding 1 unit more than page header so that the body is not touching the sides of the page header's bottom border when it scrolls. */}
         <div
@@ -147,10 +143,7 @@ export const SdaLayout = ({
       </main>
 
       <ErrorBoundary>
-        <RightSidebar
-          {...rightSidebarProps}
-          setContentRef={setRightSidebarContentRef}
-        />
+        <RightSidebar {...rightSidebarProps} />
       </ErrorBoundary>
     </div>
   )

--- a/packages/stateless/components/not_found/DaoNotFound.tsx
+++ b/packages/stateless/components/not_found/DaoNotFound.tsx
@@ -2,16 +2,23 @@ import { useTranslation } from 'react-i18next'
 
 import { ButtonLink } from '../buttons'
 import { ErrorPage } from '../error/ErrorPage'
-import { useAppContextIfAvailable } from '../layout/AppContext'
+import {
+  PageHeader,
+  PageHeaderContent,
+  useAppContextIfAvailable,
+} from '../layout'
 
 export const DaoNotFound = () => {
   const { t } = useTranslation()
-  const PageHeader = useAppContextIfAvailable()?.PageHeader
+  const appContext = useAppContextIfAvailable()
+
+  // SDA does not have AppContext here, so if not available, just render
+  // component directly. Otherwise use portal.
+  const PageHeaderRenderer = appContext ? PageHeaderContent : PageHeader
 
   return (
     <>
-      {/* SDA does not have AppLayoutContext here. */}
-      {PageHeader && <PageHeader title={t('title.daoNotFound')} />}
+      <PageHeaderRenderer title={t('title.daoNotFound')} />
 
       <ErrorPage title={t('error.couldntFindDAO')}>
         <ButtonLink href="/" variant="secondary">

--- a/packages/stateless/components/not_found/DaoNotFound.tsx
+++ b/packages/stateless/components/not_found/DaoNotFound.tsx
@@ -2,23 +2,14 @@ import { useTranslation } from 'react-i18next'
 
 import { ButtonLink } from '../buttons'
 import { ErrorPage } from '../error/ErrorPage'
-import {
-  PageHeader,
-  PageHeaderContent,
-  useAppContextIfAvailable,
-} from '../layout'
+import { PageHeaderContent } from '../layout'
 
 export const DaoNotFound = () => {
   const { t } = useTranslation()
-  const appContext = useAppContextIfAvailable()
-
-  // SDA does not have AppContext here, so if not available, just render
-  // component directly. Otherwise use portal.
-  const PageHeaderRenderer = appContext ? PageHeaderContent : PageHeader
 
   return (
     <>
-      <PageHeaderRenderer title={t('title.daoNotFound')} />
+      <PageHeaderContent title={t('title.daoNotFound')} />
 
       <ErrorPage title={t('error.couldntFindDAO')}>
         <ButtonLink href="/" variant="secondary">

--- a/packages/stateless/components/not_found/DaoNotFound.tsx
+++ b/packages/stateless/components/not_found/DaoNotFound.tsx
@@ -9,7 +9,7 @@ export const DaoNotFound = () => {
 
   return (
     <>
-      <PageHeaderContent title={t('title.daoNotFound')} />
+      <PageHeaderContent forceCenter title={t('title.daoNotFound')} />
 
       <ErrorPage title={t('error.couldntFindDAO')}>
         <ButtonLink href="/" variant="secondary">

--- a/packages/stateless/components/not_found/ProposalNotFound.tsx
+++ b/packages/stateless/components/not_found/ProposalNotFound.tsx
@@ -6,17 +6,16 @@ import { useDaoInfoContext } from '../../hooks'
 import { useNavHelpers } from '../../hooks/useNavHelpers'
 import { ButtonLink } from '../buttons'
 import { ErrorPage } from '../error/ErrorPage'
-import { useAppContext } from '../layout/AppContext'
+import { PageHeaderContent } from '../layout'
 
 export const ProposalNotFound = () => {
   const { t } = useTranslation()
-  const { PageHeader } = useAppContext()
   const { coreAddress } = useDaoInfoContext()
   const { getDaoPath } = useNavHelpers()
 
   return (
     <>
-      <PageHeader title={t('title.proposalNotFound')} />
+      <PageHeaderContent title={t('title.proposalNotFound')} />
 
       <ErrorPage title={t('error.couldntFindProposal')}>
         <ButtonLink

--- a/packages/stateless/pages/CreateProposal.tsx
+++ b/packages/stateless/pages/CreateProposal.tsx
@@ -8,7 +8,12 @@ import {
   ProposalModuleAdapter,
 } from '@dao-dao/types'
 
-import { Dropdown, DropdownOption, useAppContext } from '../components'
+import {
+  Dropdown,
+  DropdownOption,
+  PageHeaderContent,
+  RightSidebarContent,
+} from '../components'
 
 export interface CreateProposalProps {
   daoInfo: DaoInfo
@@ -28,7 +33,6 @@ export const CreateProposal = ({
   matchAdapter,
 }: CreateProposalProps) => {
   const { t } = useTranslation()
-  const { RightSidebarContent, PageHeader } = useAppContext()
 
   // List of proposal modules available, using the adapter ID to derive a label
   // to display in the dropdown.
@@ -51,7 +55,7 @@ export const CreateProposal = ({
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader
+      <PageHeaderContent
         breadcrumbs={{
           homeTab: {
             id: DaoTabId.Proposals,

--- a/packages/stateless/pages/DaoDappTabbedHome.tsx
+++ b/packages/stateless/pages/DaoDappTabbedHome.tsx
@@ -9,9 +9,10 @@ import { SDA_URL_PREFIX, getDaoPath as baseGetDaoPath } from '@dao-dao/utils'
 import {
   IconButtonLink,
   Loader,
+  PageHeaderContent,
+  RightSidebarContent,
   SegmentedControls,
   Tooltip,
-  useAppContext,
 } from '../components'
 import { DaoSplashHeader } from '../components/dao/DaoSplashHeader'
 import { useDaoInfoContext } from '../hooks/useDaoInfoContext'
@@ -27,7 +28,6 @@ export const DaoDappTabbedHome = ({
   tabs,
 }: DaoDappTabbedHomeProps) => {
   const { t } = useTranslation()
-  const { RightSidebarContent, PageHeader } = useAppContext()
   const { coreAddress } = useDaoInfoContext()
 
   const {
@@ -74,7 +74,7 @@ export const DaoDappTabbedHome = ({
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader
+      <PageHeaderContent
         breadcrumbs={{
           home: true,
           current: daoInfo.name,

--- a/packages/stateless/pages/DaoSdaWrappedTab.tsx
+++ b/packages/stateless/pages/DaoSdaWrappedTab.tsx
@@ -2,7 +2,11 @@ import clsx from 'clsx'
 
 import { DaoSdaWrappedTabProps } from '@dao-dao/types'
 
-import { PageLoader, useAppContext } from '../components'
+import {
+  PageHeaderContent,
+  PageLoader,
+  RightSidebarContent,
+} from '../components'
 
 export const DaoSdaWrappedTab = ({
   allTabs,
@@ -10,14 +14,12 @@ export const DaoSdaWrappedTab = ({
   rightSidebarContent,
   SuspenseLoader,
 }: DaoSdaWrappedTabProps) => {
-  const { RightSidebarContent, PageHeader } = useAppContext()
-
   const activeTab = allTabs.find(({ id }) => id === tabId) || allTabs[0]
 
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader
+      <PageHeaderContent
         breadcrumbs={{
           home: true,
           current: activeTab.label,

--- a/packages/stateless/pages/Home.tsx
+++ b/packages/stateless/pages/Home.tsx
@@ -8,7 +8,8 @@ import {
   FollowingDaosProps,
   HorizontalScroller,
   HorizontalScrollerProps,
-  useAppContext,
+  PageHeaderContent,
+  RightSidebarContent,
 } from '../components'
 
 export type HomeProps = {
@@ -32,12 +33,11 @@ export const Home = ({
   connected,
 }: HomeProps) => {
   const { t } = useTranslation()
-  const { RightSidebarContent, PageHeader } = useAppContext()
 
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader className={maxWidth} title={t('title.home')} />
+      <PageHeaderContent className={maxWidth} title={t('title.home')} />
 
       <div className="flex flex-col items-center gap-8">
         <p className={clsx('title-text', maxWidth)}>

--- a/packages/stateless/pages/Inbox.tsx
+++ b/packages/stateless/pages/Inbox.tsx
@@ -10,7 +10,8 @@ import {
   IconButton,
   Loader,
   NoContent,
-  useAppContext,
+  PageHeaderContent,
+  RightSidebarContent,
 } from '../components'
 import { useNavHelpers } from '../hooks'
 
@@ -27,7 +28,6 @@ export const Inbox = ({
 }: InboxProps) => {
   const { t } = useTranslation()
   const { getDaoPath } = useNavHelpers()
-  const { RightSidebarContent, PageHeader } = useAppContext()
 
   const [refreshSpinning, setRefreshSpinning] = useState(false)
   // Start spinning refresh icon if refreshing sets to true. Turn off once the
@@ -39,7 +39,7 @@ export const Inbox = ({
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader
+      <PageHeaderContent
         className="mx-auto max-w-5xl"
         rightNode={
           <IconButton

--- a/packages/stateless/pages/Proposal.tsx
+++ b/packages/stateless/pages/Proposal.tsx
@@ -8,7 +8,11 @@ import {
   LoadingData,
 } from '@dao-dao/types'
 
-import { ProposalContentDisplay, useAppContext } from '../components'
+import {
+  PageHeaderContent,
+  ProposalContentDisplay,
+  RightSidebarContent,
+} from '../components'
 
 export interface ProposalProps {
   proposalInfo: CommonProposalInfo
@@ -39,7 +43,6 @@ export const Proposal = ({
   refreshing,
 }: ProposalProps) => {
   const { t } = useTranslation()
-  const { RightSidebarContent, PageHeader } = useAppContext()
 
   // Scroll to hash manually if available since this component and thus the
   // desired target anchor text won't be ready right when the page renders.
@@ -63,7 +66,7 @@ export const Proposal = ({
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader
+      <PageHeaderContent
         breadcrumbs={{
           homeTab: {
             id: DaoTabId.Proposals,

--- a/packages/stateless/pages/Wallet.tsx
+++ b/packages/stateless/pages/Wallet.tsx
@@ -30,8 +30,9 @@ import {
   ButtonLink,
   CopyToClipboard,
   CosmosMessageDisplay,
+  PageHeaderContent,
+  RightSidebarContent,
   Tooltip,
-  useAppContext,
 } from '../components'
 
 export interface WalletProps {
@@ -65,7 +66,6 @@ export const Wallet = ({
   txHash,
 }: WalletProps) => {
   const { t } = useTranslation()
-  const { RightSidebarContent, PageHeader } = useAppContext()
 
   const {
     control,
@@ -119,7 +119,10 @@ export const Wallet = ({
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader className="mx-auto max-w-5xl" title={t('title.wallet')} />
+      <PageHeaderContent
+        className="mx-auto max-w-5xl"
+        title={t('title.wallet')}
+      />
 
       <div className="mx-auto flex max-w-5xl flex-col items-stretch pb-12">
         <FormProvider {...formMethods}>

--- a/packages/stateless/pages/WalletDisconnected.tsx
+++ b/packages/stateless/pages/WalletDisconnected.tsx
@@ -1,7 +1,11 @@
 import { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { PageLoader, useAppContext } from '../components'
+import {
+  PageHeaderContent,
+  PageLoader,
+  RightSidebarContent,
+} from '../components'
 
 export interface WalletDisconnectedProps {
   rightSidebarContent: ReactNode
@@ -15,12 +19,14 @@ export const WalletDisconnected = ({
   autoConnecting,
 }: WalletDisconnectedProps) => {
   const { t } = useTranslation()
-  const { RightSidebarContent, PageHeader } = useAppContext()
 
   return (
     <>
       <RightSidebarContent>{rightSidebarContent}</RightSidebarContent>
-      <PageHeader className="mx-auto max-w-5xl" title={t('title.wallet')} />
+      <PageHeaderContent
+        className="mx-auto max-w-5xl"
+        title={t('title.wallet')}
+      />
 
       {autoConnecting ? (
         <PageLoader />

--- a/packages/storybook/decorators/makeAppContextDecorator.tsx
+++ b/packages/storybook/decorators/makeAppContextDecorator.tsx
@@ -1,5 +1,5 @@
 import { DecoratorFn } from '@storybook/react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import { makeGenericContext } from '@dao-dao/stateful/command'
 import { AppContext } from '@dao-dao/stateless'
@@ -17,6 +17,9 @@ export const makeAppContextDecorator: (
       useState(false)
     const [updateProfileVisible, setUpdateProfileVisible] = useState(false)
 
+    const pageHeaderRef = useRef(null)
+    const rightSidebarRef = useRef(null)
+
     return (
       <AppContext.Provider
         value={{
@@ -33,10 +36,8 @@ export const makeAppContextDecorator: (
             visible: updateProfileVisible,
             toggle: () => setUpdateProfileVisible((v) => !v),
           },
-          PageHeader: () => null,
-          setPageHeaderRef: () => {},
-          RightSidebarContent: () => null,
-          setRightSidebarContentRef: () => {},
+          pageHeaderRef,
+          rightSidebarRef,
           rootCommandContextMaker: makeGenericContext,
           setRootCommandContextMaker: () => {},
           inbox: EMPTY_INBOX,

--- a/packages/types/stateless/AppContext.tsx
+++ b/packages/types/stateless/AppContext.tsx
@@ -1,10 +1,8 @@
-import { ComponentType, ReactNode } from 'react'
+import { MutableRefObject, ReactNode } from 'react'
 
 import { CommandModalContextMaker } from '../command'
 import { DaoPageMode, DaoWebSocket } from '../dao'
 import { InboxState } from '../inbox'
-import { PageHeaderProps } from './PageHeader'
-import { RightSidebarProps } from './RightSidebar'
 
 export type IAppContext = {
   // DAO page mode.
@@ -25,12 +23,10 @@ export type IAppContext = {
   }
 
   // Page header.
-  PageHeader: ComponentType<PageHeaderProps>
-  setPageHeaderRef: (ref: HTMLDivElement | null) => void
+  pageHeaderRef: MutableRefObject<HTMLDivElement | null>
 
   // Right sidebar.
-  RightSidebarContent: ComponentType<{ children: ReactNode }>
-  setRightSidebarContentRef: RightSidebarProps['setContentRef']
+  rightSidebarRef: MutableRefObject<HTMLDivElement | null>
 
   // Command modal.
   rootCommandContextMaker: CommandModalContextMaker

--- a/packages/types/stateless/DappLayout.ts
+++ b/packages/types/stateless/DappLayout.ts
@@ -8,7 +8,7 @@ import { RightSidebarProps } from './RightSidebar'
 export interface DappLayoutProps {
   navigationProps: DappNavigationProps
   children: ReactNode
-  rightSidebarProps: Omit<RightSidebarProps, 'setContentRef'>
+  rightSidebarProps: RightSidebarProps
   walletProfile?: LoadingData<WalletProfile>
   connect: () => void
   connected: boolean

--- a/packages/types/stateless/RightSidebar.ts
+++ b/packages/types/stateless/RightSidebar.ts
@@ -1,11 +1,10 @@
-import { ComponentType, ReactNode, RefCallback } from 'react'
+import { ComponentType, ReactNode } from 'react'
 
 import { KadoModalProps } from './KadoModal'
 import { ModalProps } from './Modal'
 
 export interface RightSidebarProps {
   wallet: ReactNode
-  setContentRef: RefCallback<HTMLDivElement>
   // Present if wallet connected, otherwise undefined.
   WalletFiatRampModal?: ComponentType<
     Pick<ModalProps, 'onClose' | 'visible'> &

--- a/packages/types/stateless/SdaLayout.ts
+++ b/packages/types/stateless/SdaLayout.ts
@@ -8,7 +8,7 @@ import { SdaNavigationProps } from './SdaNavigation'
 export interface SdaLayoutProps {
   navigationProps: SdaNavigationProps
   children: ReactNode
-  rightSidebarProps: Omit<RightSidebarProps, 'setContentRef'>
+  rightSidebarProps: RightSidebarProps
   walletProfile?: LoadingData<WalletProfile>
   connect: () => void
   connected: boolean


### PR DESCRIPTION
A while back I discovered React portals that lets you transport components to other places in the DOM. This has been used so that pages can control what profile card appears in the sidebar as well as what content appears in the page header, since a layout component manages navigation, header, sidebar, and page content at the same level.

When I did this, I built it an unnecessarily complex way, and for some reason that only started causing problems right now. I went back, questioned my past sanity, and fixed the code so it doesn't do weird insane memoized function component creation shit. Look at this PR, the difference is funny.