### PR TITLE
Fix page header invisible on load sometimes

### DIFF
--- a/packages/stateful/components/AppContextProvider.tsx
+++ b/packages/stateful/components/AppContextProvider.tsx
@@ -26,8 +26,8 @@ export const AppContextProvider = ({
   const [, setPageHeaderSet] = useState(false)
   const pageHeaderRef = useRef<HTMLDivElement | null>(null)
   const setPageHeaderRef = useCallback((ref: HTMLDivElement | null) => {
+    pageHeaderRef.current = ref
     if (ref) {
-      pageHeaderRef.current = ref
       setPageHeaderSet(true)
     }
   }, [])
@@ -36,8 +36,8 @@ export const AppContextProvider = ({
   const [, setRightSidebarSet] = useState(false)
   const rightSidebarRef = useRef<HTMLDivElement | null>(null)
   const setRightSidebarRef = useCallback((ref: HTMLDivElement | null) => {
+    rightSidebarRef.current = ref
     if (ref) {
-      rightSidebarRef.current = ref
       setRightSidebarSet(true)
     }
   }, [])

--- a/packages/stateful/components/AppContextProvider.tsx
+++ b/packages/stateful/components/AppContextProvider.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { AppContext } from '@dao-dao/stateless'
 import {
@@ -21,10 +21,26 @@ export const AppContextProvider = ({
     useState(false)
   const [updateProfileNftVisible, setUpdateProfileNftVisible] = useState(false)
 
-  // Page header.
+  // Page header. Set state when ref is set so it re-renders immediately.
+  // Without this, the page header is invisible until the next render.
+  const [, setPageHeaderSet] = useState(false)
   const pageHeaderRef = useRef<HTMLDivElement | null>(null)
-  // Right sidebar.
+  const setPageHeaderRef = useCallback((ref: HTMLDivElement | null) => {
+    if (ref) {
+      pageHeaderRef.current = ref
+      setPageHeaderSet(true)
+    }
+  }, [])
+  // Right sidebar. Set state when ref is set so it re-renders immediately.
+  // Without this, the right sidebar is invisible until the next render.
+  const [, setRightSidebarSet] = useState(false)
   const rightSidebarRef = useRef<HTMLDivElement | null>(null)
+  const setRightSidebarRef = useCallback((ref: HTMLDivElement | null) => {
+    if (ref) {
+      rightSidebarRef.current = ref
+      setRightSidebarSet(true)
+    }
+  }, [])
 
   // Command modal.
   const [rootCommandContextMaker, _setRootCommandContextMaker] =
@@ -58,6 +74,12 @@ export const AppContextProvider = ({
           visible: updateProfileNftVisible,
           toggle: () => setUpdateProfileNftVisible((v) => !v),
         },
+        // Include the page header and right sidebar portal refs in the context
+        // to be accessed by the component portals.
+        pageHeaderRef,
+        setPageHeaderRef,
+        rightSidebarRef,
+        setRightSidebarRef,
         rootCommandContextMaker,
         setRootCommandContextMaker: (maker) =>
           // See comment in `_setRootCommandContextMaker` for an explanation on
@@ -65,10 +87,6 @@ export const AppContextProvider = ({
           _setRootCommandContextMaker(() => maker),
         inbox,
         daoWebSocket,
-        // Include the page header and right sidebar portal refs in the context
-        // to be accessed by the component portals.
-        pageHeaderRef,
-        rightSidebarRef,
       }}
     >
       {children}

--- a/packages/stateless/components/layout/DappLayout.tsx
+++ b/packages/stateless/components/layout/DappLayout.tsx
@@ -27,7 +27,7 @@ export const DappLayout = ({
 }: DappLayoutProps) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const { responsiveNavigation, responsiveRightSidebar, pageHeaderRef } =
+  const { responsiveNavigation, responsiveRightSidebar, setPageHeaderRef } =
     useAppContext()
 
   const scrollableContainerRef = useRef<HTMLDivElement>(null)
@@ -129,7 +129,7 @@ export const DappLayout = ({
           )}
         </div>
 
-        <div className="shrink-0 px-6" ref={pageHeaderRef}></div>
+        <div className="shrink-0 px-6" ref={setPageHeaderRef}></div>
 
         {/* Make horizontal padding 1 unit more than page header so that the body is not touching the sides of the page header's bottom border when it scrolls. */}
         <div

--- a/packages/stateless/components/layout/PageHeader.tsx
+++ b/packages/stateless/components/layout/PageHeader.tsx
@@ -120,9 +120,16 @@ export const PageHeader = ({
 // If not in an AppContext, this component will render a PageHeader normally
 // instead of using the portal.
 export const PageHeaderContent = (props: PageHeaderProps) => {
-  const container = useAppContextIfAvailable()?.pageHeaderRef
-  return container?.current ? (
-    createPortal(<PageHeader {...props} />, container.current)
+  const appContext = useAppContextIfAvailable()
+
+  // If app context is available, but the page header ref is not, render nothing
+  // until the ref is available. If not in an app context, render the element
+  // directly. The direct render is useful when outside the AppContext, such as
+  // error pages in the SDA.
+  return appContext ? (
+    appContext.pageHeaderRef.current ? (
+      createPortal(<PageHeader {...props} />, appContext.pageHeaderRef.current)
+    ) : null
   ) : (
     <PageHeader {...props} />
   )

--- a/packages/stateless/components/layout/RightSidebar.tsx
+++ b/packages/stateless/components/layout/RightSidebar.tsx
@@ -26,7 +26,7 @@ export const RightSidebar = ({
   const { t } = useTranslation()
 
   const {
-    rightSidebarRef,
+    setRightSidebarRef,
     responsiveRightSidebar: {
       enabled: responsiveEnabled,
       toggle: toggleResponsive,
@@ -76,7 +76,7 @@ export const RightSidebar = ({
 
         <div className="mt-1">
           {/* Content gets inserted here when the portal <RightSidebarContent> below is used. */}
-          <div ref={rightSidebarRef}></div>
+          <div ref={setRightSidebarRef}></div>
         </div>
 
         {/* Only show if defined, which indicates wallet connected. */}
@@ -120,7 +120,7 @@ export const RightSidebar = ({
 // the right sidebar (which is located in a separate React tree due to the
 // nature of `DappLayout`/`SdaLayout` managing the layout of the navigation bar,
 // main page content, and right sidebar). This component uses a reference to the
-// container `div` (seen above with property `ref={rightSidebarRef}`) and
+// container `div` (seen above with property `ref={setRightSidebarRef}`) and
 // provides a component that will funnel its `children` into a React portal
 // (https://reactjs.org/docs/portals.html). `AppContext` provides a ref which
 // the `RightSidebar` component above uses and the `RightSidebarContent` below

--- a/packages/stateless/components/layout/SdaLayout.tsx
+++ b/packages/stateless/components/layout/SdaLayout.tsx
@@ -25,7 +25,7 @@ export const SdaLayout = ({
 }: SdaLayoutProps) => {
   const { t } = useTranslation()
   const router = useRouter()
-  const { responsiveNavigation, responsiveRightSidebar, pageHeaderRef } =
+  const { responsiveNavigation, responsiveRightSidebar, setPageHeaderRef } =
     useAppContext()
 
   const scrollableContainerRef = useRef<HTMLDivElement>(null)
@@ -127,7 +127,7 @@ export const SdaLayout = ({
           )}
         </div>
 
-        <div className="shrink-0 px-6" ref={pageHeaderRef}></div>
+        <div className="shrink-0 px-6" ref={setPageHeaderRef}></div>
 
         {/* Make horizontal padding 1 unit more than page header so that the body is not touching the sides of the page header's bottom border when it scrolls. */}
         <div

--- a/packages/storybook/decorators/makeAppContextDecorator.tsx
+++ b/packages/storybook/decorators/makeAppContextDecorator.tsx
@@ -1,5 +1,5 @@
 import { DecoratorFn } from '@storybook/react'
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import { makeGenericContext } from '@dao-dao/stateful/command'
 import { AppContext } from '@dao-dao/stateless'
@@ -17,8 +17,24 @@ export const makeAppContextDecorator: (
       useState(false)
     const [updateProfileVisible, setUpdateProfileVisible] = useState(false)
 
-    const pageHeaderRef = useRef(null)
-    const rightSidebarRef = useRef(null)
+    // Page header.
+    const [, setPageHeaderSet] = useState(false)
+    const pageHeaderRef = useRef<HTMLDivElement | null>(null)
+    const setPageHeaderRef = useCallback((ref: HTMLDivElement | null) => {
+      if (ref) {
+        pageHeaderRef.current = ref
+        setPageHeaderSet(true)
+      }
+    }, [])
+    // Right sidebar.
+    const [, setRightSidebarSet] = useState(false)
+    const rightSidebarRef = useRef<HTMLDivElement | null>(null)
+    const setRightSidebarRef = useCallback((ref: HTMLDivElement | null) => {
+      if (ref) {
+        rightSidebarRef.current = ref
+        setRightSidebarSet(true)
+      }
+    }, [])
 
     return (
       <AppContext.Provider
@@ -37,7 +53,9 @@ export const makeAppContextDecorator: (
             toggle: () => setUpdateProfileVisible((v) => !v),
           },
           pageHeaderRef,
+          setPageHeaderRef,
           rightSidebarRef,
+          setRightSidebarRef,
           rootCommandContextMaker: makeGenericContext,
           setRootCommandContextMaker: () => {},
           inbox: EMPTY_INBOX,

--- a/packages/types/stateless/AppContext.tsx
+++ b/packages/types/stateless/AppContext.tsx
@@ -24,9 +24,11 @@ export type IAppContext = {
 
   // Page header.
   pageHeaderRef: MutableRefObject<HTMLDivElement | null>
+  setPageHeaderRef: (ref: HTMLDivElement | null) => void
 
   // Right sidebar.
   rightSidebarRef: MutableRefObject<HTMLDivElement | null>
+  setRightSidebarRef: (ref: HTMLDivElement | null) => void
 
   // Command modal.
   rootCommandContextMaker: CommandModalContextMaker

--- a/packages/types/stateless/PageHeader.ts
+++ b/packages/types/stateless/PageHeader.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 
 import { BreadcrumbsProps } from './Breadcrumbs'
 
-export interface PageHeaderProps {
+export type PageHeaderProps = {
   title?: string
   breadcrumbs?: BreadcrumbsProps
   className?: string


### PR DESCRIPTION
Since refs do not trigger re-renders, the page currently doesn't load in with the header showing, which looks weird. This PR triggers an immediate re-render when the page header ref and right sidebar ref are set to fix this. In the previous change I made (#1125), I did not realize that the state variables served that purpose of causing a re-render. Now it all seems to work reliably....