### PR TITLE
SDA Header Fix

### DIFF
--- a/packages/stateful/components/SdaLayout.tsx
+++ b/packages/stateful/components/SdaLayout.tsx
@@ -17,6 +17,7 @@ import {
   DaoCreatedModal,
   InstallKeplrModal,
   NoKeplrAccountModal,
+  PageLoader,
   ProposalCreatedModal,
   SdaLayout as StatelessSdaLayout,
   useAppContext,
@@ -30,6 +31,7 @@ import { IconButtonLink } from './IconButtonLink'
 import { LinkWrapper } from './LinkWrapper'
 import { PfpkNftSelectionModal } from './PfpkNftSelectionModal'
 import { SidebarWallet } from './SidebarWallet'
+import { SuspenseLoader } from './SuspenseLoader'
 import { WalletFiatRampModal } from './WalletFiatRampModal'
 
 export const SdaLayout = ({ children }: { children: ReactNode }) => {
@@ -111,7 +113,7 @@ export const SdaLayout = ({ children }: { children: ReactNode }) => {
         status === WalletConnectionStatus.Connected ? walletProfile : undefined
       }
     >
-      {children}
+      <SuspenseLoader fallback={<PageLoader />}>{children}</SuspenseLoader>
 
       {/* Modals */}
 


### PR DESCRIPTION
For some reason, the SDA header is still hiding on load sometimes. Right now it's only happening on mainnet SDA, not on the testnet, and not on the dApp. This is weird.

I suspect it has something to do with the DaoPageWrapper that wraps the whole layout suspending the layout, which makes it take an extra render cycle to load the PageHeader in and set the ref. This could be explained by the testnet loading so fast that the flicker is imperceptible, whereas the dApp takes longer to load data. On the dApp, the layout is not suspended because the DaoPageWrapper depends on the page, so it doesn't have this problem.

Suspending the SDA page inside the layout seem to fix this problem...