### PR TITLE
Organized NFT selectors and standardized token URI data retrieval

### DIFF
--- a/packages/state/recoil/selectors/nft.ts
+++ b/packages/state/recoil/selectors/nft.ts
@@ -1,68 +1,77 @@
-import { ChainInfoID } from '@noahsaso/cosmodal'
 import { selectorFamily } from 'recoil'
 
-import { NativeStargazeCollectionInfo, WithChainId } from '@dao-dao/types'
+import { NftUriData } from '@dao-dao/types'
 import { transformIpfsUrlToHttpsIfNecessary } from '@dao-dao/utils'
 
-import { Cw721BaseSelectors } from './contracts'
-
-export const nftTokenUriDataSelector = selectorFamily({
-  key: 'nftTokenUriData',
-  get: (tokenUri: string) => async () => {
+// Tries to parse [EIP-721] metadata out of an NFT's metadata JSON.
+//
+// [EIP-721]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
+export const nftUriDataSelector = selectorFamily<
+  NftUriData | undefined,
+  string
+>({
+  key: 'nftUriData',
+  get: (tokenUri) => async () => {
     try {
       // Transform IPFS url if necessary.
-      const response = await fetch(transformIpfsUrlToHttpsIfNecessary(tokenUri))
-      return await response.text()
+      let response = await fetch(transformIpfsUrlToHttpsIfNecessary(tokenUri))
+
+      // Sometimes the tokenUri is missing a .json extension, so try again.
+      if (response.status === 502 && !tokenUri.endsWith('.json')) {
+        response = await fetch(
+          transformIpfsUrlToHttpsIfNecessary(tokenUri + '.json')
+        )
+      }
+
+      if (!response.ok) {
+        return undefined
+      }
+
+      const data = await response.json()
+
+      let name
+      let description
+      let imageUrl
+      let externalLink
+
+      if (typeof data.name === 'string' && !!data.name.trim()) {
+        name = data.name
+      }
+
+      if (typeof data.description === 'string' && !!data.description.trim()) {
+        description = data.description
+      }
+
+      if (typeof data.image === 'string' && !!data.image) {
+        imageUrl = transformIpfsUrlToHttpsIfNecessary(data.image)
+      }
+
+      if (typeof data.external_url === 'string' && !!data.external_url.trim()) {
+        const externalUrl = transformIpfsUrlToHttpsIfNecessary(
+          data.external_url
+        )
+        const externalUrlDomain = new URL(externalUrl).hostname
+        externalLink = {
+          href: externalUrl,
+          name: HostnameMap[externalUrlDomain] ?? externalUrlDomain,
+        }
+      }
+
+      return {
+        name,
+        description,
+        imageUrl,
+        externalLink,
+      }
     } catch (err) {
       console.error(err)
     }
   },
 })
 
-export const nativeAndStargazeCollectionInfoSelector = selectorFamily<
-  NativeStargazeCollectionInfo,
-  WithChainId<{ nativeCollectionAddress: string }>
->({
-  key: 'nativeAndStargazeCollectionInfo',
-  get:
-    ({ nativeCollectionAddress, chainId }) =>
-    ({ get }) => {
-      const nativeCollectionInfo = get(
-        Cw721BaseSelectors.contractInfoSelector({
-          contractAddress: nativeCollectionAddress,
-          chainId,
-          params: [],
-        })
-      )
-
-      // TODO(ICS721): Identify IBC'd Stargaze NFT collections better.
-      const stargazeCollectionAddress = nativeCollectionInfo.name.startsWith(
-        'wasm.'
-      )
-        ? nativeCollectionInfo.name.split('/').pop()
-        : undefined
-      const stargazeCollectionInfo = stargazeCollectionAddress
-        ? get(
-            Cw721BaseSelectors.contractInfoSelector({
-              contractAddress: stargazeCollectionAddress,
-              chainId: ChainInfoID.Stargaze1,
-              params: [],
-            })
-          )
-        : undefined
-
-      return {
-        native: {
-          address: nativeCollectionAddress,
-          info: nativeCollectionInfo,
-        },
-        stargaze:
-          stargazeCollectionAddress && stargazeCollectionInfo
-            ? {
-                address: stargazeCollectionAddress,
-                info: stargazeCollectionInfo,
-              }
-            : undefined,
-      }
-    },
-})
+// Maps domain -> human readable name. If a domain is in this set, NFTs
+// associated with it will have their external links displayed using the human
+// readable name provided here.
+const HostnameMap: Record<string, string | undefined> = {
+  'stargaze.zone': 'Stargaze',
+}

--- a/packages/state/recoil/selectors/profile.ts
+++ b/packages/state/recoil/selectors/profile.ts
@@ -2,9 +2,7 @@ import { selectorFamily, waitForAll } from 'recoil'
 
 import {
   KeplrWalletProfile,
-  PfpkWalletProfile,
   ProfileSearchHit,
-  WalletProfile,
   WithChainId,
 } from '@dao-dao/types'
 import {
@@ -15,49 +13,6 @@ import {
 } from '@dao-dao/utils'
 
 import { refreshWalletProfileAtom } from '../atoms/refresh'
-
-export const pfpkProfileSelector = selectorFamily<WalletProfile, string>({
-  key: 'pfpkProfile',
-  get:
-    (publicKey) =>
-    async ({ get }) => {
-      get(refreshWalletProfileAtom(publicKey))
-
-      let profile: WalletProfile = {
-        // Disallows editing if we don't have correct nonce from server.
-        nonce: -1,
-        name: null,
-        imageUrl: '',
-        nft: null,
-      }
-
-      // Load profile from PFPK API.
-      let response
-      try {
-        response = await fetch(PFPK_API_BASE + `/${publicKey}`)
-        if (response.ok) {
-          const pfpkProfile: PfpkWalletProfile = await response.json()
-          profile.nonce = pfpkProfile.nonce
-          profile.name = pfpkProfile.name
-          profile.nft = pfpkProfile.nft
-          // Set root-level `imageUrl` if NFT present.
-          if (pfpkProfile.nft?.imageUrl) {
-            profile.imageUrl = transformIpfsUrlToHttpsIfNecessary(
-              pfpkProfile.nft.imageUrl
-            )
-          }
-        } else {
-          console.error(await response.json())
-        }
-      } catch (err) {
-        console.error(processError(err))
-      }
-
-      return profile
-    },
-  // Allow overriding imageUrl with Keplr fallback.
-  dangerouslyAllowMutability: true,
-})
 
 export const keplrProfileImageSelector = selectorFamily<
   string | undefined,

--- a/packages/stateful/components/AddressInput.tsx
+++ b/packages/stateful/components/AddressInput.tsx
@@ -8,7 +8,6 @@ import {
 } from 'recoil'
 
 import {
-  pfpkProfileSelector,
   searchProfilesByNamePrefixSelector,
   walletHexPublicKeyOverridesAtom,
 } from '@dao-dao/state/recoil'
@@ -19,6 +18,7 @@ import {
 import { AddressInputProps } from '@dao-dao/types'
 import { CHAIN_BECH32_PREFIX, isValidAddress } from '@dao-dao/utils'
 
+import { pfpkProfileSelector } from '../recoil/selectors/profile'
 import { EntityDisplay } from './EntityDisplay'
 
 export const AddressInput = <

--- a/packages/stateful/hooks/useWalletProfile.ts
+++ b/packages/stateful/hooks/useWalletProfile.ts
@@ -2,12 +2,13 @@ import { constSelector, useRecoilValueLoadable } from 'recoil'
 
 import {
   keplrProfileImageSelector,
-  pfpkProfileSelector,
   walletHexPublicKeySelector,
 } from '@dao-dao/state'
 import { useCachedLoadable } from '@dao-dao/stateless'
 import { LoadingData, WalletProfile, WithChainId } from '@dao-dao/types'
 import { getFallbackImage, loadableToLoadingData } from '@dao-dao/utils'
+
+import { pfpkProfileSelector } from '../recoil/selectors/profile'
 
 export type UseWalletProfileOptions = WithChainId<{
   walletAddress: string

--- a/packages/stateful/recoil/selectors/index.ts
+++ b/packages/stateful/recoil/selectors/index.ts
@@ -1,4 +1,5 @@
 export * from './dao'
 export * from './nft'
+export * from './profile'
 export * from './dao/following'
 export * from './treasury'

--- a/packages/stateful/recoil/selectors/profile.ts
+++ b/packages/stateful/recoil/selectors/profile.ts
@@ -1,0 +1,60 @@
+import { selectorFamily } from 'recoil'
+
+import { refreshWalletProfileAtom } from '@dao-dao/state/recoil'
+import { PfpkWalletProfile, WalletProfile } from '@dao-dao/types'
+import { PFPK_API_BASE, processError } from '@dao-dao/utils'
+
+import { nftCardInfoSelector } from './nft'
+
+export const pfpkProfileSelector = selectorFamily<WalletProfile, string>({
+  key: 'pfpkProfile',
+  get:
+    (publicKey) =>
+    async ({ get }) => {
+      get(refreshWalletProfileAtom(publicKey))
+
+      let profile: WalletProfile = {
+        // Disallows editing if we don't have correct nonce from server.
+        nonce: -1,
+        name: null,
+        imageUrl: '',
+        nft: null,
+      }
+
+      // Load profile from PFPK API.
+      let response
+      try {
+        response = await fetch(PFPK_API_BASE + `/${publicKey}`)
+        if (response.ok) {
+          const pfpkProfile: PfpkWalletProfile = await response.json()
+          profile.nonce = pfpkProfile.nonce
+          profile.name = pfpkProfile.name
+          profile.nft = pfpkProfile.nft
+
+          // Get NFT info from data to extract image.
+          if (pfpkProfile.nft) {
+            const nftInfo = get(
+              nftCardInfoSelector({
+                collection: pfpkProfile.nft.collectionAddress,
+                tokenId: pfpkProfile.nft.tokenId,
+                chainId: pfpkProfile.nft.chainId,
+              })
+            )
+
+            // Set `imageUrl` if NFT present.
+            if (nftInfo?.imageUrl) {
+              profile.imageUrl = nftInfo.imageUrl
+            }
+          }
+        } else {
+          console.error(await response.json())
+        }
+      } catch (err) {
+        console.error(processError(err))
+      }
+
+      return profile
+    },
+  // Allow overriding imageUrl with Keplr fallback.
+  dangerouslyAllowMutability: true,
+})

--- a/packages/types/nft.ts
+++ b/packages/types/nft.ts
@@ -39,3 +39,10 @@ export interface NativeStargazeCollectionInfo {
     info: ContractInfoResponse
   }
 }
+
+export type NftUriData = {
+  name: string | undefined
+  description: string | undefined
+  imageUrl: string | undefined
+  externalLink: { href: string; name: string } | undefined
+}

--- a/packages/types/profile.ts
+++ b/packages/types/profile.ts
@@ -2,6 +2,7 @@ export interface PfpkWalletProfile {
   nonce: number
   name: string | null
   nft: {
+    chainId: string
     imageUrl: string
     tokenId: string
     collectionAddress: string

--- a/packages/utils/nft.ts
+++ b/packages/utils/nft.ts
@@ -1,5 +1,3 @@
-import { transformIpfsUrlToHttpsIfNecessary } from './conversion'
-
 // If name is only a number, prefix with collection name. Fallback to token ID
 // if name does not exist.
 export const getNftName = (
@@ -10,69 +8,6 @@ export const getNftName = (
   !tokenName || /^[0-9]+$/.test(tokenName.trim())
     ? `${collectionName} ${(tokenName || tokenId).trim()}`.trim()
     : tokenName
-
-// Tries to parse [EIP-721] metadata out of the data at it's metadata pointer.
-//
-// [EIP-721]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
-export const parseNftUriResponse = (
-  uriDataResponse: string
-): {
-  name: string | undefined
-  description: string | undefined
-  imageUrl: string | undefined
-  externalLink: { href: string; name: string } | undefined
-} => {
-  // Maps domain -> human readable name. If a domain is in this set, NFTs
-  // associated with it will have their external links displayed using the human
-  // readable name provided here.
-  const HostnameMap: Record<string, string | undefined> = {
-    'stargaze.zone': 'Stargaze',
-  }
-
-  let name
-  let description
-  let imageUrl
-  let externalLink
-  // Only try to parse if there's a good chance this is JSON, the
-  // heuristic being the first non-whitespace character is a "{".
-  if (uriDataResponse.trimStart().startsWith('{')) {
-    try {
-      const json = JSON.parse(uriDataResponse)
-
-      if (typeof json.name === 'string' && !!json.name.trim()) {
-        name = json.name
-      }
-
-      if (typeof json.description === 'string' && !!json.description.trim()) {
-        description = json.description
-      }
-
-      if (typeof json.image === 'string' && !!json.image) {
-        imageUrl = transformIpfsUrlToHttpsIfNecessary(json.image)
-      }
-
-      if (typeof json.external_url === 'string' && !!json.external_url.trim()) {
-        const externalUrl = transformIpfsUrlToHttpsIfNecessary(
-          json.external_url
-        )
-        const externalUrlDomain = new URL(externalUrl).hostname
-        externalLink = {
-          href: externalUrl,
-          name: HostnameMap[externalUrlDomain] ?? externalUrlDomain,
-        }
-      }
-    } catch (err) {
-      console.error(err)
-    }
-  }
-
-  return {
-    name,
-    description,
-    imageUrl,
-    externalLink,
-  }
-}
 
 // Uploads an NFT to NFT Storage and returns the metadata.
 export const uploadNft = async (


### PR DESCRIPTION
This PR cleans up some unnecessarily complex NFT selectors and starts using the token URI metadata to retrieve Stargaze info instead of extracting it from the Stargaze API response directly.

The Stargaze API response provides IPFS image URLs using their gateway (`https://ipfs.stargaze.zone`), but the gateway is no longer finding data for many NFTs. Inspecting Stargaze's website reveals they use a different gateway (`https://ipfs-gw.stargaze-apis.com`). We could switch over to this new gateway which seems to have the data, but there's no reason to rely on Stargaze's infrastructure setup like this going forward. Switching to using the token URI selector we use for all Juno NFTs, which converts IPFS URLs to our chosen gateway (`https://nftstorage.link/ipfs`) that seems to work much more reliably, is safer and DRYer.