### PR TITLE
Clean up Sentry errors

### DIFF
--- a/apps/dapp/sentry.client.config.js
+++ b/apps/dapp/sentry.client.config.js
@@ -31,4 +31,19 @@ Sentry.init({
     'TypeError: cancelled',
     'TypeError: Cancelled',
   ],
+
+  // Don't send hydration errors.
+  beforeSend: (event, hint) => {
+    const error = hint.originalException
+    if (
+      error &&
+      'message' in error &&
+      typeof error.message === 'string' &&
+      error.message.match(/hydration|hydrating/i)
+    ) {
+      return null
+    }
+
+    return event
+  },
 })

--- a/apps/dapp/sentry.client.config.js
+++ b/apps/dapp/sentry.client.config.js
@@ -30,20 +30,10 @@ Sentry.init({
     'TypeError: The request timed out.',
     'TypeError: cancelled',
     'TypeError: Cancelled',
+    'hydration',
+    'hydrating',
+    'The user aborted a request.',
+    'Cancel rendering route',
+    'Transaction rejected',
   ],
-
-  // Don't send hydration errors.
-  beforeSend: (event, hint) => {
-    const error = hint.originalException
-    if (
-      error &&
-      'message' in error &&
-      typeof error.message === 'string' &&
-      error.message.match(/hydration|hydrating/i)
-    ) {
-      return null
-    }
-
-    return event
-  },
 })

--- a/apps/sda/sentry.client.config.js
+++ b/apps/sda/sentry.client.config.js
@@ -31,4 +31,19 @@ Sentry.init({
     'TypeError: cancelled',
     'TypeError: Cancelled',
   ],
+
+  // Don't send hydration errors.
+  beforeSend: (event, hint) => {
+    const error = hint.originalException
+    if (
+      error &&
+      'message' in error &&
+      typeof error.message === 'string' &&
+      error.message.match(/hydration|hydrating/i)
+    ) {
+      return null
+    }
+
+    return event
+  },
 })

--- a/apps/sda/sentry.client.config.js
+++ b/apps/sda/sentry.client.config.js
@@ -30,20 +30,10 @@ Sentry.init({
     'TypeError: The request timed out.',
     'TypeError: cancelled',
     'TypeError: Cancelled',
+    'hydration',
+    'hydrating',
+    'The user aborted a request.',
+    'Cancel rendering route',
+    'Transaction rejected',
   ],
-
-  // Don't send hydration errors.
-  beforeSend: (event, hint) => {
-    const error = hint.originalException
-    if (
-      error &&
-      'message' in error &&
-      typeof error.message === 'string' &&
-      error.message.match(/hydration|hydrating/i)
-    ) {
-      return null
-    }
-
-    return event
-  },
 })

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/hooks/makeUsePublishProposal.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/hooks/makeUsePublishProposal.ts
@@ -256,11 +256,11 @@ export const makeUsePublishProposal =
               awaitNextBlock().then(refreshBalances)
             } catch (err) {
               throw new Error(
-                `Failed to increase allowance to pay proposal deposit: (${processError(
+                `Failed to increase allowance to pay proposal deposit: ${processError(
                   err,
                   // Don't send to Sentry, but still format SDK errors nicely.
-                  { forceCapture: true }
-                )})`
+                  { forceCapture: false }
+                )}`
               )
             }
           }

--- a/packages/stateful/server/makeGetDaoStaticProps.ts
+++ b/packages/stateful/server/makeGetDaoStaticProps.ts
@@ -545,6 +545,11 @@ const daoCoreDumpState = async (
       }
     }
   } catch (error) {
+    // Rethrow if legacy DAO.
+    if (error instanceof LegacyDaoError) {
+      throw error
+    }
+
     // Ignore error. Fallback to querying chain below.
     console.error(error, processError(error))
   }
@@ -553,6 +558,9 @@ const daoCoreDumpState = async (
   const daoCoreClient = new DaoCoreV2QueryClient(cwClient, coreAddress)
 
   const dumpedState = await daoCoreClient.dumpState()
+  if (LEGACY_DAO_CONTRACT_NAMES.includes(dumpedState.version.contract)) {
+    throw new LegacyDaoError()
+  }
 
   const coreVersion = parseContractVersion(dumpedState.version.version)
   if (!coreVersion) {


### PR DESCRIPTION
This stops forwarding errors containing `hydration` or `hydrating` in them to Sentry. [Read this to learn about hydration errors](https://nextjs.org/docs/messages/react-hydration-error). These errors do not occur on development, are not shown to users in production, and generally do not affect the usability of the site in any way. It's very tedious to locate the causes of these issues, and the error information provided to Sentry is no help at all. All that logging them is doing right now is draining our free monthly quota. The fact that these happen on prod and not dev makes it so incredibly difficult to find them. If they appear on dev, I will fix them. But logging them to Sentry is not helping.

This also fixes legacy DAO redirect error handling.