### PR TITLE
Fixed dev server

### DIFF
--- a/packages/state/recoil/selectors/chain.ts
+++ b/packages/state/recoil/selectors/chain.ts
@@ -64,6 +64,7 @@ export const stargateClientForChainSelector = selectorFamily<
     await stargateClientRouter.connect(
       chainId ? getRpcForChainId(chainId) : getRpcForChainId(CHAIN_ID)
     ),
+  dangerouslyAllowMutability: true,
 })
 
 export const cosmWasmClientForChainSelector = selectorFamily<
@@ -75,6 +76,7 @@ export const cosmWasmClientForChainSelector = selectorFamily<
     await cosmWasmClientRouter.connect(
       chainId ? getRpcForChainId(chainId) : getRpcForChainId(CHAIN_ID)
     ),
+  dangerouslyAllowMutability: true,
 })
 
 export const cosmosRpcClientForChainSelector = selectorFamily({
@@ -87,6 +89,7 @@ export const cosmosRpcClientForChainSelector = selectorFamily({
           : getRpcForChainId(CHAIN_ID),
       })
     ).cosmos,
+  dangerouslyAllowMutability: true,
 })
 
 export const junoRpcClientSelector = selector({
@@ -97,6 +100,7 @@ export const junoRpcClientSelector = selector({
         rpcEndpoint: getRpcForChainId(ChainInfoID.Juno1),
       })
     ).juno,
+  dangerouslyAllowMutability: true,
 })
 
 export const blockHeightSelector = selectorFamily<number, WithChainId<{}>>({

--- a/packages/state/recoil/selectors/contracts/Cw20Base.ts
+++ b/packages/state/recoil/selectors/contracts/Cw20Base.ts
@@ -40,6 +40,7 @@ const queryClient = selectorFamily<Cw20BaseQueryClient, QueryClientParams>({
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new Cw20BaseQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/state/recoil/selectors/contracts/Cw20Stake.ts
+++ b/packages/state/recoil/selectors/contracts/Cw20Stake.ts
@@ -36,6 +36,7 @@ const queryClient = selectorFamily<Cw20StakeQueryClient, QueryClientParams>({
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new Cw20StakeQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/state/recoil/selectors/contracts/Cw4Group.ts
+++ b/packages/state/recoil/selectors/contracts/Cw4Group.ts
@@ -28,6 +28,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new Cw4GroupQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export const adminSelector = selectorFamily<

--- a/packages/state/recoil/selectors/contracts/Cw721Base.ts
+++ b/packages/state/recoil/selectors/contracts/Cw721Base.ts
@@ -40,6 +40,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new Cw721BaseQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/state/recoil/selectors/contracts/CwTokenSwap.ts
+++ b/packages/state/recoil/selectors/contracts/CwTokenSwap.ts
@@ -22,6 +22,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new CwTokenSwapQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 export const statusSelector = selectorFamily<
   StatusResponse,

--- a/packages/state/recoil/selectors/contracts/DaoCore.v2.ts
+++ b/packages/state/recoil/selectors/contracts/DaoCore.v2.ts
@@ -69,6 +69,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new DaoCoreV2QueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/state/recoil/selectors/contracts/DaoVotingCw20Staked.ts
+++ b/packages/state/recoil/selectors/contracts/DaoVotingCw20Staked.ts
@@ -32,6 +32,7 @@ const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new DaoVotingCw20StakedQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export const stakingContractSelector = selectorFamily<

--- a/packages/state/recoil/selectors/contracts/DaoVotingCw4.ts
+++ b/packages/state/recoil/selectors/contracts/DaoVotingCw4.ts
@@ -32,6 +32,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new DaoVotingCw4QueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/state/recoil/selectors/contracts/DaoVotingCw721Staked.ts
+++ b/packages/state/recoil/selectors/contracts/DaoVotingCw721Staked.ts
@@ -37,6 +37,7 @@ const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new DaoVotingCw721StakedQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/state/recoil/selectors/contracts/DaoVotingNativeStaked.ts
+++ b/packages/state/recoil/selectors/contracts/DaoVotingNativeStaked.ts
@@ -35,6 +35,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new DaoVotingNativeStakedQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/state/recoil/selectors/contracts/WyndexFactory.ts
+++ b/packages/state/recoil/selectors/contracts/WyndexFactory.ts
@@ -34,6 +34,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new WyndexFactoryQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export const configSelector = selectorFamily<

--- a/packages/state/recoil/selectors/contracts/WyndexMultiHop.ts
+++ b/packages/state/recoil/selectors/contracts/WyndexMultiHop.ts
@@ -35,6 +35,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new WyndexMultiHopQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/contracts/CwProposalSingle.v1.recoil.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/contracts/CwProposalSingle.v1.recoil.ts
@@ -43,6 +43,7 @@ const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new CwProposalSingleV1QueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/contracts/DaoPreProposeSingle.recoil.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/contracts/DaoPreProposeSingle.recoil.ts
@@ -33,6 +33,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new CwPreProposeSingleQueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/contracts/DaoProposalSingle.v2.recoil.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/contracts/DaoProposalSingle.v2.recoil.ts
@@ -45,6 +45,7 @@ export const queryClient = selectorFamily<
       const client = get(cosmWasmClientForChainSelector(chainId))
       return new DaoProposalSingleV2QueryClient(client, contractAddress)
     },
+  dangerouslyAllowMutability: true,
 })
 
 export type ExecuteClientParams = {


### PR DESCRIPTION
After #1149, the dev server broke, because recoil by default makes the values returned from selectors read only to catch any accidental mutations. It makes the values and all nested values read only, but the batching HttpClient needs to write to its internal instance variables, so it must be mutable. This PR makes all the contract query client selectors allow mutability.