### PR TITLE
Fix transactions on Me page with Ledger/WalletConnect

### DIFF
--- a/packages/stateful/components/WalletProvider.tsx
+++ b/packages/stateful/components/WalletProvider.tsx
@@ -1,4 +1,16 @@
-import { GasPrice } from '@cosmjs/stargate'
+import { createWasmAminoConverters } from '@cosmjs/cosmwasm-stargate'
+import {
+  AminoTypes,
+  GasPrice,
+  createAuthzAminoConverters,
+  createBankAminoConverters,
+  createDistributionAminoConverters,
+  createFeegrantAminoConverters,
+  createGovAminoConverters,
+  createIbcAminoConverters,
+  createStakingAminoConverters,
+  createVestingAminoConverters,
+} from '@cosmjs/stargate'
 import {
   ChainInfoID,
   ChainInfoMap,
@@ -89,6 +101,22 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
         gasPrice: GasPrice.fromString(
           '0.0025' + chainInfo.feeCurrencies[0].coinMinimalDenom
         ),
+        // @cosmjs/stargate/SigningStargateClient.ts amino types and wasm. For
+        // some reason, the default SigningCosmWasmClient only supports wasm and
+        // bank amino types.
+        aminoTypes: new AminoTypes({
+          ...createWasmAminoConverters(),
+          ...createAuthzAminoConverters(),
+          ...createBankAminoConverters(),
+          ...createDistributionAminoConverters(),
+          ...createGovAminoConverters(),
+          ...createStakingAminoConverters(
+            chainInfo.bech32Config.bech32PrefixAccAddr
+          ),
+          ...createIbcAminoConverters(),
+          ...createFeegrantAminoConverters(),
+          ...createVestingAminoConverters(),
+        }),
       })}
       getSigningStargateClientOptions={(chainInfo) => ({
         gasPrice: GasPrice.fromString(

--- a/packages/stateless/pages/MeTransactionBuilder.tsx
+++ b/packages/stateless/pages/MeTransactionBuilder.tsx
@@ -293,7 +293,7 @@ export const MeTransactionBuilder = ({
             {saves.data.map((save, index) => (
               <Button
                 key={index}
-                contentContainerClassName="flex flex-col !items-start !gap-0 max-w-[16rem] text-left"
+                contentContainerClassName="flex flex-col !items-stretch !gap-0 max-w-[16rem] text-left"
                 onClick={() =>
                   reset({
                     // Clone the actions to prevent mutating the original


### PR DESCRIPTION
Rarma reported this in #bug-club when trying to submit a governance vote from his wallet on the Me page:
![image](https://user-images.githubusercontent.com/6721426/223502688-37e77891-3292-477e-9bbd-7166ae6a4faa.png)

The me page transactions does not support most sdk types because the Amino types are not setup correctly by default. This PR fixes that, and I will submit a PR upstream to set these up by default.