### PR TITLE
Increase size threshold for right sidebar

### DIFF
--- a/packages/stateless/components/layout/DappLayout.tsx
+++ b/packages/stateless/components/layout/DappLayout.tsx
@@ -65,15 +65,15 @@ export const DappLayout = ({
           // automatically displays.
           responsiveNavigation.enabled
             ? 'opacity-30 sm:opacity-100'
-            : // Right sidebar can be responsive up to xl size. After that, it automatically displays.
+            : // Right sidebar can be responsive up to 2xl size. After that, it automatically displays.
             responsiveRightSidebar.enabled
-            ? 'opacity-30 xl:opacity-100'
+            ? 'opacity-30 2xl:opacity-100'
             : 'opacity-100'
         )}
       >
         <div
           className={clsx(
-            'fixed right-4 bottom-4 z-10 cursor-pointer sm:right-6 sm:bottom-6 xl:hidden'
+            'fixed right-4 bottom-4 z-10 cursor-pointer sm:right-6 sm:bottom-6 2xl:hidden'
           )}
           onClick={connected ? responsiveRightSidebar.toggle : undefined}
         >

--- a/packages/stateless/components/layout/DappNavigation.tsx
+++ b/packages/stateless/components/layout/DappNavigation.tsx
@@ -147,8 +147,8 @@ export const DappNavigation = ({
         className={clsx(
           // General
           'no-scrollbar flex h-full shrink-0 flex-col overflow-y-auto bg-background-base py-6 pt-0 text-lg',
-          // If compact, items will manager their own padding so that
-          // highlighted rows fill the whole width.
+          // If compact, items will manage their own padding so that highlighted
+          // rows fill the whole width.
           !compact && 'px-6',
           // Responsive
           'absolute top-0 bottom-0 z-20 w-[90vw] shadow-dp8 transition-all',
@@ -157,9 +157,9 @@ export const DappNavigation = ({
           'sm:relative sm:left-0 sm:shadow-none sm:transition-[padding-left]',
           compact ? 'sm:w-min' : 'sm:w-[264px]',
 
-          // Dim if responsive right sidebar is open. Right sidebar can be responsive up to xl size. After that, it automatically displays.
+          // Dim if responsive right sidebar is open. Right sidebar can be responsive up to 2xl size. After that, it automatically displays.
           responsiveRightSidebarEnabled
-            ? 'opacity-30 xl:opacity-100'
+            ? 'opacity-30 2xl:opacity-100'
             : 'opacity-100'
         )}
       >

--- a/packages/stateless/components/layout/RightSidebar.tsx
+++ b/packages/stateless/components/layout/RightSidebar.tsx
@@ -26,7 +26,7 @@ export const RightSidebar = ({ wallet }: RightSidebarProps) => {
       {/* Layer underneath that allows closing the responsive sidebar by tapping on visible parts of the page. */}
       {responsiveEnabled && (
         <div
-          className="absolute top-0 right-0 bottom-0 left-0 z-[29] cursor-pointer xl:hidden"
+          className="absolute top-0 right-0 bottom-0 left-0 z-[29] cursor-pointer 2xl:hidden"
           onClick={() => responsiveEnabled && toggleResponsive()}
         ></div>
       )}
@@ -41,11 +41,11 @@ export const RightSidebar = ({ wallet }: RightSidebarProps) => {
             ? 'right-0 opacity-100'
             : 'pointer-events-none -right-full opacity-0 sm:-right-96',
           // Large
-          'xl:pointer-events-auto xl:relative xl:left-0 xl:shrink-0 xl:opacity-100 xl:shadow-none'
+          '2xl:pointer-events-auto 2xl:relative 2xl:left-0 2xl:shrink-0 2xl:opacity-100 2xl:shadow-none'
         )}
       >
         {/* Show responsive close button. */}
-        <div className="fixed right-4 bottom-4 z-40 cursor-pointer rounded-full bg-background-base shadow-dp8 transition sm:right-6 sm:bottom-6 xl:hidden">
+        <div className="fixed right-4 bottom-4 z-40 cursor-pointer rounded-full bg-background-base shadow-dp8 transition sm:right-6 sm:bottom-6 2xl:hidden">
           <IconButton
             Icon={KeyboardDoubleArrowRight}
             // Match ProfileImage rounding.

--- a/packages/stateless/components/layout/SdaLayout.tsx
+++ b/packages/stateless/components/layout/SdaLayout.tsx
@@ -63,15 +63,15 @@ export const SdaLayout = ({
           // automatically displays.
           responsiveNavigation.enabled
             ? 'opacity-30 sm:opacity-100'
-            : // Right sidebar can be responsive up to xl size. After that, it automatically displays.
+            : // Right sidebar can be responsive up to 2xl size. After that, it automatically displays.
             responsiveRightSidebar.enabled
-            ? 'opacity-30 xl:opacity-100'
+            ? 'opacity-30 2xl:opacity-100'
             : 'opacity-100'
         )}
       >
         <div
           className={clsx(
-            'fixed right-4 bottom-4 z-10 cursor-pointer sm:right-6 sm:bottom-6 xl:hidden'
+            'fixed right-4 bottom-4 z-10 cursor-pointer sm:right-6 sm:bottom-6 2xl:hidden'
           )}
           onClick={connected ? responsiveRightSidebar.toggle : undefined}
         >

--- a/packages/stateless/components/layout/SdaNavigation.tsx
+++ b/packages/stateless/components/layout/SdaNavigation.tsx
@@ -135,9 +135,9 @@ export const SdaNavigation = ({
           'sm:relative sm:left-0 sm:shadow-none sm:transition-[padding-left]',
           compact ? 'sm:w-min' : 'sm:w-[264px]',
 
-          // Dim if responsive right sidebar is open. Right sidebar can be responsive up to xl size. After that, it automatically displays.
+          // Dim if responsive right sidebar is open. Right sidebar can be responsive up to 2xl size. After that, it automatically displays.
           responsiveRightSidebarEnabled
-            ? 'opacity-30 xl:opacity-100'
+            ? 'opacity-30 2xl:opacity-100'
             : 'opacity-100'
         )}
       >


### PR DESCRIPTION
The right sidebar that displays wallet and profile information hides behind an expandable profile button at the bottom up to a certain screen width, at which point it reveals as a static right sidebar. I think the current width that it appears inline with the page content is a bit too small, such that the main content of the page has insufficient space with respect to how much empty space the right sidebar takes up. In other words, I think the minimum ratio of the page content to the right sidebar width should increase. This PR increases the screen width at which this switch from responsive to inline occurs.

The responsive groups below show the right sidebar just under the height at which it gets displayed inline. In other words, this is the max width at which the responsive button will show and the right sidebar will be concealed. The new threshold is `1536px` and the old one is `1280px`.

## New threshold

### Responsive
Nav expanded:
<img width="1647" alt="Screenshot 2023-03-19 at 9 44 42 PM" src="https://user-images.githubusercontent.com/6721426/226248985-18488e54-9b5f-4206-b718-1f0ca3032eed.png">
Nav compacted:
<img width="1647" alt="Screenshot 2023-03-19 at 9 44 54 PM" src="https://user-images.githubusercontent.com/6721426/226249015-ad290ce1-de1a-4a4a-90e8-7c557031530a.png">

### Inline
Nav expanded:
<img width="1648" alt="Screenshot 2023-03-19 at 9 45 54 PM" src="https://user-images.githubusercontent.com/6721426/226249113-aa92c9eb-41b2-4f56-9646-6b52be83a98f.png">
Nav compacted:
<img width="1648" alt="Screenshot 2023-03-19 at 9 46 05 PM" src="https://user-images.githubusercontent.com/6721426/226249133-e28199a5-1769-45fd-ae7c-55f6e41ec74d.png">

## Old threshold

### Responsive
Nav expanded:
<img width="1391" alt="Screenshot 2023-03-19 at 9 43 07 PM" src="https://user-images.githubusercontent.com/6721426/226248807-071f08bb-23ec-449c-bf3c-1edf289aca7d.png">
Nav compacted:
<img width="1391" alt="Screenshot 2023-03-19 at 9 43 17 PM" src="https://user-images.githubusercontent.com/6721426/226248835-543f6bde-40f6-4249-bdc9-19a7ddd9992c.png">

### Inline
Nav expanded:
<img width="1393" alt="Screenshot 2023-03-19 at 9 42 12 PM" src="https://user-images.githubusercontent.com/6721426/226248695-76d4754d-9862-4e62-b74b-0b7b17f44326.png">
Nav compacted:
<img width="1392" alt="Screenshot 2023-03-19 at 9 47 45 PM" src="https://user-images.githubusercontent.com/6721426/226249285-d720a288-0d5f-4804-8f08-a6179f804e6e.png">
