### PR TITLE
Fixed token swap withdraw action matching non-token swap contracts, and other action decoders

### DIFF
--- a/packages/stateful/actions/actions/Instantiate.tsx
+++ b/packages/stateful/actions/actions/Instantiate.tsx
@@ -18,6 +18,7 @@ import {
   convertDenomToMicroDenomWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   makeWasmMessage,
+  objectMatchesStructure,
 } from '@dao-dao/utils'
 
 import { useExecutedProposalTxLoadable } from '../../hooks/useExecutedProposalTxLoadable'
@@ -64,32 +65,39 @@ const useTransformToCosmos: UseTransformToCosmos<InstantiateData> = () =>
 const useDecodedCosmosMsg: UseDecodedCosmosMsg<InstantiateData> = (
   msg: Record<string, any>
 ) =>
-  useMemo(
-    () =>
-      'wasm' in msg && 'instantiate' in msg.wasm
-        ? {
-            match: true,
-            data: {
-              admin: msg.wasm.instantiate.admin ?? '',
-              codeId: msg.wasm.instantiate.code_id,
-              label: msg.wasm.instantiate.label,
-              message: JSON.stringify(msg.wasm.instantiate.msg, undefined, 2),
-              funds: (msg.wasm.instantiate.funds as Coin[]).map(
-                ({ denom, amount }) => ({
-                  denom,
-                  amount: Number(
-                    convertMicroDenomToDenomWithDecimals(
-                      amount,
-                      NATIVE_TOKEN.decimals
-                    )
-                  ),
-                })
+  objectMatchesStructure(msg, {
+    wasm: {
+      instantiate: {
+        code_id: {},
+        label: {},
+        msg: {},
+        funds: {},
+      },
+    },
+  })
+    ? {
+        match: true,
+        data: {
+          admin: msg.wasm.instantiate.admin ?? '',
+          codeId: msg.wasm.instantiate.code_id,
+          label: msg.wasm.instantiate.label,
+          message: JSON.stringify(msg.wasm.instantiate.msg, undefined, 2),
+          funds: (msg.wasm.instantiate.funds as Coin[]).map(
+            ({ denom, amount }) => ({
+              denom,
+              amount: Number(
+                convertMicroDenomToDenomWithDecimals(
+                  amount,
+                  NATIVE_TOKEN.decimals
+                )
               ),
-            },
-          }
-        : { match: false },
-    [msg]
-  )
+            })
+          ),
+        },
+      }
+    : {
+        match: false,
+      }
 
 const Component: ActionComponent = (props) => {
   // Get the selected tokens if not creating.

--- a/packages/stateful/actions/actions/ManageCw20.tsx
+++ b/packages/stateful/actions/actions/ManageCw20.tsx
@@ -133,46 +133,6 @@ const Component: ActionComponent = (props) => {
   )
 }
 
-const useDecodedCosmosMsg: UseDecodedCosmosMsg<ManageCw20Data> = (
-  msg: Record<string, any>
-) =>
-  useMemo(
-    () =>
-      objectMatchesStructure(msg, {
-        wasm: {
-          execute: {
-            contract_addr: {},
-            funds: {},
-            msg: {
-              update_cw20_list: {
-                to_add: {},
-                to_remove: {},
-              },
-            },
-          },
-        },
-      }) &&
-      // Ensure only one token is being added or removed, but not both, and not
-      // more than one token. Ideally this component lets you add or remove
-      // multiple tokens at once, but that's not supported yet.
-      ((msg.wasm.execute.msg.update_cw20_list.to_add.length === 1 &&
-        msg.wasm.execute.msg.update_cw20_list.to_remove.length === 0) ||
-        (msg.wasm.execute.msg.update_cw20_list.to_add.length === 0 &&
-          msg.wasm.execute.msg.update_cw20_list.to_remove.length === 1))
-        ? {
-            match: true,
-            data: {
-              adding: msg.wasm.execute.msg.update_cw20_list.to_add.length === 1,
-              address:
-                msg.wasm.execute.msg.update_cw20_list.to_add.length === 1
-                  ? msg.wasm.execute.msg.update_cw20_list.to_add[0]
-                  : msg.wasm.execute.msg.update_cw20_list.to_remove[0],
-            },
-          }
-        : { match: false },
-    [msg]
-  )
-
 export const makeManageCw20Action: ActionMaker<ManageCw20Data> = ({
   t,
   address,
@@ -202,6 +162,45 @@ export const makeManageCw20Action: ActionMaker<ManageCw20Data> = ({
         }),
       []
     )
+
+  const useDecodedCosmosMsg: UseDecodedCosmosMsg<ManageCw20Data> = (
+    msg: Record<string, any>
+  ) =>
+    objectMatchesStructure(msg, {
+      wasm: {
+        execute: {
+          contract_addr: {},
+          funds: {},
+          msg: {
+            update_cw20_list: {
+              to_add: {},
+              to_remove: {},
+            },
+          },
+        },
+      },
+    }) &&
+    msg.wasm.execute.contract_addr === address &&
+    // Ensure only one token is being added or removed, but not both, and not
+    // more than one token. Ideally this component lets you add or remove
+    // multiple tokens at once, but that's not supported yet.
+    ((msg.wasm.execute.msg.update_cw20_list.to_add.length === 1 &&
+      msg.wasm.execute.msg.update_cw20_list.to_remove.length === 0) ||
+      (msg.wasm.execute.msg.update_cw20_list.to_add.length === 0 &&
+        msg.wasm.execute.msg.update_cw20_list.to_remove.length === 1))
+      ? {
+          match: true,
+          data: {
+            adding: msg.wasm.execute.msg.update_cw20_list.to_add.length === 1,
+            address:
+              msg.wasm.execute.msg.update_cw20_list.to_add.length === 1
+                ? msg.wasm.execute.msg.update_cw20_list.to_add[0]
+                : msg.wasm.execute.msg.update_cw20_list.to_remove[0],
+          },
+        }
+      : {
+          match: false,
+        }
 
   return {
     key: CoreActionKey.ManageCw20,

--- a/packages/stateful/actions/actions/ManageCw721.tsx
+++ b/packages/stateful/actions/actions/ManageCw721.tsx
@@ -133,47 +133,6 @@ const Component: ActionComponent = (props) => {
   )
 }
 
-const useDecodedCosmosMsg: UseDecodedCosmosMsg<ManageCw721Data> = (
-  msg: Record<string, any>
-) =>
-  useMemo(
-    () =>
-      objectMatchesStructure(msg, {
-        wasm: {
-          execute: {
-            contract_addr: {},
-            funds: {},
-            msg: {
-              update_cw721_list: {
-                to_add: {},
-                to_remove: {},
-              },
-            },
-          },
-        },
-      }) &&
-      // Ensure only one collection is being added or removed, but not both, and
-      // not more than one collection. Ideally this component lets you add or
-      // remove multiple collections at once, but that's not supported yet.
-      ((msg.wasm.execute.msg.update_cw721_list.to_add.length === 1 &&
-        msg.wasm.execute.msg.update_cw721_list.to_remove.length === 0) ||
-        (msg.wasm.execute.msg.update_cw721_list.to_add.length === 0 &&
-          msg.wasm.execute.msg.update_cw721_list.to_remove.length === 1))
-        ? {
-            match: true,
-            data: {
-              adding:
-                msg.wasm.execute.msg.update_cw721_list.to_add.length === 1,
-              address:
-                msg.wasm.execute.msg.update_cw721_list.to_add.length === 1
-                  ? msg.wasm.execute.msg.update_cw721_list.to_add[0]
-                  : msg.wasm.execute.msg.update_cw721_list.to_remove[0],
-            },
-          }
-        : { match: false },
-    [msg]
-  )
-
 export const makeManageCw721Action: ActionMaker<ManageCw721Data> = ({
   t,
   address,
@@ -203,6 +162,45 @@ export const makeManageCw721Action: ActionMaker<ManageCw721Data> = ({
         }),
       []
     )
+
+  const useDecodedCosmosMsg: UseDecodedCosmosMsg<ManageCw721Data> = (
+    msg: Record<string, any>
+  ) =>
+    objectMatchesStructure(msg, {
+      wasm: {
+        execute: {
+          contract_addr: {},
+          funds: {},
+          msg: {
+            update_cw721_list: {
+              to_add: {},
+              to_remove: {},
+            },
+          },
+        },
+      },
+    }) &&
+    msg.wasm.execute.contract_addr === address &&
+    // Ensure only one collection is being added or removed, but not both, and
+    // not more than one collection. Ideally this component lets you add or
+    // remove multiple collections at once, but that's not supported yet.
+    ((msg.wasm.execute.msg.update_cw721_list.to_add.length === 1 &&
+      msg.wasm.execute.msg.update_cw721_list.to_remove.length === 0) ||
+      (msg.wasm.execute.msg.update_cw721_list.to_add.length === 0 &&
+        msg.wasm.execute.msg.update_cw721_list.to_remove.length === 1))
+      ? {
+          match: true,
+          data: {
+            adding: msg.wasm.execute.msg.update_cw721_list.to_add.length === 1,
+            address:
+              msg.wasm.execute.msg.update_cw721_list.to_add.length === 1
+                ? msg.wasm.execute.msg.update_cw721_list.to_add[0]
+                : msg.wasm.execute.msg.update_cw721_list.to_remove[0],
+          },
+        }
+      : {
+          match: false,
+        }
 
   return {
     key: CoreActionKey.ManageCw721,

--- a/packages/stateful/actions/actions/MigrateContract.tsx
+++ b/packages/stateful/actions/actions/MigrateContract.tsx
@@ -1,5 +1,5 @@
 import JSON5 from 'json5'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useRecoilValueLoadable } from 'recoil'
 
 import { contractAdminSelector } from '@dao-dao/state'
@@ -12,7 +12,7 @@ import {
   UseDefaults,
   UseTransformToCosmos,
 } from '@dao-dao/types/actions'
-import { makeWasmMessage } from '@dao-dao/utils'
+import { makeWasmMessage, objectMatchesStructure } from '@dao-dao/utils'
 
 import { MigrateContractComponent as StatelessMigrateContractComponent } from '../components/MigrateContract'
 
@@ -59,20 +59,27 @@ const useTransformToCosmos: UseTransformToCosmos<MigrateData> = () =>
 const useDecodedCosmosMsg: UseDecodedCosmosMsg<MigrateData> = (
   msg: Record<string, any>
 ) =>
-  useMemo(
-    () =>
-      'wasm' in msg && 'migrate' in msg.wasm
-        ? {
-            match: true,
-            data: {
-              contract: msg.wasm.migrate.contract_addr,
-              codeId: msg.wasm.migrate.new_code_id,
-              msg: JSON.stringify(msg.wasm.migrate.msg, undefined, 2),
-            },
-          }
-        : { match: false },
-    [msg]
-  )
+  objectMatchesStructure(msg, {
+    wasm: {
+      migrate: {
+        contract_addr: {},
+        new_code_id: {},
+        msg: {},
+      },
+    },
+  })
+    ? {
+        match: true,
+        data: {
+          contract: msg.wasm.migrate.contract_addr,
+          codeId: msg.wasm.migrate.new_code_id,
+          msg: JSON.stringify(msg.wasm.migrate.msg, undefined, 2),
+        },
+      }
+    : {
+        match: false,
+      }
+
 const Component: ActionComponent = (props) => {
   const [contract, setContract] = useState('')
 

--- a/packages/stateful/actions/actions/UpdateAdmin.tsx
+++ b/packages/stateful/actions/actions/UpdateAdmin.tsx
@@ -44,7 +44,10 @@ const useDecodedCosmosMsg: UseDecodedCosmosMsg<UpdateAdminData> = (
 ) =>
   objectMatchesStructure(msg, {
     wasm: {
-      update_admin: {},
+      update_admin: {
+        contract_addr: {},
+        admin: {},
+      },
     },
   })
     ? {

--- a/packages/stateful/actions/actions/UpdateAdmin.tsx
+++ b/packages/stateful/actions/actions/UpdateAdmin.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { constSelector, useRecoilValueLoadable } from 'recoil'
 
 import { contractAdminSelector } from '@dao-dao/state'
@@ -11,7 +11,7 @@ import {
   UseDefaults,
   UseTransformToCosmos,
 } from '@dao-dao/types/actions'
-import { isValidContractAddress } from '@dao-dao/utils'
+import { isValidContractAddress, objectMatchesStructure } from '@dao-dao/utils'
 
 import { UpdateAdminComponent as StatelessUpdateAdminComponent } from '../components/UpdateAdmin'
 import { useActionOptions } from '../react'
@@ -42,19 +42,19 @@ const useTransformToCosmos: UseTransformToCosmos<UpdateAdminData> = () =>
 const useDecodedCosmosMsg: UseDecodedCosmosMsg<UpdateAdminData> = (
   msg: Record<string, any>
 ) =>
-  useMemo(
-    () =>
-      'wasm' in msg && 'update_admin' in msg.wasm
-        ? {
-            match: true,
-            data: {
-              contract: msg.wasm.update_admin.contract_addr,
-              newAdmin: msg.wasm.update_admin.admin,
-            },
-          }
-        : { match: false },
-    [msg]
-  )
+  objectMatchesStructure(msg, {
+    wasm: {
+      update_admin: {},
+    },
+  })
+    ? {
+        match: true,
+        data: {
+          contract: msg.wasm.update_admin.contract_addr,
+          newAdmin: msg.wasm.update_admin.admin,
+        },
+      }
+    : { match: false }
 
 const Component: ActionComponent = (props) => {
   const { chainId, bech32Prefix } = useActionOptions()

--- a/packages/stateful/actions/actions/UpdateAdmin.tsx
+++ b/packages/stateful/actions/actions/UpdateAdmin.tsx
@@ -57,7 +57,9 @@ const useDecodedCosmosMsg: UseDecodedCosmosMsg<UpdateAdminData> = (
           newAdmin: msg.wasm.update_admin.admin,
         },
       }
-    : { match: false }
+    : {
+        match: false,
+      }
 
 const Component: ActionComponent = (props) => {
   const { chainId, bech32Prefix } = useActionOptions()

--- a/packages/stateful/actions/actions/token_swap/makePerformTokenSwapAction.tsx
+++ b/packages/stateful/actions/actions/token_swap/makePerformTokenSwapAction.tsx
@@ -28,6 +28,7 @@ import {
 import { SuspenseLoader } from '../../../components'
 import { ActionCard } from '../../components/ActionCard'
 import { PerformTokenSwapData } from '../../components/token_swap'
+import { useMsgExecutesContract } from '../../hooks'
 import { ChooseExistingTokenSwap } from './ChooseExistingTokenSwap'
 import { FundTokenSwap } from './FundTokenSwap'
 import { InstantiateTokenSwap } from './InstantiateTokenSwap'
@@ -190,18 +191,13 @@ const useTransformToCosmos: UseTransformToCosmos<PerformTokenSwapData> = () => {
 const useDecodedCosmosMsg: UseDecodedCosmosMsg<PerformTokenSwapData> = (
   msg: Record<string, any>
 ) => {
+  const isTokenSwapExecute = useMsgExecutesContract(msg, 'cw-token-swap')
+
   // Native
   if (
-    objectMatchesStructure(msg, {
-      wasm: {
-        execute: {
-          contract_addr: {},
-          funds: {},
-          msg: {
-            fund: {},
-          },
-        },
-      },
+    isTokenSwapExecute &&
+    objectMatchesStructure(msg.wasm.execute.msg, {
+      fund: {},
     }) &&
     Array.isArray(msg.wasm.execute.funds) &&
     msg.wasm.execute.funds.length === 1

--- a/packages/stateful/actions/actions/token_swap/makeWithdrawTokenSwapAction.tsx
+++ b/packages/stateful/actions/actions/token_swap/makeWithdrawTokenSwapAction.tsx
@@ -16,6 +16,7 @@ import { makeWasmMessage, objectMatchesStructure } from '@dao-dao/utils'
 import { SuspenseLoader } from '../../../components'
 import { ActionCard } from '../../components/ActionCard'
 import { WithdrawTokenSwapData } from '../../components/token_swap'
+import { useMsgExecutesContract } from '../../hooks'
 import { ChooseExistingTokenSwap } from './ChooseExistingTokenSwap'
 import { WithdrawTokenSwap } from './WithdrawTokenSwap'
 
@@ -103,17 +104,12 @@ export const makeWithdrawTokenSwapAction: ActionMaker<
   const useDecodedCosmosMsg: UseDecodedCosmosMsg<WithdrawTokenSwapData> = (
     msg: Record<string, any>
   ) => {
+    const isTokenSwapExecute = useMsgExecutesContract(msg, 'cw-token-swap')
+
     if (
-      objectMatchesStructure(msg, {
-        wasm: {
-          execute: {
-            contract_addr: {},
-            funds: {},
-            msg: {
-              withdraw: {},
-            },
-          },
-        },
+      isTokenSwapExecute &&
+      objectMatchesStructure(msg.wasm.execute.msg, {
+        withdraw: {},
       })
     ) {
       return {

--- a/packages/stateful/actions/hooks/index.ts
+++ b/packages/stateful/actions/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './useMsgExecutesContract'
 export * from './useTokenBalances'

--- a/packages/stateful/actions/hooks/useMsgExecutesContract.ts
+++ b/packages/stateful/actions/hooks/useMsgExecutesContract.ts
@@ -1,0 +1,44 @@
+import { constSelector } from 'recoil'
+
+import { isContractSelector } from '@dao-dao/state/recoil'
+import { useCachedLoadable } from '@dao-dao/stateless'
+import { objectMatchesStructure } from '@dao-dao/utils'
+
+// Returns if the message is a wasm message that executes a specific contract.
+// The names are checked against the data stored in contract_info, via the
+// indexer's `info` formula, falling back to a contract `info` query.
+export const useMsgExecutesContract = (
+  msg: Record<string, any>,
+  nameOrNames: string | string[],
+  chainId?: string
+): boolean => {
+  const isWasmExecuteMessage = objectMatchesStructure(msg, {
+    wasm: {
+      execute: {
+        contract_addr: {},
+        funds: {},
+        msg: {
+          fund: {},
+        },
+      },
+    },
+  })
+
+  const isContractLoadable = useCachedLoadable(
+    isWasmExecuteMessage
+      ? isContractSelector({
+          contractAddress: msg.wasm.execute.contract_addr,
+          chainId,
+          ...(typeof nameOrNames === 'string'
+            ? {
+                name: nameOrNames,
+              }
+            : {
+                names: nameOrNames,
+              }),
+        })
+      : constSelector(false)
+  )
+
+  return isContractLoadable.state === 'hasValue' && isContractLoadable.contents
+}

--- a/packages/stateful/actions/hooks/useMsgExecutesContract.ts
+++ b/packages/stateful/actions/hooks/useMsgExecutesContract.ts
@@ -17,9 +17,7 @@ export const useMsgExecutesContract = (
       execute: {
         contract_addr: {},
         funds: {},
-        msg: {
-          fund: {},
-        },
+        msg: {},
       },
     },
   })


### PR DESCRIPTION
Right now, the token swap withdraw action simply matches all messages that execute `withdraw` on a contract.

This PR checks if the contract being executed is a `cw-token-swap` contract as to not mismatch.

I also cleaned up some other action decoder matchers and made them more specific.