### PR TITLE
Add balances to membership tab and CSV download

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -1086,6 +1086,7 @@
     "votingEnd": "Voting end",
     "votingOpened": "Voting opened",
     "votingPower": "Voting power",
+    "votingWeight": "Voting weight",
     "wallet": "Wallet",
     "watchOut": "Watch out!",
     "when": "When",

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/components/MembersTab.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/components/MembersTab.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
 import { DaoVotingCw20StakedSelectors } from '@dao-dao/state/recoil'
 import { MembersTab as StatelessMembersTab } from '@dao-dao/stateless'
 import { StatefulDaoMemberCardProps } from '@dao-dao/types'
+import { convertMicroDenomToDenomWithDecimals } from '@dao-dao/utils'
 
 import {
   ButtonLink,
@@ -10,9 +12,12 @@ import {
   EntityDisplay,
 } from '../../../../components'
 import { useVotingModuleAdapterOptions } from '../../../react/context'
+import { useGovernanceTokenInfo } from '../hooks/useGovernanceTokenInfo'
 
 export const MembersTab = () => {
+  const { t } = useTranslation()
   const { votingModuleAddress } = useVotingModuleAdapterOptions()
+  const { token } = useGovernanceTokenInfo()
 
   const topStakers = useRecoilValue(
     DaoVotingCw20StakedSelectors.topStakersSelector({
@@ -21,9 +26,25 @@ export const MembersTab = () => {
   )
 
   const memberCards: StatefulDaoMemberCardProps[] = (topStakers ?? []).map(
-    ({ address, votingPowerPercent }) => ({
+    ({ address, balance, votingPowerPercent }) => ({
       address,
-      votingPowerPercent: { loading: false, data: votingPowerPercent },
+      balance: {
+        label: t('title.staked'),
+        unit: '$' + token.symbol,
+        value: {
+          loading: false,
+          data: convertMicroDenomToDenomWithDecimals(
+            balance,
+            token.decimals
+          ).toLocaleString(undefined, {
+            maximumFractionDigits: token.decimals,
+          }),
+        },
+      },
+      votingPowerPercent: {
+        loading: false,
+        data: votingPowerPercent,
+      },
     })
   )
 

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw4/components/MembersTab.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw4/components/MembersTab.tsx
@@ -52,10 +52,20 @@ export const MembersTab = () => {
   const memberCards: ComponentPropsWithoutRef<typeof DaoMemberCard>[] =
     members.map(({ addr, weight }) => ({
       address: addr,
+      balance: {
+        label: t('title.votingWeight'),
+        value: {
+          loading: false,
+          data: weight.toLocaleString(),
+        },
+      },
       votingPowerPercent:
         totalVotingWeight === undefined
           ? { loading: true }
-          : { loading: false, data: (weight / totalVotingWeight) * 100 },
+          : {
+              loading: false,
+              data: (weight / totalVotingWeight) * 100,
+            },
     }))
 
   return (

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw721Staked/components/MembersTab.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw721Staked/components/MembersTab.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
 import { DaoVotingCw721StakedSelectors } from '@dao-dao/state/recoil'
@@ -10,9 +11,12 @@ import {
   EntityDisplay,
 } from '../../../../components'
 import { useVotingModuleAdapterOptions } from '../../../react/context'
+import { useGovernanceCollectionInfo } from '../hooks'
 
 export const MembersTab = () => {
+  const { t } = useTranslation()
   const { votingModuleAddress } = useVotingModuleAdapterOptions()
+  const { collectionInfo } = useGovernanceCollectionInfo()
 
   const topStakers = useRecoilValue(
     DaoVotingCw721StakedSelectors.topStakersSelector({
@@ -21,9 +25,20 @@ export const MembersTab = () => {
   )
 
   const memberCards: StatefulDaoMemberCardProps[] = (topStakers ?? []).map(
-    ({ address, votingPowerPercent }) => ({
+    ({ address, count, votingPowerPercent }) => ({
       address,
-      votingPowerPercent: { loading: false, data: votingPowerPercent },
+      balance: {
+        label: t('title.staked'),
+        unit: '$' + collectionInfo.symbol,
+        value: {
+          loading: false,
+          data: count.toLocaleString(),
+        },
+      },
+      votingPowerPercent: {
+        loading: false,
+        data: votingPowerPercent,
+      },
     })
   )
 

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingNativeStaked/components/MembersTab.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingNativeStaked/components/MembersTab.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from 'react-i18next'
 import { useRecoilValue } from 'recoil'
 
 import { DaoVotingNativeStakedSelectors } from '@dao-dao/state/recoil'
 import { MembersTab as StatelessMembersTab } from '@dao-dao/stateless'
 import { StatefulDaoMemberCardProps } from '@dao-dao/types'
+import { convertMicroDenomToDenomWithDecimals } from '@dao-dao/utils'
 
 import {
   ButtonLink,
@@ -10,9 +12,12 @@ import {
   EntityDisplay,
 } from '../../../../components'
 import { useVotingModuleAdapterOptions } from '../../../react/context'
+import { useGovernanceTokenInfo } from '../hooks/useGovernanceTokenInfo'
 
 export const MembersTab = () => {
+  const { t } = useTranslation()
   const { votingModuleAddress } = useVotingModuleAdapterOptions()
+  const { token } = useGovernanceTokenInfo()
 
   const topStakers = useRecoilValue(
     DaoVotingNativeStakedSelectors.topStakersSelector({
@@ -21,9 +26,25 @@ export const MembersTab = () => {
   )
 
   const memberCards: StatefulDaoMemberCardProps[] = (topStakers ?? []).map(
-    ({ address, votingPowerPercent }) => ({
+    ({ address, balance, votingPowerPercent }) => ({
       address,
-      votingPowerPercent: { loading: false, data: votingPowerPercent },
+      balance: {
+        label: t('title.staked'),
+        unit: '$' + token.symbol,
+        value: {
+          loading: false,
+          data: convertMicroDenomToDenomWithDecimals(
+            balance,
+            token.decimals
+          ).toLocaleString(undefined, {
+            maximumFractionDigits: token.decimals,
+          }),
+        },
+      },
+      votingPowerPercent: {
+        loading: false,
+        data: votingPowerPercent,
+      },
     })
   )
 

--- a/packages/stateless/components/dao/DaoMemberCard.stories.tsx
+++ b/packages/stateless/components/dao/DaoMemberCard.stories.tsx
@@ -18,6 +18,19 @@ const Template: ComponentStory<typeof DaoMemberCard> = (args) => (
 
 export const makeProps = (): DaoMemberCardProps => ({
   address: 'juno1abczhsdyechxcjz90y',
+  // Random number between 0 and 100,000 with 6 decimals.
+  balance: {
+    label: 'Staked',
+    unit: 'DAO',
+    value: {
+      loading: false,
+      data: (
+        Math.floor(Math.random() * (100000 * 1e6) + 1e6) / 1e6
+      ).toLocaleString(undefined, {
+        maximumFractionDigits: 6,
+      }),
+    },
+  },
   // Random number between 0 and 31 with 2 decimals.
   votingPowerPercent: {
     loading: false,

--- a/packages/stateless/components/dao/DaoMemberCard.tsx
+++ b/packages/stateless/components/dao/DaoMemberCard.tsx
@@ -10,6 +10,7 @@ import { ProfileImage } from '../profile'
 
 export const DaoMemberCard = ({
   address,
+  balance,
   votingPowerPercent,
   profileData: { profile, loading: profileLoading },
 }: DaoMemberCardProps) => {
@@ -45,19 +46,37 @@ export const DaoMemberCard = ({
         </div>
       </div>
 
-      <div className="flex flex-row items-center justify-between gap-4 border-t border-border-interactive-disabled p-4">
+      <div className="flex flex-col gap-2 border-t border-border-interactive-disabled p-4">
         {/* Voting power */}
-        <p className="secondary-text">{t('title.votingPower')}</p>
-        <p
-          className={clsx(
-            'symbol-small-body-text font-mono',
-            votingPowerPercent.loading && 'animate-pulse'
-          )}
-        >
-          {votingPowerPercent.loading
-            ? '...'
-            : formatPercentOf100(votingPowerPercent.data)}
-        </p>
+        <div className="flex flex-row flex-wrap items-center justify-between gap-x-2 gap-y-1">
+          <p className="secondary-text">{t('title.votingPower')}</p>
+
+          <p
+            className={clsx(
+              'body-text font-mono',
+              votingPowerPercent.loading && 'animate-pulse'
+            )}
+          >
+            {votingPowerPercent.loading
+              ? '...'
+              : formatPercentOf100(votingPowerPercent.data)}
+          </p>
+        </div>
+
+        {/* Balance */}
+        <div className="flex flex-row flex-wrap items-center justify-between gap-x-2 gap-y-1">
+          <p className="secondary-text text-text-tertiary">{balance.label}</p>
+          <p
+            className={clsx(
+              'caption-text font-mono',
+              balance.value.loading && 'animate-pulse'
+            )}
+          >
+            {balance.value.loading
+              ? '...'
+              : balance.value.data + (balance.unit ? ' ' + balance.unit : '')}
+          </p>
+        </div>
       </div>
     </div>
   )

--- a/packages/stateless/components/dao/tabs/MembersTab.tsx
+++ b/packages/stateless/components/dao/tabs/MembersTab.tsx
@@ -350,10 +350,18 @@ export const MembersTab = ({
       <CSVLink
         className="hidden"
         data={[
-          ['Member', 'Voting Power'],
-          ...members.map(({ address, votingPowerPercent }) => [
+          [
+            'Member',
+            members.length
+              ? members[0].balance.label +
+                (members[0].balance.unit ? ` (${members[0].balance.unit})` : '')
+              : 'Balance',
+            'Voting power',
+          ],
+          ...members.map(({ address, balance, votingPowerPercent }) => [
             address,
-            votingPowerPercent.loading === false && votingPowerPercent.data,
+            balance.value.loading ? '...' : balance.value.data,
+            votingPowerPercent.loading ? '...' : votingPowerPercent.data,
           ]),
         ]}
         filename="members.csv"

--- a/packages/types/stateless/DaoMemberCard.ts
+++ b/packages/types/stateless/DaoMemberCard.ts
@@ -3,6 +3,11 @@ import { LoadingData } from './common'
 
 export type DaoMemberCardProps = {
   address: string
+  balance: {
+    label: string
+    unit?: string
+    value: LoadingData<string>
+  }
   votingPowerPercent: LoadingData<number>
   profileData: WalletProfileData
 }


### PR DESCRIPTION
Resolves #1142 

This adds staked balances and voting weights to the members tab and CSV download.

<img width="910" alt="Screenshot 2023-03-25 at 2 06 32 PM" src="https://user-images.githubusercontent.com/6721426/227741933-19ed7245-993e-4991-a317-f05b2e8fbcc2.png">

<img width="1140" alt="Screenshot 2023-03-25 at 2 06 13 PM" src="https://user-images.githubusercontent.com/6721426/227741918-bed85076-e094-4ff8-9846-54d4810093d9.png">
