### PR TITLE
Support legacy code ID in v2 upgrade action

### DIFF
--- a/packages/state/recoil/selectors/chain.ts
+++ b/packages/state/recoil/selectors/chain.ts
@@ -1,4 +1,4 @@
-import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate'
+import { Contract, CosmWasmClient } from '@cosmjs/cosmwasm-stargate'
 import { fromBase64, toHex } from '@cosmjs/encoding'
 import {
   Coin,
@@ -659,4 +659,17 @@ export const validatorSlashesSelector = selectorFamily<
           formula: 'staking/slashes',
         })
       )) ?? [],
+})
+
+export const contractSelector = selectorFamily<
+  Contract,
+  WithChainId<{ contractAddress: string }>
+>({
+  key: 'contract',
+  get:
+    ({ contractAddress, chainId }) =>
+    async ({ get }) => {
+      const client = get(cosmWasmClientForChainSelector(chainId))
+      return await client.getContract(contractAddress)
+    },
 })

--- a/packages/stateful/actions/actions/UpgradeV1ToV2.tsx
+++ b/packages/stateful/actions/actions/UpgradeV1ToV2.tsx
@@ -114,6 +114,8 @@ export const makeUpgradeV1ToV2: ActionMaker<UpgradeV1ToV2Data> = ({
           })
         : constSelector(undefined)
     )
+    // Allow only legacy (41) or v1 (430) code ID.
+    const stakingContractCodeId = stakingContract?.codeId === 41 ? 41 : 430
 
     return useCallback(
       ({ subDaos }) => {
@@ -185,7 +187,7 @@ export const makeUpgradeV1ToV2: ActionMaker<UpgradeV1ToV2Data> = ({
                       v1_code_ids: {
                         proposal_single: 427,
                         cw4_voting: 429,
-                        cw20_stake: stakingContract?.codeId ?? 430,
+                        cw20_stake: stakingContractCodeId,
                         cw20_staked_balances_voting: 431,
                       },
                       v2_code_ids: {
@@ -203,7 +205,7 @@ export const makeUpgradeV1ToV2: ActionMaker<UpgradeV1ToV2Data> = ({
           },
         })
       },
-      [proposalModuleDepositInfosLoadable, stakingContract?.codeId]
+      [proposalModuleDepositInfosLoadable, stakingContractCodeId]
     )
   }
 


### PR DESCRIPTION
This PR checks the code ID of the staking contract used by the DAO, if one exists, and uses that code ID in the migration. This enables support for both legacy and v1 staking contract upgrades.