### PR TITLE
Fix DAO Admin Exec not properly loading DAO context

### DIFF
--- a/packages/stateful/recoil/selectors/dao/misc.ts
+++ b/packages/stateful/recoil/selectors/dao/misc.ts
@@ -208,7 +208,7 @@ export const daoInfoSelector: (param: {
 
       const _items = get(
         DaoCoreV2Selectors.listAllItemsSelector({
-          contractAddress: dumpState.voting_module,
+          contractAddress: coreAddress,
           chainId,
         })
       )


### PR DESCRIPTION
This PR fixes the DAO info selector not properly loading items from the DAO. These items are currently only loaded to detect whether or not to show certain widget actions (to check if they're already enabled), and this specific selector is only used by the DAO Admin Exec action, so it's not a big deal, but it is a bug.