### PR TITLE
Fix action amount docs.

### DIFF
--- a/packages/stateful/actions/core/smart_contracting/Execute/README.md
+++ b/packages/stateful/actions/core/smart_contracting/Execute/README.md
@@ -30,8 +30,3 @@ guide](https://github.com/DA0-DA0/dao-dao-ui/wiki/Bulk-importing-actions).
 
 If `cw20` is true, then `funds` can only contain 1 entry, and `denom` should be
 the address of a CW20 token.
-
-`amount` and `denom` are in the base unit with no decimals. For example, if you
-want to spend 1 $JUNO, since JUNO has 6 decimals, then `amount` should be
-`1000000` and `denom` should be `ujuno`. If this is confusing, please ask for
-help!

--- a/packages/stateful/actions/core/smart_contracting/Instantiate/README.md
+++ b/packages/stateful/actions/core/smart_contracting/Instantiate/README.md
@@ -30,8 +30,3 @@ guide](https://github.com/DA0-DA0/dao-dao-ui/wiki/Bulk-importing-actions).
   ]
 }
 ```
-
-`amount` and `denom` are in the base unit with no decimals. For example, if you
-want to spend 1 $JUNO, since JUNO has 6 decimals, then `amount` should be
-`1000000` and `denom` should be `ujuno`. If this is confusing, please ask for
-help!

--- a/packages/stateful/actions/core/treasury/ManageStaking/README.md
+++ b/packages/stateful/actions/core/treasury/ManageStaking/README.md
@@ -30,9 +30,5 @@ guide](https://github.com/DA0-DA0/dao-dao-ui/wiki/Bulk-importing-actions).
 - `redelegate`
 - `withdraw_delegator_reward`
 
-`amount` is in the base unit with no decimals. For example, if you want to stake
-1 $JUNO, since JUNO has 6 decimals, then `amount` should be `1000000`. If this
-is confusing, please ask for help!
-
 `toValidator` is only required when `stakeType` is `redelegate`. Otherwise, it
 is ignored and can be omitted.

--- a/packages/stateful/actions/core/treasury/Spend/README.md
+++ b/packages/stateful/actions/core/treasury/Spend/README.md
@@ -20,8 +20,3 @@ guide](https://github.com/DA0-DA0/dao-dao-ui/wiki/Bulk-importing-actions).
   "denom": "<DENOM>"
 }
 ```
-
-`amount` and `denom` are in the base unit with no decimals. For example, if you
-want to spend 1 $JUNO, since JUNO has 6 decimals, then `amount` should be
-`1000000` and `denom` should be `ujuno`. If this is confusing, please ask for
-help!

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/actions/Mint/README.md
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw20Staked/actions/Mint/README.md
@@ -19,8 +19,3 @@ guide](https://github.com/DA0-DA0/dao-dao-ui/wiki/Bulk-importing-actions).
   "amount": "<AMOUNT>"
 }
 ```
-
-`amount` is in the base unit with no decimals. For example, if you want to mint
-1 governance token, and your governance token has 6 decimals (which is the
-default), then `amount` should be `1000000`. If this is confusing, please ask
-for help!

--- a/packages/stateful/widgets/widgets/VestingPayments/actions/ManageVesting/README.md
+++ b/packages/stateful/widgets/widgets/VestingPayments/actions/ManageVesting/README.md
@@ -45,11 +45,6 @@ guide](https://github.com/DA0-DA0/dao-dao-ui/wiki/Bulk-importing-actions).
 `denomOrAddress` should be either a native/IBC token denomination (e.g.
 `ujuno`), or a CW20 token contract address.
 
-`amount` and `denomOrAddress` are in the base unit with no decimals. For
-example, if you want to spend 1 $JUNO, since JUNO has 6 decimals, then `amount`
-should be `1000000` and `denomOrAddress` should be `ujuno`. If this is
-confusing, please ask for help!
-
 Only the corresponding field is required for each mode. For example, if you want
 to begin a vesting payment, then only `begin` is required, and `cancel` and
 `registerSlash` can be omitted.


### PR DESCRIPTION
This removes inaccurate amount/denom explanations from action docs. I previously added clarifications that `amount` was in the `denom` base unit with no decimals, but every action actually converts the data, so this is not true.