### PR TITLE
Preserve action order within groups

### DIFF
--- a/packages/stateful/actions/core/dao_governance/DaoAdminExec/Component.tsx
+++ b/packages/stateful/actions/core/dao_governance/DaoAdminExec/Component.tsx
@@ -2,6 +2,7 @@ import { ComponentType, useMemo } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import useDeepCompareEffect from 'use-deep-compare-effect'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   ActionCategorySelector,
@@ -16,7 +17,6 @@ import {
   CategorizedAction,
   CosmosMsgFor_Empty,
   LoadingData,
-  PartialCategorizedActionKeyAndData,
   StatefulEntityDisplayProps,
   SuspenseLoaderProps,
 } from '@dao-dao/types'
@@ -24,6 +24,7 @@ import {
   ActionComponent,
   CategorizedActionAndData,
   LoadedActions,
+  PartialCategorizedActionKeyAndData,
 } from '@dao-dao/types/actions'
 import {
   CHAIN_BECH32_PREFIX,
@@ -171,6 +172,10 @@ export const DaoAdminExecActionEditor: ActionComponent<DaoAdminExecOptions> = ({
             categories={categories}
             onSelectCategory={({ key }) => {
               append({
+                // See `CategorizedActionKeyAndData` comment in
+                // `packages/types/actions.ts` for an explanation of why we need
+                // to append with a unique ID.
+                _id: uuidv4(),
                 categoryKey: key,
               })
             }}

--- a/packages/stateful/components/WalletNftCard.tsx
+++ b/packages/stateful/components/WalletNftCard.tsx
@@ -102,35 +102,31 @@ export const WalletNftCard = (props: ComponentProps<typeof NftCard>) => {
                 Icon: SendRounded,
                 label: t('button.transfer'),
                 closeOnClick: true,
-                href: getMeTxPrefillPath({
-                  actions: [
-                    {
-                      actionKey: ActionKey.TransferNft,
-                      data: {
-                        ...transferActionDefaults,
-                        collection: props.collection.address,
-                        tokenId: props.tokenId,
-                        recipient: '',
-                      },
+                href: getMeTxPrefillPath([
+                  {
+                    actionKey: ActionKey.TransferNft,
+                    data: {
+                      ...transferActionDefaults,
+                      collection: props.collection.address,
+                      tokenId: props.tokenId,
+                      recipient: '',
                     },
-                  ],
-                }),
+                  },
+                ]),
               },
               {
                 Icon: LocalFireDepartment,
                 label: t('button.burn'),
                 closeOnClick: true,
-                href: getMeTxPrefillPath({
-                  actions: [
-                    {
-                      actionKey: ActionKey.BurnNft,
-                      data: {
-                        collection: props.collection.address,
-                        tokenId: props.tokenId,
-                      },
+                href: getMeTxPrefillPath([
+                  {
+                    actionKey: ActionKey.BurnNft,
+                    data: {
+                      collection: props.collection.address,
+                      tokenId: props.tokenId,
                     },
-                  ],
-                }),
+                  },
+                ]),
               },
             ],
           },

--- a/packages/stateful/components/WalletTokenCard.tsx
+++ b/packages/stateful/components/WalletTokenCard.tsx
@@ -207,18 +207,16 @@ export const WalletTokenCard = (props: TokenCardInfo) => {
               Icon: PaymentRounded,
               label: t('button.spend'),
               closeOnClick: true,
-              href: getMeTxPrefillPath({
-                actions: [
-                  {
-                    actionKey: ActionKey.Spend,
-                    data: {
-                      to: '',
-                      amount: 0,
-                      denom: props.token.denomOrAddress,
-                    },
+              href: getMeTxPrefillPath([
+                {
+                  actionKey: ActionKey.Spend,
+                  data: {
+                    to: '',
+                    amount: 0,
+                    denom: props.token.denomOrAddress,
                   },
-                ],
-              }),
+                },
+              ]),
             },
             ...(isUsdc && MAINNET
               ? [

--- a/packages/stateful/hooks/useDaoProposalSinglePrefill.ts
+++ b/packages/stateful/hooks/useDaoProposalSinglePrefill.ts
@@ -1,6 +1,6 @@
 import { useDaoInfoContext } from '@dao-dao/stateless'
 import {
-  PartialCategorizedActionKeyAndData,
+  PartialCategorizedActionKeyAndDataNoId,
   ProposalPrefill,
 } from '@dao-dao/types'
 import { DaoProposalSingleAdapterId } from '@dao-dao/utils'
@@ -9,7 +9,7 @@ import { matchAdapter as matchProposalModuleAdapter } from '../proposal-module-a
 import { NewProposalForm } from '../proposal-module-adapter/adapters/DaoProposalSingle/types'
 
 export interface UseEncodedProposalPrefillUrlOptions {
-  actions: PartialCategorizedActionKeyAndData[]
+  actions: PartialCategorizedActionKeyAndDataNoId[]
   title?: string
   description?: string
   proposalModuleId?: string
@@ -36,7 +36,10 @@ export const useDaoProposalSinglePrefill = ({
     data: {
       title,
       description,
-      actionData: actions,
+      actionData: actions.map((action, index) => ({
+        _id: index.toString(),
+        ...action,
+      })),
     },
   }
 

--- a/packages/stateful/package.json
+++ b/packages/stateful/package.json
@@ -43,7 +43,8 @@
     "react-timeago": "^7.1.0",
     "recoil": "^0.7.2",
     "remove-markdown": "^0.5.0",
-    "use-deep-compare-effect": "^1.8.1"
+    "use-deep-compare-effect": "^1.8.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@cosmjs/amino": "^0.30.1",
@@ -57,6 +58,7 @@
     "@types/lodash.uniq": "^4.5.7",
     "@types/papaparse": "^5.3.7",
     "@types/remove-markdown": "^0.3.1",
+    "@types/uuid": "^9.0.1",
     "eslint": "^8.23.1",
     "next": "12.2.6",
     "next-i18next": "^11.0.0",

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/components/MultipleChoiceOptionEditor.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/components/MultipleChoiceOptionEditor.tsx
@@ -12,6 +12,7 @@ import {
   useFormContext,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   ActionCategorySelector,
@@ -180,6 +181,10 @@ export const MultipleChoiceOptionEditor = <
             disableKeybind
             onSelectCategory={({ key }) => {
               append({
+                // See `CategorizedActionKeyAndData` comment in
+                // `packages/types/actions.ts` for an explanation of why we need
+                // to append with a unique ID.
+                _id: uuidv4(),
                 categoryKey: key,
               })
             }}

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/components/ProposalInnerContentDisplay.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/components/ProposalInnerContentDisplay.tsx
@@ -124,7 +124,11 @@ export const InnerProposalInnerContentDisplay = ({
           title: choice.title,
           description: choice.description,
           actionData: actionData.map(
-            ({ category, action, data }): CategorizedActionKeyAndData => ({
+            (
+              { category, action, data },
+              index
+            ): CategorizedActionKeyAndData => ({
+              _id: index.toString(),
               categoryKey: category.key,
               actionKey: action.key,
               data,

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/components/NewProposal/NewProposal.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/components/NewProposal/NewProposal.tsx
@@ -16,6 +16,7 @@ import {
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import TimeAgo from 'react-timeago'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   ActionCategorySelector,
@@ -231,6 +232,10 @@ export const NewProposal = ({
           categories={categories}
           onSelectCategory={({ key }) => {
             append({
+              // See `CategorizedActionKeyAndData` comment in
+              // `packages/types/actions.ts` for an explanation of why we need
+              // to append with a unique ID.
+              _id: uuidv4(),
               categoryKey: key,
             })
           }}

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/components/ProposalInnerContentDisplay.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/components/ProposalInnerContentDisplay.tsx
@@ -84,7 +84,8 @@ const InnerProposalInnerContentDisplay = ({
   )
 
   const actionKeyAndData = actionData.map(
-    ({ category, action, data }): CategorizedActionKeyAndData => ({
+    ({ category, action, data }, index): CategorizedActionKeyAndData => ({
+      _id: index.toString(),
       categoryKey: category.key,
       actionKey: action.key,
       data,

--- a/packages/stateless/components/actions/ActionsEditor.tsx
+++ b/packages/stateless/components/actions/ActionsEditor.tsx
@@ -1,9 +1,10 @@
 import { Add, Remove } from '@mui/icons-material'
 import clsx from 'clsx'
 import cloneDeep from 'lodash.clonedeep'
-import { ComponentType, useState } from 'react'
+import { ComponentType, useCallback, useState } from 'react'
 import { FieldErrors, useFieldArray, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { v4 as uuidv4 } from 'uuid'
 
 import { SuspenseLoaderProps } from '@dao-dao/types'
 import {
@@ -41,6 +42,7 @@ type GroupedActionData = Omit<
   category: ActionCategoryWithLabel
   actionDefaults: any
   all: {
+    _id: string
     // Index of data in `actionData` list.
     index: number
     data: any
@@ -59,15 +61,18 @@ export const ActionsEditor = ({
   const { watch } = useFormContext<{
     actionData: PartialCategorizedActionKeyAndData[]
   }>()
+
   // All categorized actions from the form.
   const actionData = watch(actionDataFieldName as 'actionData') || []
 
   // Group action data by adjacent action, preserving order. Adjacent data of
   // the same action are combined into a group so they can be rendered together.
   const groupedActionData = actionData.reduce(
-    (acc, field, index): GroupedActionData[] => {
-      const { categoryKey, actionKey, data } = field
-
+    (
+      acc,
+      { _id, categoryKey, actionKey, data },
+      index
+    ): GroupedActionData[] => {
       const loadedAction = actionKey && loadedActions[actionKey]
 
       // Get category from loaded action if key is undefined. It should only be
@@ -94,7 +99,13 @@ export const ActionsEditor = ({
             category,
             action: undefined,
             actionDefaults: {},
-            all: [{ index, data }],
+            all: [
+              {
+                _id,
+                index,
+                data,
+              },
+            ],
           },
         ]
       }
@@ -104,7 +115,11 @@ export const ActionsEditor = ({
       const lastGroup = acc[acc.length - 1]
       if (lastGroup?.action && lastGroup.action.key === actionKey) {
         // Add data to group.
-        lastGroup.all.push({ index, data })
+        lastGroup.all.push({
+          _id,
+          index,
+          data,
+        })
       } else {
         // or create new group if previously adjacent group is for a different
         // action.
@@ -112,7 +127,13 @@ export const ActionsEditor = ({
           category,
           action: loadedAction.action,
           actionDefaults: loadedAction.defaults,
-          all: [{ index, data }],
+          all: [
+            {
+              _id,
+              index,
+              data,
+            },
+          ],
         })
       }
 
@@ -124,7 +145,14 @@ export const ActionsEditor = ({
   return groupedActionData.length > 0 ? (
     <div className={clsx('flex flex-col gap-2', className)}>
       {groupedActionData.map((group, index) => (
-        <div key={index} className="group relative" id={`A${index + 1}`}>
+        <div
+          key={
+            // Re-render when the group at a given position changes.
+            `${index}-${group.category.key}`
+          }
+          className="group relative"
+          id={`A${index + 1}`}
+        >
           <ActionEditor
             {...group}
             SuspenseLoader={SuspenseLoader}
@@ -143,11 +171,11 @@ export type ActionEditorProps = GroupedActionData & {
   categories: ActionCategoryWithLabel[]
   loadedActions: LoadedActions
   actionDataFieldName: string
-
   // The errors for all actions, pointed to by `actionsFieldName` above.
   actionDataErrors:
     | FieldErrors<PartialCategorizedActionKeyAndData[]>
     | undefined
+
   SuspenseLoader: ComponentType<SuspenseLoaderProps>
 }
 
@@ -176,6 +204,17 @@ export const ActionEditor = ({
     name: actionDataFieldName,
     control,
   })
+  const addAction = useCallback(
+    (data: Omit<PartialCategorizedActionKeyAndData, '_id'>) =>
+      append({
+        // See `CategorizedActionKeyAndData` comment in
+        // `packages/types/actions.ts` for an explanation of why we need to
+        // append with a unique ID.
+        _id: uuidv4(),
+        ...data,
+      }),
+    [append]
+  )
 
   // All categorized actions from the form.
   const actionData = watch(actionDataFieldName as 'actionData') || []
@@ -217,7 +256,7 @@ export const ActionEditor = ({
 
             // If holding shift, add as a new action.
             if (event.shiftKey) {
-              append({
+              addAction({
                 categoryKey: category.key,
                 actionKey: key,
                 // Clone to prevent the form from mutating the original object.
@@ -291,7 +330,7 @@ export const ActionEditor = ({
       onCategoryClick={goBackToCategoryPicker}
       onRemove={onRemove}
     >
-      {all.map(({ index, data }) => {
+      {all.map(({ _id, index, data }) => {
         const removeAction = () => {
           clearErrors(`${actionDataFieldName}.${index}`)
           remove(index)
@@ -300,15 +339,18 @@ export const ActionEditor = ({
         return (
           <div
             key={
-              // Re-render when the action at a given position changes.
-              `${index}-${action.key}`
+              // If _id empty, likely due to an old saved form state, use index
+              // and action as re-render key. Using a unique `key` ensures that
+              // the action does not re-render when other parts of the form
+              // change.
+              _id || `${index}-${action.key}`
             }
             className="flex animate-fade-in flex-row items-start gap-4"
           >
             <div className="flex min-w-0 grow flex-col gap-4">
               <SuspenseLoader fallback={<Loader size={36} />}>
                 <action.Component
-                  addAction={append}
+                  addAction={addAction}
                   allActionsWithData={actionData}
                   data={data}
                   errors={actionDataErrors?.[index]?.data || {}}
@@ -359,6 +401,10 @@ export const ActionEditor = ({
               // Insert another entry for the same action with the default
               // values after the last one in this group.
               insert(all[all.length - 1].index + 1, {
+                // See `CategorizedActionKeyAndData` comment in
+                // `packages/types/actions.ts` for an explanation of why we need
+                // to insert with a unique ID.
+                _id: uuidv4(),
                 categoryKey: category.key,
                 actionKey: action.key,
                 data: cloneDeep(actionDefaults),

--- a/packages/stateless/components/actions/ActionsRenderer.tsx
+++ b/packages/stateless/components/actions/ActionsRenderer.tsx
@@ -33,11 +33,11 @@ export const ActionsRenderer = ({
   const actionKeysWithData = useMemo(
     () =>
       actionData.map(
-        ({
-          category: { key: categoryKey },
-          action: { key: actionKey },
-          data,
-        }): CategorizedActionKeyAndData => ({
+        (
+          { category: { key: categoryKey }, action: { key: actionKey }, data },
+          index
+        ): CategorizedActionKeyAndData => ({
+          _id: index.toString(),
           categoryKey,
           actionKey,
           data,

--- a/packages/stateless/components/actions/ActionsRenderer.tsx
+++ b/packages/stateless/components/actions/ActionsRenderer.tsx
@@ -7,7 +7,6 @@ import { SuspenseLoaderProps } from '@dao-dao/types'
 import {
   Action,
   ActionCategoryWithLabel,
-  ActionKey,
   CategorizedActionAndData,
   CategorizedActionKeyAndData,
 } from '@dao-dao/types/actions'
@@ -48,32 +47,36 @@ export const ActionsRenderer = ({
     useDeepCompareMemoize([actionData])
   )
 
-  // Group action data by action.
+  // Group action data by adjacent action, preserving order.
   const groupedActionData = useMemo(
     () =>
-      Object.entries(
-        actionData.reduce(
-          (acc, { category, action, data }, index) => ({
-            ...acc,
-            [action.key]: {
-              category,
-              action,
-              all: [
-                ...(acc[action.key]?.all || []),
-                {
-                  data,
-                  // Index in the original array.
-                  index,
-                },
-              ],
-            },
-          }),
-          {} as Record<
-            ActionKey,
-            Omit<ActionRendererProps, 'allActionsWithData'>
-          >
-        )
-      ),
+      actionData.reduce((acc, { category, action, data }, index) => {
+        // If most recent action is the same as the current action, add the
+        // current action's data to the most recent action's data.
+        const lastAction = acc[acc.length - 1]
+        if (lastAction && lastAction.action.key === action.key) {
+          lastAction.all.push({
+            data,
+            // Index in the original array.
+            index,
+          })
+        } else {
+          // Otherwise, add a new action to the list.
+          acc.push({
+            category,
+            action,
+            all: [
+              {
+                data,
+                // Index in the original array.
+                index,
+              },
+            ],
+          })
+        }
+
+        return acc
+      }, [] as Omit<ActionRendererProps, 'SuspenseLoader' | 'allActionsWithData'>[]),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useDeepCompareMemoize([actionData])
   )
@@ -88,7 +91,7 @@ export const ActionsRenderer = ({
 
   return (
     <div className="flex flex-col gap-2">
-      {groupedActionData.map(([actionKey, props], index) => (
+      {groupedActionData.map((props, index) => (
         <div key={index} className="group relative" id={`A${index + 1}`}>
           <ActionRenderer
             key={
@@ -101,7 +104,7 @@ export const ActionsRenderer = ({
               // the action changes. This is necessary because the component
               // expects to exist inside a FormProvider, and a FormProvider
               // depends on a `useForm` hook return value.
-              `${index}-${actionKey}`
+              `${index}-${props.action.key}`
             }
             {...props}
             SuspenseLoader={SuspenseLoader}

--- a/packages/stateless/package.json
+++ b/packages/stateless/package.json
@@ -33,7 +33,8 @@
     "react-player": "^2.12.0",
     "react-timeago": "^7.1.0",
     "remark-gfm": "^3.0.1",
-    "use-deep-compare-effect": "^1.8.1"
+    "use-deep-compare-effect": "^1.8.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@dao-dao/config": "2.2.0",
@@ -44,6 +45,7 @@
     "@types/react-csv": "^1.1.3",
     "@types/react-dom": "^17.0.11",
     "@types/react-timeago": "^4.1.3",
+    "@types/uuid": "^9.0.1",
     "eslint": "^8.23.1",
     "eslint-plugin-storybook": "^0.6.4",
     "i18next": "^21.8.10",

--- a/packages/stateless/pages/MeTransactionBuilder.stories.tsx
+++ b/packages/stateless/pages/MeTransactionBuilder.stories.tsx
@@ -59,6 +59,7 @@ Default.args = {
           'Send $10 USDC to my DAO. This is a very long description. I wish it were shorter.',
         actions: [
           {
+            _id: 'spend1',
             actionKey: ActionKey.Spend,
             data: {},
           },

--- a/packages/stateless/pages/MeTransactionBuilder.tsx
+++ b/packages/stateless/pages/MeTransactionBuilder.tsx
@@ -16,6 +16,7 @@ import {
   useForm,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   MeTransactionBuilderProps,
@@ -177,6 +178,10 @@ export const MeTransactionBuilder = ({
               categories={categories}
               onSelectCategory={({ key }) => {
                 append({
+                  // See `CategorizedActionKeyAndData` comment in
+                  // `packages/types/actions.ts` for an explanation of why we
+                  // need to append with a unique ID.
+                  _id: uuidv4(),
                   categoryKey: key,
                 })
               }}

--- a/packages/types/actions.ts
+++ b/packages/types/actions.ts
@@ -67,14 +67,24 @@ export type CategorizedActionAndData = {
 
 export type PartialCategorizedActionAndData = Partial<CategorizedActionAndData>
 
-export interface CategorizedActionKeyAndData {
+export type CategorizedActionKeyAndData = {
+  // Add an ID field to prevent unnecessary re-renders when things move around.
+  // This should be handled by react-hook-form's `useFieldArray`, but it only
+  // works internally for that specific hook call, and we need to use it in many
+  // different components.
+  _id: string
   categoryKey: ActionCategoryKey
   actionKey: ActionKey
   data: any
 }
 
+export type PartialCategorizedActionKeyAndDataNoId = Partial<
+  Omit<CategorizedActionKeyAndData, '_id'>
+>
+
 export type PartialCategorizedActionKeyAndData =
-  Partial<CategorizedActionKeyAndData>
+  PartialCategorizedActionKeyAndDataNoId &
+    Pick<CategorizedActionKeyAndData, '_id'>
 
 export type CategorizedAction = {
   category: ActionCategoryWithLabel
@@ -92,7 +102,9 @@ export type ActionComponentProps<O = undefined, D = any> = {
       isCreating: true
       errors: FieldErrors
       // Adds a new action to the form.
-      addAction: (action: PartialCategorizedActionKeyAndData) => void
+      addAction: (
+        action: Omit<PartialCategorizedActionKeyAndData, '_id'>
+      ) => void
       // Removes this action from the form.
       remove: () => void
     }

--- a/packages/utils/url.ts
+++ b/packages/utils/url.ts
@@ -1,6 +1,9 @@
 import queryString from 'query-string'
 
-import { DaoPageMode, MeTransactionForm } from '@dao-dao/types'
+import {
+  DaoPageMode,
+  PartialCategorizedActionKeyAndDataNoId,
+} from '@dao-dao/types'
 
 // Create a path to a DAO page based on the app's page mode.
 export const getDaoPath = (
@@ -33,9 +36,18 @@ export const getDaoProposalPath = (
 
 // Create a path for the Me page transaction builder with a pre-filled
 // transaction form.
-export const getMeTxPrefillPath = (data: MeTransactionForm) => {
+export const getMeTxPrefillPath = (
+  actions: PartialCategorizedActionKeyAndDataNoId[]
+) => {
   const base = '/me/tx'
-  const query = `?${queryString.stringify({ prefill: JSON.stringify(data) })}`
+  const query = `?${queryString.stringify({
+    prefill: JSON.stringify({
+      actions: actions.map((action, index) => ({
+        _id: index.toString(),
+        ...action,
+      })),
+    }),
+  })}`
 
   return base + query
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6540,6 +6540,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/uuid@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.1.tgz#98586dc36aee8dacc98cc396dbca8d0429647aa6"
+  integrity sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==
+
 "@types/webpack-env@^1.16.0":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.17.0.tgz#f99ce359f1bfd87da90cc4a57cab0a18f34a48d0"


### PR DESCRIPTION
PUPMOS pointed out that the action groups disrupt the order of actions, but the order actions are executed in *is very important*.

This PR fixes that by only grouping adjacent actions of the same type (instead of pulling actions into an earlier group), preserving action order, while still saving space by grouping actions.

## On creation
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/6721426/230338927-51ecd34c-7400-4300-8f2c-82d95f37150b.png">

## On viewing
<img width="562" alt="Screenshot 2023-04-06 at 2 45 09 AM" src="https://user-images.githubusercontent.com/6721426/230339746-1b723244-35b8-4004-bdf6-427da21238d3.png">
