### PR TITLE
Paginate actions during creation

### DIFF
--- a/packages/stateless/components/actions/ActionsEditor.tsx
+++ b/packages/stateless/components/actions/ActionsEditor.tsx
@@ -1,7 +1,7 @@
 import { Add, Remove } from '@mui/icons-material'
 import clsx from 'clsx'
 import cloneDeep from 'lodash.clonedeep'
-import { ComponentType, useCallback, useState } from 'react'
+import { ComponentType, useCallback, useEffect, useState } from 'react'
 import { FieldErrors, useFieldArray, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { v4 as uuidv4 } from 'uuid'
@@ -17,11 +17,13 @@ import {
 
 import { IconButton } from '../icon_buttons'
 import { Loader } from '../logo/Loader'
+import { PAGINATION_MIN_PAGE, Pagination } from '../Pagination'
 import { FilterableItemPopup } from '../popup/FilterableItemPopup'
 import { Tooltip } from '../tooltip'
 import { ActionCard } from './ActionCard'
 import { ActionCategoryActionPickerCard } from './ActionCategoryActionPickerCard'
 import { ACTION_CATEGORY_SELECTOR_FILTERABLE_KEYS } from './ActionCategorySelector'
+import { ACTIONS_PER_PAGE } from './ActionsRenderer'
 
 // The props needed to render an action from a message.
 export type ActionsEditorProps = {
@@ -221,6 +223,16 @@ export const ActionEditor = ({
 
   const [changeCategoryOpen, setChangeCategoryOpen] = useState(false)
 
+  const [page, setPage] = useState(PAGINATION_MIN_PAGE)
+  const lastPage = Math.ceil(all.length / ACTIONS_PER_PAGE)
+  // If the last page changes, reset the page to it. This ensures that if an
+  // action gets deleted and the page we're on is now invalid, we reset to the
+  // last page. And if an action gets created and we're not on the last page
+  // anymore, go to it.
+  useEffect(() => {
+    setPage(lastPage)
+  }, [lastPage])
+
   // Clear all errors when the action is removed, in case any manual errors were
   // not cleaned up. If manual errors persist, the form gets stuck.
   const onRemove = () => {
@@ -331,61 +343,64 @@ export const ActionEditor = ({
       onCategoryClick={goBackToCategoryPicker}
       onRemove={onRemove}
     >
-      {all.map(({ _id, index, data }) => {
-        const removeAction = () => {
-          clearErrors(`${actionDataFieldName}.${index}`)
-          remove(index)
-        }
+      {all
+        // Paginate.
+        .slice((page - 1) * ACTIONS_PER_PAGE, page * ACTIONS_PER_PAGE)
+        .map(({ _id, index, data }) => {
+          const removeAction = () => {
+            clearErrors(`${actionDataFieldName}.${index}`)
+            remove(index)
+          }
 
-        return (
-          <div
-            key={
-              // If _id empty, likely due to an old saved form state, use index
-              // and action as re-render key. Using a unique `key` ensures that
-              // the action does not re-render when other parts of the form
-              // change.
-              _id || `${index}-${action.key}`
-            }
-            className="flex animate-fade-in flex-row items-start gap-4"
-          >
-            <div className="flex min-w-0 grow flex-col gap-4">
-              <SuspenseLoader fallback={<Loader size={36} />}>
-                <action.Component
-                  addAction={addAction}
-                  allActionsWithData={actionData}
-                  data={data}
-                  errors={actionDataErrors?.[index]?.data || {}}
-                  fieldNamePrefix={`${actionDataFieldName}.${index}.data.`}
-                  index={index}
-                  isCreating
-                  remove={removeAction}
-                />
-              </SuspenseLoader>
+          return (
+            <div
+              key={
+                // If _id empty, likely due to an old saved form state, use index
+                // and action as re-render key. Using a unique `key` ensures that
+                // the action does not re-render when other parts of the form
+                // change.
+                _id || `${index}-${action.key}`
+              }
+              className="flex animate-fade-in flex-row items-start gap-4"
+            >
+              <div className="flex min-w-0 grow flex-col gap-4">
+                <SuspenseLoader fallback={<Loader size={36} />}>
+                  <action.Component
+                    addAction={addAction}
+                    allActionsWithData={actionData}
+                    data={data}
+                    errors={actionDataErrors?.[index]?.data || {}}
+                    fieldNamePrefix={`${actionDataFieldName}.${index}.data.`}
+                    index={index}
+                    isCreating
+                    remove={removeAction}
+                  />
+                </SuspenseLoader>
+              </div>
+
+              {/* Show remove button if action is resuable OR if there are more than one action. If there are more than one action, individual ones should be removable. But if there is only one, which is the intended state for an action configured as not reusable, don't show the remove button. */}
+              {(!action.notReusable || all.length > 1) && (
+                <Tooltip title={t('button.remove')}>
+                  <IconButton
+                    Icon={Remove}
+                    circular
+                    onClick={() => {
+                      // If only one action left, go back to category picker.
+                      if (all.length === 1) {
+                        goBackToCategoryPicker()
+                      } else {
+                        // Otherwise just remove this action.
+                        removeAction()
+                      }
+                    }}
+                    size="sm"
+                    variant="secondary"
+                  />
+                </Tooltip>
+              )}
             </div>
-
-            {/* Show remove button if action is resuable OR if there are more than one action. If there are more than one action, individual ones should be removable. But if there is only one, which is the intended state for an action configured as not reusable, don't show the remove button. */}
-            {(!action.notReusable || all.length > 1) && (
-              <Tooltip title={t('button.remove')}>
-                <IconButton
-                  Icon={Remove}
-                  circular
-                  onClick={() => {
-                    // If only one action left, go back to category picker.
-                    if (all.length === 1) {
-                      goBackToCategoryPicker()
-                    } else {
-                      // Otherwise just remove this action.
-                      removeAction()
-                    }
-                  }}
-                  size="sm"
-                  variant="secondary"
-                />
-              </Tooltip>
-            )}
-          </div>
-        )
-      })}
+          )
+        })}
 
       {/* Don't show add button if action is not reusable. */}
       {!action.notReusable && (
@@ -398,7 +413,7 @@ export const ActionEditor = ({
             Icon={Add}
             circular
             className="self-end"
-            onClick={() =>
+            onClick={() => {
               // Insert another entry for the same action with the default
               // values after the last one in this group.
               insert(all[all.length - 1].index + 1, {
@@ -410,11 +425,26 @@ export const ActionEditor = ({
                 actionKey: action.key,
                 data: cloneDeep(actionDefaults),
               })
-            }
+
+              // Go to the last page.
+              setPage(lastPage)
+            }}
             size="sm"
             variant="secondary"
           />
         </Tooltip>
+      )}
+
+      {lastPage > PAGINATION_MIN_PAGE && (
+        <div className="-mx-6 flex flex-col gap-4 border-t border-border-secondary px-6 pt-5">
+          <Pagination
+            className="w-full self-center"
+            page={page}
+            pageSize={ACTIONS_PER_PAGE}
+            setPage={setPage}
+            total={all.length}
+          />
+        </div>
       )}
     </ActionCard>
   )

--- a/packages/stateless/components/actions/ActionsRenderer.tsx
+++ b/packages/stateless/components/actions/ActionsRenderer.tsx
@@ -17,7 +17,7 @@ import { Loader } from '../logo/Loader'
 import { PAGINATION_MIN_PAGE, Pagination } from '../Pagination'
 import { ActionCard } from './ActionCard'
 
-const ACTIONS_PER_PAGE = 20
+export const ACTIONS_PER_PAGE = 20
 
 // The props needed to render an action from a message.
 export interface ActionsRendererProps {


### PR DESCRIPTION
This PR adds pagination to the actions editor in the proposal view since that page is also susceptible to memory lag when many actions are being added.

<img width="895" alt="Screenshot 2023-04-07 at 4 11 47 PM" src="https://user-images.githubusercontent.com/6721426/230690781-05c2ce36-a567-4a18-953a-242098117f6a.png">
