### PR TITLE
Only show web3auth warning when using web3auth wallet

### DIFF
--- a/packages/stateful/components/wallet/CosmodalConnected.tsx
+++ b/packages/stateful/components/wallet/CosmodalConnected.tsx
@@ -26,10 +26,12 @@ export const CosmodalConnected = ({ connectedWallet }: UiProps) => {
 
   return connectedWallet ? (
     <div className="flex flex-col items-stretch gap-6">
-      <Warning
-        content={t('info.socialLoginWarning', { context: 'onlySocial' })}
-        size="sm"
-      />
+      {isWeb3Auth && (
+        <Warning
+          content={t('info.socialLoginWarning', { context: 'onlySocial' })}
+          size="sm"
+        />
+      )}
 
       <div className="flex flex-col items-center">
         {/* Image */}


### PR DESCRIPTION
This fixes the Web3Auth warning that shows up whenever any wallet is connected. It should only show up when a Web3Auth wallet is connected.