### PR TITLE
Fix vesting redelegation amount

### DIFF
--- a/packages/stateless/components/token/StakingModal.tsx
+++ b/packages/stateless/components/token/StakingModal.tsx
@@ -55,11 +55,15 @@ export const StakingModal = ({
 
   // If choosing a validator, unstakable amount depends on chosen validator.
   if (validatorPicker) {
+    // If restaking, fromValidator is source of funds.
+    const targetValidator =
+      mode === StakingMode.Restake ? fromValidator : validator
+
     loadingUnstakableTokens = {
       loading: false,
       data:
         validatorPicker.stakes?.find(
-          (stake) => stake.validator.address === validator
+          (stake) => stake.validator.address === targetValidator
         )?.amount ?? 0,
     }
   }


### PR DESCRIPTION
The amount that can be redelegated is computed incorrectly in the vesting staking modal. This PR fixes it.