### PR TITLE
Don't load wallet NFTs until visible

### DIFF
--- a/packages/stateful/components/PfpkNftSelectionModal.tsx
+++ b/packages/stateful/components/PfpkNftSelectionModal.tsx
@@ -53,7 +53,8 @@ export const InnerPfpkNftSelectionModal = ({
     `${nft.collection.address}:${nft.tokenId}`
 
   const nfts = useCachedLoadingWithError(
-    walletAddress
+    // Don't load NFTs until visible.
+    walletAddress && visible
       ? walletNativeAndStargazeNftsSelector(walletAddress)
       : undefined
   )


### PR DESCRIPTION
This is slowing down the site a bit and causing a lot of network requests, so stop loading NFTs early.