### PR TITLE
Upgraded cosmodal to fix RPC issue

### DIFF
--- a/apps/dapp/package.json
+++ b/apps/dapp/package.json
@@ -31,7 +31,7 @@
     "@keplr-wallet/stores": "^0.11.49",
     "@keplr-wallet/types": "^0.11.49",
     "@mui/icons-material": "^5.10.3",
-    "@noahsaso/cosmodal": "0.11.0",
+    "@noahsaso/cosmodal": "0.11.1",
     "@sentry/nextjs": "^7.7.0",
     "@types/formidable": "^2.0.5",
     "cors": "^2.8.5",

--- a/apps/sda/package.json
+++ b/apps/sda/package.json
@@ -30,7 +30,7 @@
     "@keplr-wallet/stores": "^0.11.49",
     "@keplr-wallet/types": "^0.11.49",
     "@mui/icons-material": "^5.10.3",
-    "@noahsaso/cosmodal": "0.11.0",
+    "@noahsaso/cosmodal": "0.11.1",
     "@sentry/nextjs": "^7.7.0",
     "@types/formidable": "^2.0.5",
     "cors": "^2.8.5",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@dao-dao/config": "2.2.0",
     "@dao-dao/types": "2.2.0",
-    "@noahsaso/cosmodal": "0.11.0",
+    "@noahsaso/cosmodal": "0.11.1",
     "typescript": "^4.8.3"
   },
   "prettier": "@dao-dao/config/prettier"

--- a/packages/stateful/package.json
+++ b/packages/stateful/package.json
@@ -51,7 +51,7 @@
     "@cosmjs/amino": "^0.30.1",
     "@dao-dao/config": "2.2.0",
     "@dao-dao/types": "2.2.0",
-    "@noahsaso/cosmodal": "0.11.0",
+    "@noahsaso/cosmodal": "0.11.1",
     "@storybook/react": "^6.5.10",
     "@types/file-saver": "^2.0.5",
     "@types/lodash.clonedeep": "^4.5.0",

--- a/packages/stateless/package.json
+++ b/packages/stateless/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@dao-dao/config": "2.2.0",
-    "@noahsaso/cosmodal": "0.11.0",
+    "@noahsaso/cosmodal": "0.11.1",
     "@storybook/react": "^6.5.10",
     "@types/lodash.clonedeep": "^4.5.0",
     "@types/react": "^17.0.37",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -31,7 +31,7 @@
     "@dao-dao/config": "2.2.0",
     "@dao-dao/types": "2.2.0",
     "@keplr-wallet/types": "^0.11.49",
-    "@noahsaso/cosmodal": "0.11.0",
+    "@noahsaso/cosmodal": "0.11.1",
     "@types/ripemd160": "^2.0.0",
     "interchain-rpc": "1.5.0",
     "jest": "^29.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4117,10 +4117,10 @@
     jsbi "^3.1.5"
     sha.js "^2.4.11"
 
-"@noahsaso/cosmodal@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@noahsaso/cosmodal/-/cosmodal-0.11.0.tgz#73a1da8984e34af3fda103def477750f21c73fac"
-  integrity sha512-9LQzdoghQOJ+XRUWElNhCTHCqPAxKmQI0xGChg7vNYcYHv2qeXc5mFQ44kqNK4EIhCi+BGt3/Go1Yby0zO6ASw==
+"@noahsaso/cosmodal@0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@noahsaso/cosmodal/-/cosmodal-0.11.1.tgz#8a9d1941ff2f814313b882403fbf589f051138a3"
+  integrity sha512-3mpaT5IA3nFBX/IARVhCDgipzyK+1bbICmhdg1o4z2Qv3YHL/ZwOJm/+nCrOfDblbPlcfItZuoFKjg24153vPQ==
   dependencies:
     "@toruslabs/eccrypto" "^2.1.1"
     "@walletconnect/client" "^1.7.8"


### PR DESCRIPTION
This updates @noashaso/cosmodal to v0.11.1, which fixes an issue where chain info overrides were not overriding existing chain infos. Unfortunate. Now it's fixed so the RPC should be correct.