### PR TITLE
Fix Authz Exec Wallet Source

### DIFF
--- a/packages/stateful/actions/core/authorizations/AuthzExec/index.tsx
+++ b/packages/stateful/actions/core/authorizations/AuthzExec/index.tsx
@@ -120,7 +120,7 @@ const InnerComponentWrapper: ActionComponent<
       <InnerComponentLoading {...props} />
     )
   ) : isWalletAddress ? (
-    <WalletActionsProvider>
+    <WalletActionsProvider address={address}>
       <InnerComponent {...props} />
     </WalletActionsProvider>
   ) : (

--- a/packages/stateful/actions/react/provider.tsx
+++ b/packages/stateful/actions/react/provider.tsx
@@ -18,8 +18,13 @@ import {
 } from '../core'
 import { ActionsContext } from './context'
 
-export interface ActionsProviderProps {
+export type ActionsProviderProps = {
   children: ReactNode | ReactNode[]
+}
+
+export type WalletActionsProviderProps = ActionsProviderProps & {
+  // If passed, will override the connected wallet address.
+  address?: string
 }
 
 // Make sure this re-renders when the options change. You can do this by setting
@@ -101,9 +106,14 @@ export const DaoActionsProvider = ({ children }: ActionsProviderProps) => {
   )
 }
 
-export const WalletActionsProvider = ({ children }: ActionsProviderProps) => {
+export const WalletActionsProvider = ({
+  address: overrideAddress,
+  children,
+}: WalletActionsProviderProps) => {
   const { t } = useTranslation()
-  const { chainInfo, address } = useWallet()
+  const { chainInfo, address: connectedAddress } = useWallet()
+
+  const address = overrideAddress || connectedAddress
 
   if (!chainInfo || !address) {
     return <Loader />


### PR DESCRIPTION
Resolves #1279 

This fixes a bug when using authz exec to execute an action on behalf of a wallet address, where the actions did not properly use the new source wallet address.