### PR TITLE
Fix authz exec action bulk data format docs

### DIFF
--- a/packages/stateful/actions/core/authorizations/AuthzExec/README.md
+++ b/packages/stateful/actions/core/authorizations/AuthzExec/README.md
@@ -1,7 +1,7 @@
 # AuthzExec
 
-Execute a message on an account that has authorized the executor to act behalf
-of its account via authz.
+Execute a message on an account that has authorized the executor to act on
+behalf of its account via authz.
 
 ## Bulk import format
 
@@ -16,62 +16,13 @@ guide](https://github.com/DA0-DA0/dao-dao-ui/wiki/Bulk-importing-actions).
 
 ```json
 {
-  "authzExecActionType": "<AUTHORIZED MESSAGE TYPE URL>",
-  "delegate": {
-    "amount": {
-      "denom": "<DENOM>",
-      "amount": "<AMOUNT>"
-    },
-    "delegatorAddress": "<DELEGATOR ADDRESS>",
-    "validatorAddress": "<VALIDATOR ADDRESS>"
-  },
-  "undelegate": {
-    "amount": {
-      "denom": "<DENOM>",
-      "amount": "<AMOUNT>"
-    },
-    "delegatorAddress": "<DELEGATOR ADDRESS>",
-    "validatorAddress": "<VALIDATOR ADDRESS>"
-  },
-  "redelegate": {
-    "delegatorAddress": "<DELEGATOR ADDRESS>",
-    "validatorSrcAddress": "<VALIDATOR SRC ADDRESS>",
-    "validatorDstAddress": "<VALIDATOR DST ADDRESS>",
-    "amount": {
-      "denom": "<DENOM>",
-      "amount": "<AMOUNT>"
-    }
-  },
-  "claimRewards": {
-    "delegatorAddress": "<DELEGATOR ADDRESS>",
-    "validatorAddress": "<VALIDATOR ADDRESS>"
-  },
-  "custom": "<ARRAY OF CUSTOM MESSAGES>"
+  "address": "<TARGET ACCOUNT ADDRESS>",
+  "msgs": [
+    // COSMWASM MESSAGE
+  ]
 }
 ```
 
-`authzExecActionType` can be one of the following authorized message type URLs:
-
-- `/cosmos.staking.v1beta1.MsgDelegate`
-- `/cosmos.staking.v1beta1.MsgUndelegate`
-- `/cosmos.staking.v1beta1.MsgBeginRedelegate`
-- `/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward`
-- `custom`
-
-Based on the selection, only the corresponding object needs to be filled in. For
-example, if you wanted to execute a delegate action, all you would need to
-include is:
-
-```json
-{
-  "authzExecActionType": "/cosmos.staking.v1beta1.MsgDelegate",
-  "delegate": {
-    "amount": {
-      "denom": "<DENOM>",
-      "amount": "<AMOUNT>"
-    },
-    "delegatorAddress": "<DELEGATOR ADDRESS>",
-    "validatorAddress": "<VALIDATOR ADDRESS>"
-  }
-}
-```
+Each message is a CosmWasm message object in JSON format. You can find this by
+viewing the raw data of an action in a proposal, or by viewing the preview in
+the proposal creation UI with the action you want.


### PR DESCRIPTION
The authz execute action switched to allow any type of message instead of just staking actions, but the bulk data format docs were not updated. This updates them so they are accurate.