### PR TITLE
Hide DAO migrator if nonexistent

### DIFF
--- a/packages/stateful/actions/core/dao_governance/UpgradeV1ToV2/index.tsx
+++ b/packages/stateful/actions/core/dao_governance/UpgradeV1ToV2/index.tsx
@@ -138,7 +138,11 @@ export const makeUpgradeV1ToV2Action: ActionMaker<UpgradeV1ToV2Data> = ({
   address,
   chain,
 }) => {
-  if (context.type !== ActionContextType.Dao) {
+  if (
+    context.type !== ActionContextType.Dao ||
+    // If no DAO migrator, don't show upgrade action.
+    CODE_ID_CONFIG.DaoMigrator > 0
+  ) {
     return null
   }
 


### PR DESCRIPTION
Hide upgrade action if contract does not exist. Osmosis will only have v2 DAOs, so no need to show an upgrade to v2.