### PR TITLE
Fix opening vesting payment proposal from card options

### DIFF
--- a/packages/stateful/widgets/widgets/VestingPayments/components/NativeStakingModal.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/components/NativeStakingModal.tsx
@@ -136,6 +136,7 @@ export const NativeStakingModal = ({
                 {
                   actionKey: ActionKey.Execute,
                   data: {
+                    chainId,
                     address: vestingContractAddress,
                     message: JSON.stringify(
                       {
@@ -170,6 +171,7 @@ export const NativeStakingModal = ({
                 {
                   actionKey: ActionKey.Execute,
                   data: {
+                    chainId,
                     address: vestingContractAddress,
                     message: JSON.stringify(
                       {
@@ -210,6 +212,7 @@ export const NativeStakingModal = ({
                 {
                   actionKey: ActionKey.Execute,
                   data: {
+                    chainId,
                     address: vestingContractAddress,
                     message: JSON.stringify(
                       {

--- a/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/index.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/index.tsx
@@ -110,6 +110,7 @@ export const VestingPaymentCard = (vestingInfo: VestingInfo) => {
               {
                 actionKey: ActionKey.Execute,
                 data: {
+                  chainId,
                   address: vestingContractAddress,
                   message: JSON.stringify(
                     {
@@ -160,6 +161,7 @@ export const VestingPaymentCard = (vestingInfo: VestingInfo) => {
               actions: validators?.map((validator) => ({
                 actionKey: ActionKey.Execute,
                 data: {
+                  chainId,
                   address: vestingContractAddress,
                   message: JSON.stringify(
                     {


### PR DESCRIPTION
When creating a new proposal to claim rewards from a vesting payment, the chain ID is not being set properly, resulting in an unexpected Polytone UI bug. This fixes that.
 
![image](https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/7b1fccb6-843e-4820-8c40-5fdced3615e6)
