### PR TITLE
Disable self-relay between Juno and Stargaze

### DIFF
--- a/packages/utils/constants/chains.ts
+++ b/packages/utils/constants/chains.ts
@@ -92,7 +92,6 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
           // localClient: '07-tendermint-44',
           // stargaze
           // remoteClient: '07-tendermint-13',
-          needsSelfRelay: true,
         },
       },
     },
@@ -276,7 +275,6 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
           // localClient: '07-tendermint-13',
           // juno
           // remoteClient: '07-tendermint-44',
-          needsSelfRelay: true,
         },
       },
     },


### PR DESCRIPTION
There is an inconsistent error during Juno <> Stargaze self-relaying. It is not a good user experience and there's really no workaround except "try a bunch of times" until it's fixed. For now, we'll fund and run a relayer until we can figure out why this error happens or decide a relayer is sustainable.

It looks like this:
```
Query failed with (6): rpc error: code = Unknown desc = header failed basic validation: commit signs block EF504681166265EC0B29A698F754800C068B1A8FD00571C592BAF4B3C6F98CB4, header is block E1F1035EC36DDD2D04AB6E9BB12F17B8FC9DF94222BA21B2EA665119E8C31879 [cosmos/ibc-go/v7@v7.2.0/modules/light-clients/07-tendermint/header.go:62] With gas wanted: '0' and gas used: '3432' : unknown request
```