### PR TITLE
Detect when parent DAO is chain module

### DIFF
--- a/packages/state/recoil/selectors/chain.ts
+++ b/packages/state/recoil/selectors/chain.ts
@@ -39,6 +39,7 @@ import {
 } from '@dao-dao/types'
 import {
   MAINNET,
+  addressIsModule,
   cosmWasmClientRouter,
   cosmosSdkVersionIs47OrHigher,
   cosmosValidatorToValidator,
@@ -887,6 +888,20 @@ export const moduleNameForAddressSelector = selectorFamily<
         // Rethrow other errors.
         throw err
       }
+    },
+})
+
+// Check whether or not the address is a module account.
+export const addressIsModuleSelector = selectorFamily<
+  boolean,
+  WithChainId<{ address: string }>
+>({
+  key: 'addressIsModule',
+  get:
+    ({ address, chainId }) =>
+    async ({ get }) => {
+      const client = get(cosmosRpcClientForChainSelector(chainId))
+      return await addressIsModule(client, address)
     },
 })
 

--- a/packages/stateless/components/dao/DaoCard.tsx
+++ b/packages/stateless/components/dao/DaoCard.tsx
@@ -9,8 +9,9 @@ import clsx from 'clsx'
 import { useTranslation } from 'react-i18next'
 import removeMarkdown from 'remove-markdown'
 
+import { ContractVersion } from '@dao-dao/types'
 import { DaoCardProps } from '@dao-dao/types/stateless/DaoCard'
-import { formatDate } from '@dao-dao/utils'
+import { formatDate, getGovPath } from '@dao-dao/utils'
 
 import { useDaoNavHelpers } from '../../hooks'
 import { IconButton } from '../icon_buttons'
@@ -72,7 +73,9 @@ export const DaoCard = ({
                 />
               )}
               className="text-icon-interactive-disabled"
-              href={getDaoPath(parentDao.coreAddress)}
+              href={(parentDao.coreVersion === ContractVersion.Gov
+                ? getGovPath
+                : getDaoPath)(parentDao.coreAddress)}
               onClick={
                 // Don't click on DAO card.
                 (event) => event.stopPropagation()

--- a/packages/stateless/components/dao/DaoImage.stories.tsx
+++ b/packages/stateless/components/dao/DaoImage.stories.tsx
@@ -1,5 +1,7 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
 
+import { ContractVersion } from '@dao-dao/types'
+
 import { LinkWrapper } from '../LinkWrapper'
 import { DaoImage } from './DaoImage'
 
@@ -27,6 +29,7 @@ SmallWithParent.args = {
   imageUrl: '/placeholders/1.svg',
   parentDao: {
     name: 'Parent DAO',
+    coreVersion: ContractVersion.V210,
     coreAddress: 'parent',
     imageUrl: '/placeholders/2.svg',
     registeredSubDao: true,
@@ -49,6 +52,7 @@ LargeWithParent.args = {
   imageUrl: '/placeholders/1.svg',
   parentDao: {
     name: 'Parent DAO',
+    coreVersion: ContractVersion.V210,
     coreAddress: 'parent',
     imageUrl: '/placeholders/2.svg',
     registeredSubDao: true,

--- a/packages/stateless/components/dao/DaoImage.tsx
+++ b/packages/stateless/components/dao/DaoImage.tsx
@@ -3,9 +3,13 @@ import clsx from 'clsx'
 import { ComponentType, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { LinkWrapperProps } from '@dao-dao/types'
+import { ContractVersion, LinkWrapperProps } from '@dao-dao/types'
 import { DaoParentInfo } from '@dao-dao/types/dao'
-import { getFallbackImage, toAccessibleImageUrl } from '@dao-dao/utils'
+import {
+  getFallbackImage,
+  getGovPath,
+  toAccessibleImageUrl,
+} from '@dao-dao/utils'
 
 import { useDaoNavHelpers } from '../../hooks'
 import { Tooltip } from '../tooltip'
@@ -18,7 +22,7 @@ export interface DaoImageProps {
   coreAddress?: string
   parentDao?: Pick<
     DaoParentInfo,
-    'name' | 'coreAddress' | 'imageUrl' | 'registeredSubDao'
+    'name' | 'coreAddress' | 'coreVersion' | 'imageUrl' | 'registeredSubDao'
   > | null
   className?: string
   imageClassName?: string
@@ -88,7 +92,8 @@ export const DaoImage = ({
       {parentDao && (
         <Tooltip
           title={t(
-            parentDao.registeredSubDao
+            parentDao.registeredSubDao ||
+              parentDao.coreVersion === ContractVersion.Gov
               ? 'info.subDaoRegistered'
               : 'info.subDaoNeedsAdding',
             {
@@ -100,13 +105,15 @@ export const DaoImage = ({
           <LinkWrapper
             className="block h-full w-full"
             containerClassName={clsx(
-              'absolute right-0 bottom-0 rounded-full bg-cover bg-center shadow-dp4',
+              'absolute -top-2 -left-2 rounded-full bg-cover bg-center shadow-dp4',
               {
                 'h-8 w-8': size === 'sm',
                 'h-10 w-10': size === 'lg',
               }
             )}
-            href={getDaoPath(parentDao.coreAddress)}
+            href={(parentDao.coreVersion === ContractVersion.Gov
+              ? getGovPath
+              : getDaoPath)(parentDao.coreAddress)}
             onClick={(e) => e.stopPropagation()}
             style={{
               backgroundImage: `url(${
@@ -117,16 +124,17 @@ export const DaoImage = ({
             }}
           >
             {/* Show gray overlay with question mark if parent has not registered this SubDAO. */}
-            {!parentDao.registeredSubDao && (
-              <div className="absolute top-0 right-0 bottom-0 left-0 flex items-center justify-center rounded-full bg-background-overlay">
-                <QuestionMark
-                  className={clsx('text-text-secondary', {
-                    '!h-5 !w-5': size === 'sm',
-                    '!h-6 !w-6': size === 'lg',
-                  })}
-                />
-              </div>
-            )}
+            {!parentDao.registeredSubDao &&
+              parentDao.coreVersion !== ContractVersion.Gov && (
+                <div className="absolute top-0 right-0 bottom-0 left-0 flex items-center justify-center rounded-full bg-background-overlay">
+                  <QuestionMark
+                    className={clsx('text-text-secondary', {
+                      '!h-5 !w-5': size === 'sm',
+                      '!h-6 !w-6': size === 'lg',
+                    })}
+                  />
+                </div>
+              )}
           </LinkWrapper>
         </Tooltip>
       )}

--- a/packages/utils/dao.ts
+++ b/packages/utils/dao.ts
@@ -1,11 +1,13 @@
 import {
   BreadcrumbCrumb,
+  ContractVersion,
   DaoParentInfo,
   DaoWebSocketChannelInfo,
   PolytoneProxies,
 } from '@dao-dao/types'
 
 import { getSupportedChainConfig } from './chain'
+import { getGovPath } from './url'
 
 export const getParentDaoBreadcrumbs = (
   getDaoPath: (coreAddress: string) => string,
@@ -15,7 +17,9 @@ export const getParentDaoBreadcrumbs = (
     ? [
         ...getParentDaoBreadcrumbs(getDaoPath, parentDao.parentDao),
         {
-          href: getDaoPath(parentDao.coreAddress),
+          href: (parentDao.coreVersion === ContractVersion.Gov
+            ? getGovPath
+            : getDaoPath)(parentDao.coreAddress),
           label: parentDao.name,
         },
       ]


### PR DESCRIPTION
Resolves #1098 

This detects when a DAO's parent/admin is set to a chain module account (like x/gov or x/distribution for the community pool) and shows a chain image/links to the chain governance page where the parent DAO is typically shown.

This also moves the admin image to the top left instead of the bottom right.

<img width="281" alt="Screenshot 2023-09-06 at 17 36 08" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/5d8e694a-df63-487b-b54e-546f66afdfc6">
<img width="1140" alt="Screenshot 2023-09-06 at 17 36 26" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/80a48eee-57c1-47f0-a5de-2eb0704ca3d8">
<img width="368" alt="Screenshot 2023-09-06 at 17 36 34" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/874f9033-30ef-4c68-a7dc-6425e83d3141">
