### PR TITLE
Lazy load NFTs on DAO page to support DAOs with many NFTs

### DIFF
--- a/packages/stateful/actions/core/nfts/MintNft/MintNft.tsx
+++ b/packages/stateful/actions/core/nfts/MintNft/MintNft.tsx
@@ -80,6 +80,7 @@ export const MintNft: ActionComponent = (props) => {
       creatingCollectionInfoLoading.loading
       ? undefined
       : {
+          key: chainId + collectionAddress + mintMsg.token_id,
           collection: {
             address: collectionAddress,
             name: creatingCollectionInfoLoading.data?.name ?? '',

--- a/packages/stateful/components/NftCard.tsx
+++ b/packages/stateful/components/NftCard.tsx
@@ -28,6 +28,7 @@ export const StakedNftCard = (props: ComponentProps<typeof NftCard>) => {
 }
 
 export const LazyNftCard = ({
+  key,
   type = 'owner',
   collectionAddress,
   tokenId,
@@ -66,6 +67,7 @@ export const LazyNftCard = ({
 
   return info.loading || info.errored ? (
     <NftCardToUse
+      key={key}
       chainId={chainId}
       className="animate-pulse"
       collection={{

--- a/packages/stateful/components/NftCard.tsx
+++ b/packages/stateful/components/NftCard.tsx
@@ -6,7 +6,7 @@ import {
   NftCard as StatelessNftCard,
   useCachedLoadingWithError,
 } from '@dao-dao/stateless'
-import { WithChainId } from '@dao-dao/types'
+import { LazyNftCardProps } from '@dao-dao/types'
 
 import {
   nftCardInfoSelector,
@@ -27,14 +27,8 @@ export const StakedNftCard = (props: ComponentProps<typeof NftCard>) => {
   return <NftCard hideCollection ownerLabel={t('title.staker')} {...props} />
 }
 
-export type LazyNftCardProps = WithChainId<{
-  collectionAddress: string
-  tokenId: string
-  // If passed and the NFT is staked, get staker info from this contract.
-  stakingContractAddress?: string
-}>
-
 export const LazyNftCard = ({
+  type = 'owner',
   collectionAddress,
   tokenId,
   stakingContractAddress,
@@ -49,12 +43,14 @@ export const LazyNftCard = ({
   )
 
   const stakerOrOwner = useCachedLoadingWithError(
-    nftStakerOrOwnerSelector({
-      collectionAddress,
-      tokenId,
-      stakingContractAddress,
-      chainId,
-    })
+    type === 'owner'
+      ? nftStakerOrOwnerSelector({
+          collectionAddress,
+          tokenId,
+          stakingContractAddress,
+          chainId,
+        })
+      : undefined
   )
 
   const staked =
@@ -62,7 +58,11 @@ export const LazyNftCard = ({
     !stakerOrOwner.errored &&
     stakerOrOwner.data.staked
 
-  const NftCardToUse = staked ? StakedNftCard : NftCardNoCollection
+  const NftCardToUse = staked
+    ? StakedNftCard
+    : type === 'owner'
+    ? NftCardNoCollection
+    : NftCard
 
   return info.loading || info.errored ? (
     <NftCardToUse

--- a/packages/stateful/components/dao/tabs/TreasuryAndNftsTab.tsx
+++ b/packages/stateful/components/dao/tabs/TreasuryAndNftsTab.tsx
@@ -6,7 +6,7 @@ import {
   useDaoInfoContext,
   useDaoNavHelpers,
 } from '@dao-dao/stateless'
-import { ActionKey, TokenCardInfo } from '@dao-dao/types'
+import { ActionKey, LazyNftCardProps, TokenCardInfo } from '@dao-dao/types'
 import { getDaoProposalSinglePrefill } from '@dao-dao/utils'
 
 import { useActionForKey } from '../../../actions'
@@ -87,10 +87,10 @@ export const TreasuryAndNftsTab = () => {
   })
 
   return (
-    <StatelessTreasuryAndNftsTab
+    <StatelessTreasuryAndNftsTab<TokenCardInfo, LazyNftCardProps>
       ButtonLink={ButtonLink}
       FiatDepositModal={DaoFiatDepositModal}
-      LazyNftCard={LazyNftCard}
+      NftCard={LazyNftCard}
       StargazeNftImportModal={StargazeNftImportModal}
       TokenCard={DaoTokenCard}
       addCollectionHref={

--- a/packages/stateful/components/dao/tabs/TreasuryAndNftsTab.tsx
+++ b/packages/stateful/components/dao/tabs/TreasuryAndNftsTab.tsx
@@ -12,7 +12,7 @@ import { getDaoProposalSinglePrefill } from '@dao-dao/utils'
 import { useActionForKey } from '../../../actions'
 import { useMembership, useWallet } from '../../../hooks'
 import {
-  nftCardInfosForDaoSelector,
+  lazyNftCardPropsForDaoSelector,
   treasuryTokenCardInfosSelector,
 } from '../../../recoil'
 import {
@@ -21,7 +21,7 @@ import {
   useNativeCommonGovernanceTokenInfoIfExists,
 } from '../../../voting-module-adapter'
 import { ButtonLink } from '../../ButtonLink'
-import { NftCard } from '../../NftCard'
+import { LazyNftCard } from '../../NftCard'
 import { StargazeNftImportModal } from '../../StargazeNftImportModal'
 import { DaoFiatDepositModal } from '../DaoFiatDepositModal'
 import { DaoTokenCard } from '../DaoTokenCard'
@@ -63,7 +63,7 @@ export const TreasuryAndNftsTab = () => {
     []
   )
   const nfts = useCachedLoading(
-    nftCardInfosForDaoSelector({
+    lazyNftCardPropsForDaoSelector({
       chainId: daoInfo.chainId,
       coreAddress: daoInfo.coreAddress,
       governanceCollectionAddress: cw721GovernanceCollectionAddress,
@@ -90,7 +90,7 @@ export const TreasuryAndNftsTab = () => {
     <StatelessTreasuryAndNftsTab
       ButtonLink={ButtonLink}
       FiatDepositModal={DaoFiatDepositModal}
-      NftCard={NftCard}
+      LazyNftCard={LazyNftCard}
       StargazeNftImportModal={StargazeNftImportModal}
       TokenCard={DaoTokenCard}
       addCollectionHref={

--- a/packages/stateful/recoil/selectors/nft.ts
+++ b/packages/stateful/recoil/selectors/nft.ts
@@ -100,6 +100,7 @@ export const nftCardInfoWithUriSelector = selectorFamily<
       const { name = '', description, imageUrl, externalLink } = metadata || {}
 
       const info: NftCardInfo = {
+        key: chainId + collection + tokenId,
         collection: {
           address: collection,
           name: collectionInfo.name,
@@ -200,6 +201,7 @@ export const lazyNftCardPropsForDaoSelector = selectorFamily<
               nftCollectionTokenIds[index].state === 'hasValue'
                 ? (nftCollectionTokenIds[index].contents as string[]).map(
                     (tokenId): LazyNftCardProps => ({
+                      key: chainId + collectionAddress + tokenId,
                       chainId,
                       tokenId,
                       collectionAddress,

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingCw721Staked/components/NftCollectionTab.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingCw721Staked/components/NftCollectionTab.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { CommonNftSelectors } from '@dao-dao/state/recoil'
 import { NftsTab, useCachedLoading, useChain } from '@dao-dao/stateless'
+import { LazyNftCardProps } from '@dao-dao/types'
 
 import { LazyNftCard } from '../../../../components'
 import { useGovernanceCollectionInfo } from '../hooks'
@@ -29,13 +30,16 @@ export const NftCollectionTab = () => {
           ? { loading: true }
           : {
               loading: false,
-              data: allTokens.data.map((tokenId) => ({
-                chainId,
-                collectionAddress,
-                tokenId,
-                stakingContractAddress,
-                key: collectionAddress + tokenId,
-              })),
+              data: allTokens.data.map(
+                (tokenId): LazyNftCardProps & { key: string } => ({
+                  chainId,
+                  collectionAddress,
+                  tokenId,
+                  stakingContractAddress,
+                  key: chainId + collectionAddress + tokenId,
+                  type: 'owner',
+                })
+              ),
             }
       }
     />

--- a/packages/stateless/components/NftCard.stories.tsx
+++ b/packages/stateless/components/NftCard.stories.tsx
@@ -38,6 +38,7 @@ export const makeProps = (): NftCardProps => {
   id++
 
   return {
+    key: `${id}`,
     collection: {
       address: 'starsCollectionAddress',
       name: 'French Bulldog',

--- a/packages/stateless/components/dao/DaoChainTreasuryAndNfts.tsx
+++ b/packages/stateless/components/dao/DaoChainTreasuryAndNfts.tsx
@@ -1,0 +1,203 @@
+import { Image } from '@mui/icons-material'
+import clsx from 'clsx'
+import { ComponentType, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  ButtonLinkProps,
+  DaoChainTreasury,
+  LazyNftCardProps,
+  TokenCardInfo,
+} from '@dao-dao/types'
+import {
+  getChainForChainId,
+  getDisplayNameForChainId,
+  getSupportedChainConfig,
+} from '@dao-dao/utils'
+
+import {
+  CopyToClipboard,
+  GridCardContainer,
+  NoContent,
+  PAGINATION_MIN_PAGE,
+  Pagination,
+} from '../../components'
+import { useDaoInfoContext } from '../../hooks'
+import { Button } from '../buttons'
+import { ChainLogo } from '../ChainLogo'
+import { DropdownIconButton } from '../icon_buttons'
+import { Loader } from '../logo'
+
+export type DaoChainTreasuryAndNftsProps<T extends TokenCardInfo> = {
+  treasury: DaoChainTreasury<T>
+  connected: boolean
+  isMember: boolean
+  createCrossChainAccountPrefillHref: string
+  addCollectionHref?: string
+  setDepositFiatChainId: (chainId: string | undefined) => void
+  TokenCard: ComponentType<T>
+  LazyNftCard: ComponentType<LazyNftCardProps>
+  ButtonLink: ComponentType<ButtonLinkProps>
+}
+
+const NFTS_PER_PAGE = 15
+
+export const DaoChainTreasuryAndNfts = <T extends TokenCardInfo>({
+  treasury: { chainId, address, tokens, nfts },
+  connected,
+  isMember,
+  createCrossChainAccountPrefillHref,
+  addCollectionHref,
+  setDepositFiatChainId,
+  TokenCard,
+  LazyNftCard,
+  ButtonLink,
+}: DaoChainTreasuryAndNftsProps<T>) => {
+  const { t } = useTranslation()
+  const { chainId: daoChainId } = useDaoInfoContext()
+
+  const bech32Prefix = getChainForChainId(chainId).bech32_prefix
+  // Whether or not the treasury address is defined, meaning it is the current
+  // chain or a polytone account has already been created on that chain.
+  const exists = !!address
+
+  const [collapsed, setCollapsed] = useState(false)
+  const [nftPage, setNftPage] = useState(PAGINATION_MIN_PAGE)
+
+  return (
+    <div className="flex flex-col gap-4 pl-8">
+      {/* header min-height of 3.5rem standardized across all tabs */}
+      <div className="flex min-h-[3.5rem] grow flex-row flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <div className="relative flex flex-row items-center gap-2">
+          <div className="absolute -left-8">
+            {exists ? (
+              <DropdownIconButton
+                open={!collapsed}
+                toggle={() => setCollapsed((c) => !c)}
+              />
+            ) : (
+              <div className="flex h-6 w-6 items-center justify-center">
+                <div className="h-1 w-1 rounded-full bg-icon-interactive-disabled"></div>
+              </div>
+            )}
+          </div>
+
+          <ChainLogo chainId={chainId} size={28} />
+
+          <p className="title-text shrink-0">
+            {getDisplayNameForChainId(chainId)}
+          </p>
+        </div>
+
+        {exists ? (
+          <div className="flex grow flex-row items-stretch justify-between gap-6">
+            <CopyToClipboard
+              className="!gap-2 rounded-md bg-background-tertiary p-2 font-mono transition hover:bg-background-secondary"
+              takeStartEnd={{
+                start: bech32Prefix.length + 6,
+                end: 6,
+              }}
+              textClassName="!bg-transparent !p-0"
+              tooltip={t('button.clickToCopyAddress')}
+              value={address}
+            />
+
+            {connected && !!getSupportedChainConfig(chainId)?.kado && (
+              <Button
+                onClick={() => setDepositFiatChainId(chainId)}
+                variant="ghost_outline"
+              >
+                {t('button.depositFiat')}
+              </Button>
+            )}
+          </div>
+        ) : (
+          <ButtonLink
+            href={createCrossChainAccountPrefillHref}
+            variant="ghost_outline"
+          >
+            {t('button.createAccount')}
+          </ButtonLink>
+        )}
+      </div>
+
+      {exists && (
+        <div
+          className={clsx(
+            'flex flex-col gap-3 overflow-hidden',
+            collapsed ? 'h-0' : 'h-auto'
+          )}
+        >
+          {tokens.loading ? (
+            <Loader />
+          ) : (
+            tokens.data.length > 0 && (
+              <GridCardContainer cardType="wide">
+                {tokens.data.map((props, index) => (
+                  <TokenCard {...props} key={index} />
+                ))}
+              </GridCardContainer>
+            )
+          )}
+
+          {nfts.loading ? (
+            <Loader className="mt-6" />
+          ) : (
+            nfts.data.length > 0 && (
+              <>
+                <p className="title-text mt-4">
+                  {nfts.loading
+                    ? t('title.nfts')
+                    : t('title.numNfts', { count: nfts.data.length })}
+                </p>
+
+                <GridCardContainer>
+                  {nfts.data
+                    .slice(
+                      (nftPage - 1) * NFTS_PER_PAGE,
+                      nftPage * NFTS_PER_PAGE
+                    )
+                    .map((props) => (
+                      <LazyNftCard
+                        {...props}
+                        key={
+                          props.chainId +
+                          props.collectionAddress +
+                          props.tokenId
+                        }
+                      />
+                    ))}
+                </GridCardContainer>
+
+                <Pagination
+                  className="mx-auto mt-9"
+                  page={nftPage}
+                  pageSize={NFTS_PER_PAGE}
+                  setPage={setNftPage}
+                  total={nfts.data.length}
+                />
+              </>
+            )
+          )}
+
+          {!tokens.loading &&
+            tokens.data.length === 0 &&
+            !nfts.loading &&
+            nfts.data.length === 0 &&
+            (chainId === daoChainId ? (
+              <p className="secondary-text">{t('info.nothingFound')}</p>
+            ) : (
+              // Show NFT add prompt if on current chain.
+              <NoContent
+                Icon={Image}
+                actionNudge={t('info.areTheyMissingQuestion')}
+                body={t('info.noNftsYet')}
+                buttonLabel={t('button.addCollection')}
+                href={isMember ? addCollectionHref : undefined}
+              />
+            ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/stateless/components/dao/DaoChainTreasuryAndNfts.tsx
+++ b/packages/stateless/components/dao/DaoChainTreasuryAndNfts.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from 'react-i18next'
 import {
   ButtonLinkProps,
   DaoChainTreasury,
-  LazyNftCardProps,
   TokenCardInfo,
 } from '@dao-dao/types'
 import {
@@ -28,21 +27,27 @@ import { ChainLogo } from '../ChainLogo'
 import { DropdownIconButton } from '../icon_buttons'
 import { Loader } from '../logo'
 
-export type DaoChainTreasuryAndNftsProps<T extends TokenCardInfo> = {
-  treasury: DaoChainTreasury<T>
+export type DaoChainTreasuryAndNftsProps<
+  T extends TokenCardInfo,
+  N extends object
+> = {
+  treasury: DaoChainTreasury<T, N>
   connected: boolean
   isMember: boolean
   createCrossChainAccountPrefillHref: string
   addCollectionHref?: string
   setDepositFiatChainId: (chainId: string | undefined) => void
   TokenCard: ComponentType<T>
-  LazyNftCard: ComponentType<LazyNftCardProps>
+  NftCard: ComponentType<N>
   ButtonLink: ComponentType<ButtonLinkProps>
 }
 
 const NFTS_PER_PAGE = 15
 
-export const DaoChainTreasuryAndNfts = <T extends TokenCardInfo>({
+export const DaoChainTreasuryAndNfts = <
+  T extends TokenCardInfo,
+  N extends object
+>({
   treasury: { chainId, address, tokens, nfts },
   connected,
   isMember,
@@ -50,9 +55,9 @@ export const DaoChainTreasuryAndNfts = <T extends TokenCardInfo>({
   addCollectionHref,
   setDepositFiatChainId,
   TokenCard,
-  LazyNftCard,
+  NftCard,
   ButtonLink,
-}: DaoChainTreasuryAndNftsProps<T>) => {
+}: DaoChainTreasuryAndNftsProps<T, N>) => {
   const { t } = useTranslation()
   const { chainId: daoChainId } = useDaoInfoContext()
 
@@ -158,14 +163,7 @@ export const DaoChainTreasuryAndNfts = <T extends TokenCardInfo>({
                       nftPage * NFTS_PER_PAGE
                     )
                     .map((props) => (
-                      <LazyNftCard
-                        {...props}
-                        key={
-                          props.chainId +
-                          props.collectionAddress +
-                          props.tokenId
-                        }
-                      />
+                      <NftCard {...props} key={props.key} />
                     ))}
                 </GridCardContainer>
 

--- a/packages/stateless/components/dao/tabs/TreasuryAndNftsTab.stories.tsx
+++ b/packages/stateless/components/dao/tabs/TreasuryAndNftsTab.stories.tsx
@@ -19,7 +19,7 @@ export default {
 } as ComponentMeta<typeof TreasuryAndNftsTab>
 
 const Template: ComponentStory<
-  typeof TreasuryAndNftsTab<TokenCardProps, NftCardProps>
+  typeof TreasuryAndNftsTab<TokenCardProps, NftCardProps & { key: string }>
 > = (args) => <TreasuryAndNftsTab {...args} />
 
 export const Default = Template.bind({})

--- a/packages/stateless/components/dao/tabs/TreasuryAndNftsTab.tsx
+++ b/packages/stateless/components/dao/tabs/TreasuryAndNftsTab.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import {
   DaoChainTreasury,
   DaoFiatDepositModalProps,
-  LazyNftCardProps,
   LoadingData,
   LoadingNfts,
   TokenCardInfo,
@@ -20,26 +19,32 @@ import {
   DaoChainTreasuryAndNftsProps,
 } from '../DaoChainTreasuryAndNfts'
 
-export type TreasuryAndNftsTabProps<T extends TokenCardInfo> = {
+export type TreasuryAndNftsTabProps<
+  T extends TokenCardInfo,
+  N extends object
+> = {
   connected: boolean
   tokens: LoadingData<{
     infos: T[]
     // Map chain ID to loading state.
     loading: Record<string, boolean>
   }>
-  nfts: LoadingNfts<LazyNftCardProps>
+  nfts: LoadingNfts<N & { key: string }>
   StargazeNftImportModal: ComponentType<Pick<ModalProps, 'onClose'>>
   FiatDepositModal: ComponentType<DaoFiatDepositModalProps>
-} & Omit<DaoChainTreasuryAndNftsProps<T>, 'treasury' | 'setDepositFiatChainId'>
+} & Omit<
+  DaoChainTreasuryAndNftsProps<T, N>,
+  'treasury' | 'setDepositFiatChainId'
+>
 
-export const TreasuryAndNftsTab = <T extends TokenCardInfo>({
+export const TreasuryAndNftsTab = <T extends TokenCardInfo, N extends object>({
   connected,
   tokens,
   nfts,
   FiatDepositModal,
   createCrossChainAccountPrefillHref,
   ...props
-}: TreasuryAndNftsTabProps<T>) => {
+}: TreasuryAndNftsTabProps<T, N>) => {
   const { t } = useTranslation()
   const {
     chain: { chain_id: currentChainId },
@@ -54,7 +59,7 @@ export const TreasuryAndNftsTab = <T extends TokenCardInfo>({
       chainId,
       polytoneProxies[chainId],
     ]),
-  ].map(([chainId, address]): DaoChainTreasury<T> => {
+  ].map(([chainId, address]): DaoChainTreasury<T, N> => {
     const chainNfts = nfts[chainId]
 
     return {

--- a/packages/stateless/components/modals/NftSelectionModal.tsx
+++ b/packages/stateless/components/modals/NftSelectionModal.tsx
@@ -29,13 +29,13 @@ import { NoContent } from '../NoContent'
 import { ButtonPopup } from '../popup'
 import { Modal } from './Modal'
 
-export interface NftSelectionModalProps<T extends NftCardInfo>
+export interface NftSelectionModalProps<N extends NftCardInfo>
   extends Omit<ModalProps, 'children' | 'header'>,
     Required<Pick<ModalProps, 'header'>> {
-  nfts: LoadingDataWithError<T[]>
+  nfts: LoadingDataWithError<N[]>
   selectedIds: string[]
-  getIdForNft: (nft: T) => string
-  onNftClick: (nft: T) => void
+  getIdForNft: (nft: N) => string
+  onNftClick: (nft: N) => void
   onSelectAll?: () => void
   onDeselectAll?: () => void
   action: {
@@ -56,7 +56,7 @@ export interface NftSelectionModalProps<T extends NftCardInfo>
   noneDisplay?: ReactNode
 }
 
-export const NftSelectionModal = <T extends NftCardInfo>({
+export const NftSelectionModal = <N extends NftCardInfo>({
   nfts,
   selectedIds,
   getIdForNft,
@@ -72,7 +72,7 @@ export const NftSelectionModal = <T extends NftCardInfo>({
   headerDisplay,
   noneDisplay,
   ...modalProps
-}: NftSelectionModalProps<T>) => {
+}: NftSelectionModalProps<N>) => {
   const { t } = useTranslation()
   const showSelectAll =
     (onSelectAll || onDeselectAll) &&
@@ -266,19 +266,19 @@ export const NftSelectionModal = <T extends NftCardInfo>({
           </pre>
         </>
       ) : nfts.data.length > 0 ? (
-        filteredSortedSearchedNfts.map(({ item: nft }) => (
+        filteredSortedSearchedNfts.map(({ item }) => (
           <NftCard
-            key={getIdForNft(nft as T)}
             ref={
-              selectedIds[0] === getIdForNft(nft as T)
+              selectedIds[0] === getIdForNft(item as N)
                 ? firstSelectedRef
                 : undefined
             }
-            {...(nft as T)}
+            {...(item as N)}
+            key={(item as N).key}
             checkbox={{
-              checked: selectedIds.includes(getIdForNft(nft as T)),
+              checked: selectedIds.includes(getIdForNft(item as N)),
               // Disable toggling if currently staking.
-              onClick: () => !action.loading && onNftClick(nft as T),
+              onClick: () => !action.loading && onNftClick(item as N),
             }}
           />
         ))

--- a/packages/types/dao.ts
+++ b/packages/types/dao.ts
@@ -16,7 +16,6 @@ import { ContractVersion } from './chain'
 import { DepositRefundPolicy, ModuleInstantiateInfo } from './contracts/common'
 import { InstantiateMsg as DaoCoreV2InstantiateMsg } from './contracts/DaoCore.v2'
 import { DaoCreator } from './creators'
-import { LazyNftCardProps } from './nft'
 import {
   PercentOrMajorityValue,
   ProposalModuleAdapter,
@@ -295,9 +294,9 @@ export type DaoWebSocketChannelInfo = {
   coreAddress: string
 }
 
-export type DaoChainTreasury<T extends TokenCardInfo> = {
+export type DaoChainTreasury<T extends TokenCardInfo, N extends object> = {
   chainId: string
   address: string | undefined
   tokens: LoadingData<T[]>
-  nfts: LoadingData<LazyNftCardProps[]>
+  nfts: LoadingData<(N & { key: string })[]>
 }

--- a/packages/types/dao.ts
+++ b/packages/types/dao.ts
@@ -16,12 +16,13 @@ import { ContractVersion } from './chain'
 import { DepositRefundPolicy, ModuleInstantiateInfo } from './contracts/common'
 import { InstantiateMsg as DaoCoreV2InstantiateMsg } from './contracts/DaoCore.v2'
 import { DaoCreator } from './creators'
+import { LazyNftCardProps } from './nft'
 import {
   PercentOrMajorityValue,
   ProposalModuleAdapter,
 } from './proposal-module-adapter'
-import { DaoCardProps, SuspenseLoaderProps } from './stateless'
-import { GenericToken } from './token'
+import { DaoCardProps, LoadingData, SuspenseLoaderProps } from './stateless'
+import { GenericToken, TokenCardInfo } from './token'
 import { DurationWithUnits } from './units'
 import { CodeIdConfig } from './utils'
 
@@ -292,4 +293,11 @@ export enum DaoPageMode {
 export type DaoWebSocketChannelInfo = {
   chainId: string
   coreAddress: string
+}
+
+export type DaoChainTreasury<T extends TokenCardInfo> = {
+  chainId: string
+  address: string | undefined
+  tokens: LoadingData<T[]>
+  nfts: LoadingData<LazyNftCardProps[]>
 }

--- a/packages/types/nft.ts
+++ b/packages/types/nft.ts
@@ -53,6 +53,7 @@ export type NftUriData = {
 
 export type NftCardInfo = {
   chainId: string
+  key: string
   collection: {
     address: string
     name: string
@@ -84,6 +85,7 @@ export type LoadingNfts<N extends object> = Partial<
 >
 
 export type LazyNftCardProps = WithChainId<{
+  key: string
   // Whether to show the collection or the owner/staker. Default is owner.
   type?: 'collection' | 'owner'
   collectionAddress: string

--- a/packages/types/nft.ts
+++ b/packages/types/nft.ts
@@ -1,5 +1,6 @@
 import { ChainId } from './chain'
 import { ContractInfoResponse } from './contracts/Cw721Base'
+import { WithChainId } from './state'
 import { LoadingDataWithError } from './stateless'
 
 export interface StargazeNft {
@@ -78,6 +79,15 @@ export type NftCardInfo = {
 }
 
 // Map chain ID to loading NFTs on that chain.
-export type LoadingNfts<N extends NftCardInfo = NftCardInfo> = Partial<
+export type LoadingNfts<N extends object> = Partial<
   Record<ChainId | string, LoadingDataWithError<N[]>>
 >
+
+export type LazyNftCardProps = WithChainId<{
+  // Whether to show the collection or the owner/staker. Default is owner.
+  type?: 'collection' | 'owner'
+  collectionAddress: string
+  tokenId: string
+  // If passed and the NFT is staked, get staker info from this contract.
+  stakingContractAddress?: string
+}>


### PR DESCRIPTION
This fixes support for DAOs with many NFTs by lazy loading NFTs only when the card is showing and paginating the NFTs in the treasury tab.