### PR TITLE
Fix API nonce bug

### DIFF
--- a/packages/stateful/hooks/useCfWorkerAuthPostRequest.ts
+++ b/packages/stateful/hooks/useCfWorkerAuthPostRequest.ts
@@ -9,7 +9,7 @@ import { useWallet } from './useWallet'
 // Cloudflare KV is slow to update, so keep track of the last successful nonce
 // that worked so we don't have to wait for the nonce query to update. Make this
 // a global variable so it persists across all hook uses.
-const lastSuccessfulNonceForType: Record<string, number | undefined> = {}
+const lastSuccessfulNonceForApi: Record<string, number | undefined> = {}
 
 export const useCfWorkerAuthPostRequest = (
   apiBase: string,
@@ -57,8 +57,7 @@ export const useCfWorkerAuthPostRequest = (
 
       // If nonce was already used, manually increment.
       let nonce = nonceResponse.nonce
-      const lastSuccessfulNonce =
-        lastSuccessfulNonceForType[signatureType] ?? -1
+      const lastSuccessfulNonce = lastSuccessfulNonceForApi[apiBase] ?? -1
       if (nonce <= lastSuccessfulNonce) {
         nonce = lastSuccessfulNonce + 1
       }
@@ -134,7 +133,7 @@ export const useCfWorkerAuthPostRequest = (
       }
 
       // If succeeded, store nonce.
-      lastSuccessfulNonceForType[signatureType] = nonce
+      lastSuccessfulNonceForApi[apiBase] = nonce
 
       // If response OK, return response body.
       return await response.json()


### PR DESCRIPTION
This fixes a bug with the storing of the last successful nonce and autoincrementing it. The key should be the URL of the API used instead of the type used in the signature.