### PR TITLE
Synchronize fallback images

### DIFF
--- a/packages/stateful/recoil/selectors/profile.ts
+++ b/packages/stateful/recoil/selectors/profile.ts
@@ -17,7 +17,6 @@ import {
   STARGAZE_NAMES_CONTRACT,
   getChainForChainId,
   getFallbackImage,
-  toBech32Hash,
   transformBech32Address,
 } from '@dao-dao/utils'
 
@@ -100,7 +99,7 @@ export const makeDefaultWalletProfileData = (
   loading,
   address,
   profile: { ...EMPTY_WALLET_PROFILE },
-  backupImageUrl: getFallbackImage(),
+  backupImageUrl: getFallbackImage(address),
 })
 
 // This selector returns the profile for a wallet with some helpful metadata,
@@ -135,7 +134,7 @@ export const walletProfileDataSelector = selectorFamily<
         profile.nft = pfpkProfile.nft
       }
 
-      const backupImageUrl = getFallbackImage(toBech32Hash(address))
+      const backupImageUrl = getFallbackImage(address)
 
       // Set `imageUrl` to PFPK image, defaulting to fallback image.
       profile.imageUrl = pfpkProfile?.nft?.imageUrl || backupImageUrl

--- a/packages/stateless/components/EntityDisplay.tsx
+++ b/packages/stateless/components/EntityDisplay.tsx
@@ -10,7 +10,6 @@ import {
   concatAddressStartEnd,
   getFallbackImage,
   toAccessibleImageUrl,
-  toBech32Hash,
 } from '@dao-dao/utils'
 
 import { useChainContext, useDaoNavHelpers, useDetectTruncate } from '../hooks'
@@ -102,7 +101,7 @@ export const EntityDisplay = ({
               style={{
                 backgroundImage: `url(${
                   loadingEntity.loading
-                    ? getFallbackImage(toBech32Hash(address))
+                    ? getFallbackImage(address)
                     : toAccessibleImageUrl(loadingEntity.data.imageUrl)
                 })`,
                 width: imageSize,

--- a/packages/stateless/components/proposal/ProposalVotes.stories.tsx
+++ b/packages/stateless/components/proposal/ProposalVotes.stories.tsx
@@ -4,7 +4,7 @@ import { VoteDisplay } from '@dao-dao/stateful/proposal-module-adapter/adapters/
 import { CHAIN_ID } from '@dao-dao/storybook'
 import { EntityType } from '@dao-dao/types'
 import { Vote } from '@dao-dao/types/contracts/DaoProposalSingle.common'
-import { getFallbackImage, toBech32Hash } from '@dao-dao/utils'
+import { getFallbackImage } from '@dao-dao/utils'
 
 import { EntityDisplay } from '../EntityDisplay'
 import { ProposalVotes, ProposalVotesProps } from './ProposalVotes'
@@ -45,7 +45,7 @@ export const makeProps = (): ProposalVotesProps<Vote> => ({
           chainId: CHAIN_ID,
           address: props.address,
           name: null,
-          imageUrl: getFallbackImage(toBech32Hash(props.address)),
+          imageUrl: getFallbackImage(props.address),
         },
       }}
       {...props}

--- a/packages/utils/getFallbackImage.ts
+++ b/packages/utils/getFallbackImage.ts
@@ -5,6 +5,7 @@ import { ChainId } from '@dao-dao/types'
 
 import { getImageUrlForChainId } from './chain'
 import { NEUTRON_GOVERNANCE_DAO } from './constants'
+import { toBech32Hash } from './conversion'
 
 // fallback images in the public/placeholders directory.
 export const getFallbackImage = (identifier = '') => {
@@ -12,6 +13,10 @@ export const getFallbackImage = (identifier = '') => {
   if (identifier === NEUTRON_GOVERNANCE_DAO) {
     return getImageUrlForChainId(ChainId.NeutronMainnet)
   }
+
+  // If identitifer is an address, get its bech32 data, so it's consistent
+  // across chains.
+  identifier = toBech32Hash(identifier) || identifier
 
   const hashed = identifier.split('').reduce((p, n) => n.charCodeAt(0) + p, 0)
   const index = (hashed % 5) + 1


### PR DESCRIPTION
We should use the bech32 data of an address instead of its raw address so its fallback image is consistent across chains.