### PR TITLE
Connect to all chains when connecting to wallet

### DIFF
--- a/packages/stateful/components/ConnectWallet.tsx
+++ b/packages/stateful/components/ConnectWallet.tsx
@@ -1,12 +1,13 @@
+import { useChains } from '@cosmos-kit/react-lite'
 import { useTranslation } from 'react-i18next'
 
 import {
   ConnectWalletProps,
   ConnectWallet as StatelessConnectWallet,
   Tooltip,
+  useChainContextIfAvailable,
 } from '@dao-dao/stateless'
-
-import { useWallet } from '../hooks/useWallet'
+import { getSupportedChains } from '@dao-dao/utils'
 
 export type StatefulConnectWalletProps = Omit<
   ConnectWalletProps,
@@ -15,7 +16,19 @@ export type StatefulConnectWalletProps = Omit<
 
 export const ConnectWallet = (props: StatefulConnectWalletProps) => {
   const { t } = useTranslation()
-  const { connect, disconnect, isWalletConnecting } = useWallet()
+
+  const {
+    chain: { chain_name: currentChainName } = { chain_name: undefined },
+  } = useChainContextIfAvailable() ?? {}
+  const chainNames = getSupportedChains().map(({ chain }) => chain.chain_name)
+  const { connect, disconnect, isWalletConnecting } =
+    useChains(chainNames)[
+      // Use current chain if available, or just use first chain. Should not
+      // matter because connect/disconnect will sync to all chains, but in case
+      // the user only approves some chains and not others, we want to make sure
+      // the current chain is priority.
+      currentChainName || chainNames[0]
+    ]
 
   return (
     <Tooltip

--- a/packages/stateful/components/WalletProvider.tsx
+++ b/packages/stateful/components/WalletProvider.tsx
@@ -11,7 +11,7 @@ import { wallets as leapWallets } from '@cosmos-kit/leap'
 import { wallets as leapMetamaskWallets } from '@cosmos-kit/leap-metamask-cosmos-snap'
 import { wallets as okxWallets } from '@cosmos-kit/okxwallet'
 import { wallets as omniWallets } from '@cosmos-kit/omni'
-import { ChainProvider, walletContext } from '@cosmos-kit/react-lite'
+import { ChainProvider } from '@cosmos-kit/react-lite'
 import { wallets as shellWallets } from '@cosmos-kit/shell'
 import { wallets as stationWallets } from '@cosmos-kit/station'
 import { wallets as trustWallets } from '@cosmos-kit/trust'
@@ -24,7 +24,6 @@ import {
   PropsWithChildren,
   ReactNode,
   SetStateAction,
-  useContext,
   useEffect,
   useMemo,
 } from 'react'
@@ -213,17 +212,7 @@ export const WalletProvider = ({
 const InnerWalletProvider = ({ children }: PropsWithChildren<{}>) => {
   useSyncWalletSigner()
 
-  const { isWalletDisconnected, chain, walletRepo } = useWallet()
-  // Re-run account restore logic on wallet chain switch to ensure connected.
-  const { walletManager } = useContext(walletContext)
-  useEffect(() => {
-    if (isWalletDisconnected) {
-      // @ts-ignore
-      walletManager._restoreAccounts()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chain.chain_id, walletManager])
-
+  const { isWalletDisconnected, walletRepo } = useWallet()
   // Auto-connect to Keplr mobile web if in that context.
   const isKeplrMobileWeb = useRecoilValue(isKeplrMobileWebAtom)
   useEffect(() => {


### PR DESCRIPTION
This fixes a bug where the wallet would not appear connected to other chains because cosmos kit was not attempting to request connection when its `useChain` hook was called. This fixes that by connecting to all chains on initial wallet connection.

It also removes a hacky workaround that was manually calling a private method.