### PR TITLE
Fix decimal bug

### DIFF
--- a/packages/state/recoil/selectors/chain.ts
+++ b/packages/state/recoil/selectors/chain.ts
@@ -1,11 +1,6 @@
 import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate'
 import { fromBase64, toHex } from '@cosmjs/encoding'
-import {
-  Coin,
-  IndexedTx,
-  StargateClient,
-  decodeCosmosSdkDecFromProto,
-} from '@cosmjs/stargate'
+import { Coin, IndexedTx, StargateClient } from '@cosmjs/stargate'
 import { selector, selectorFamily, waitForAll, waitForAny } from 'recoil'
 
 import { cosmos, ibc, juno } from '@dao-dao/protobuf'
@@ -804,15 +799,9 @@ export const govParamsSelector = selectorFamily<AllGovParams, WithChainId<{}>>({
         minDeposit: depositParams.minDeposit,
         maxDepositPeriod: depositParams.maxDepositPeriod,
         votingPeriod: votingParams.votingPeriod,
-        quorum: decodeCosmosSdkDecFromProto(
-          tallyParams.quorum
-        ).toFloatApproximation(),
-        threshold: decodeCosmosSdkDecFromProto(
-          tallyParams.threshold
-        ).toFloatApproximation(),
-        vetoThreshold: decodeCosmosSdkDecFromProto(
-          tallyParams.vetoThreshold
-        ).toFloatApproximation(),
+        quorum: Number(tallyParams.quorum),
+        threshold: Number(tallyParams.threshold),
+        vetoThreshold: Number(tallyParams.vetoThreshold),
         // Cannot retrieve this from v1beta1 query, so just assume 0.25 as it is
         // a conservative estimate. Osmosis uses 0.25 and Juno uses 0.2 as of
         // 2023-08-13
@@ -955,11 +944,8 @@ export const communityPoolBalancesSelector = selectorFamily<
       const balances = tokens.map(
         (token, i): GenericTokenBalance => ({
           token,
-          balance: BigInt(
-            decodeCosmosSdkDecFromProto(pool[i].amount)
-              .floor()
-              .toFloatApproximation()
-          ).toString(),
+          // Truncate.
+          balance: pool[i].amount.split('.')[0],
         })
       )
 
@@ -1070,16 +1056,8 @@ export const nativeDelegationInfoSelector = selectorFamily<
                 return
               }
 
-              // pendingReward is represented as a Decimal Coin (DecCoin), which
-              // includes 18 decimals and no decimal point, so it needs to be
-              // converted manually. See issues:
-              // https://github.com/osmosis-labs/telescope/issues/247
-              // https://github.com/cosmos/cosmos-sdk/issues/10863
-              pendingReward.amount = decodeCosmosSdkDecFromProto(
-                pendingReward.amount
-              )
-                .floor()
-                .toString()
+              // Truncate.
+              pendingReward.amount = pendingReward.amount.split('.')[0]
 
               return {
                 validator: cosmosValidatorToValidator(validator),

--- a/packages/stateful/actions/core/chain_governance/GovernanceVote/Component.tsx
+++ b/packages/stateful/actions/core/chain_governance/GovernanceVote/Component.tsx
@@ -1,4 +1,3 @@
-import { decodeCosmosSdkDecFromProto } from '@cosmjs/stargate'
 import {
   Block,
   Check,
@@ -244,11 +243,7 @@ const VoteFooter = ({
                       {/* You can cast weighted votes and vote on more than one option if you want, so this lists the weight for each one if there are more than one. Typically there will only be one, so no need to show 100% every time. */}
                       {existingVotesLoading.data!.length > 1 && (
                         <p className="text-text-secondary">
-                          {formatPercentOf100(
-                            decodeCosmosSdkDecFromProto(
-                              vote.weight
-                            ).toFloatApproximation() * 100
-                          )}
+                          {formatPercentOf100(Number(vote.weight) * 100)}
                         </p>
                       )}
                     </div>

--- a/packages/stateful/widgets/widgets/VestingPayments/Renderer/TabRenderer/TabRenderer.stories.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/Renderer/TabRenderer/TabRenderer.stories.tsx
@@ -22,6 +22,7 @@ export const Default = Template.bind({})
 Default.args = {
   vestingPaymentsLoading: {
     loading: false,
+    errored: false,
     data: [],
   },
   isMember: true,

--- a/packages/stateful/widgets/widgets/VestingPayments/Renderer/TabRenderer/index.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/Renderer/TabRenderer/index.tsx
@@ -11,7 +11,7 @@ import {
 import { ActionKey, WidgetRendererProps } from '@dao-dao/types'
 import {
   getDaoProposalSinglePrefill,
-  loadableToLoadingData,
+  loadableToLoadingDataWithError,
 } from '@dao-dao/utils'
 
 import { useActionForKey } from '../../../../../actions'
@@ -39,25 +39,25 @@ export const TabRenderer = ({
     return () => clearInterval(interval)
   }, [setRefresh])
 
-  const vestingPaymentsLoading = loadableToLoadingData(
+  const vestingPaymentsLoading = loadableToLoadingDataWithError(
     useCachedLoadable(
       vestingInfosSelector({
         factory,
         chainId,
       })
-    ),
-    []
+    )
   )
 
   const vestingAction = useActionForKey(ActionKey.ManageVesting)
   const vestingActionDefaults = vestingAction?.action.useDefaults()
 
   // Vesting payments that need a slash registered.
-  const vestingPaymentsNeedingSlashRegistration = vestingPaymentsLoading.loading
-    ? []
-    : vestingPaymentsLoading.data.filter(
-        ({ hasUnregisteredSlashes }) => hasUnregisteredSlashes
-      )
+  const vestingPaymentsNeedingSlashRegistration =
+    vestingPaymentsLoading.loading || vestingPaymentsLoading.errored
+      ? []
+      : vestingPaymentsLoading.data.filter(
+          ({ hasUnregisteredSlashes }) => hasUnregisteredSlashes
+        )
 
   return (
     <StatelessTabRenderer

--- a/packages/utils/chain.ts
+++ b/packages/utils/chain.ts
@@ -3,7 +3,7 @@ import { Buffer } from 'buffer'
 import { asset_lists } from '@chain-registry/assets'
 import { AssetList, Chain, IBCInfo } from '@chain-registry/types'
 import { fromBech32, fromHex, toBech32 } from '@cosmjs/encoding'
-import { GasPrice, decodeCosmosSdkDecFromProto } from '@cosmjs/stargate'
+import { GasPrice } from '@cosmjs/stargate'
 import { assets, chains, ibc } from 'chain-registry'
 import RIPEMD160 from 'ripemd160'
 
@@ -65,9 +65,7 @@ export const cosmosValidatorToValidator = ({
     website && (website.startsWith('http') ? website : `https://${website}`),
   details,
   commission: commission?.commissionRates
-    ? decodeCosmosSdkDecFromProto(
-        commission.commissionRates.rate
-      ).toFloatApproximation()
+    ? Number(commission.commissionRates.rate)
     : -1,
   status: bondStatusToJSON(status),
   tokens: Number(tokens),


### PR DESCRIPTION
The manual Decimal decoders are no longer necessary, I think due to the recent Decimal protobuf fix (#1397). Native vesting payments are erroring and thus hiding right now because of this.