### PR TITLE
Fixed existing token label in DAO creation

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -1438,6 +1438,7 @@
     "timeRemaining": "Time remaining",
     "title": "Title",
     "token": "Token",
+    "tokenIdentifier": "Token identifier",
     "tokenSwap": "Token Swap",
     "topAbsolute": "Top {{count}}",
     "topPercent": "Top {{percent}}%",

--- a/packages/stateful/creators/TokenBased/GovernanceConfigurationInput.tsx
+++ b/packages/stateful/creators/TokenBased/GovernanceConfigurationInput.tsx
@@ -515,7 +515,7 @@ export const GovernanceConfigurationInput = ({
         <div className="rounded-lg bg-background-tertiary">
           <div className="flex h-14 flex-row items-center border-b border-border-base p-4">
             <p className="primary-text text-text-body">
-              {t('form.tokenContractAddressTitle')}
+              {t('form.tokenIdentifier')}
             </p>
           </div>
 


### PR DESCRIPTION
Since we use native token denominations now instead of CW20s, the label now reads `Token identifier` instead of `Token contract address`.