### PR TITLE
Various fixes

### DIFF
--- a/packages/stateful/actions/core/dao_governance/UpgradeV1ToV2/index.tsx
+++ b/packages/stateful/actions/core/dao_governance/UpgradeV1ToV2/index.tsx
@@ -283,7 +283,9 @@ export const makeUpgradeV1ToV2Action: ActionMaker<UpgradeV1ToV2Data> = ({
                   info: {
                     admin: { core_module: {} },
                     code_id: codeIds.DaoPreProposeSingle,
-                    label: `DAO_${name}_pre-propose-${DaoProposalSingleAdapter.id}`,
+                    label: `DAO_${name.trim()}_pre-propose-${
+                      DaoProposalSingleAdapter.id
+                    }`,
                     msg: Buffer.from(
                       JSON.stringify({
                         deposit_info: depositInfo

--- a/packages/stateful/actions/core/treasury/CommunityPoolDeposit/index.tsx
+++ b/packages/stateful/actions/core/treasury/CommunityPoolDeposit/index.tsx
@@ -1,4 +1,4 @@
-import { coins } from '@cosmjs/amino'
+import { coins } from '@cosmjs/stargate'
 import { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { constSelector, useRecoilValue } from 'recoil'
@@ -15,7 +15,7 @@ import {
   UseTransformToCosmos,
 } from '@dao-dao/types/actions'
 import {
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   decodePolytoneExecuteMsg,
   isDecodedStargateMsg,
@@ -105,11 +105,6 @@ export const makeCommunityPoolDepositAction: ActionMaker<
           throw new Error(`Unknown token: ${denom}`)
         }
 
-        const microAmount = convertDenomToMicroDenomWithDecimals(
-          amount,
-          token.decimals
-        )
-
         return maybeMakePolytoneExecuteMessage(
           currentChainId,
           chainId,
@@ -118,7 +113,13 @@ export const makeCommunityPoolDepositAction: ActionMaker<
               typeUrl: MsgFundCommunityPool.typeUrl,
               value: MsgFundCommunityPool.fromPartial({
                 depositor: address,
-                amount: coins(microAmount, denom),
+                amount: coins(
+                  convertDenomToMicroDenomStringWithDecimals(
+                    amount,
+                    token.decimals
+                  ),
+                  denom
+                ),
               }),
             },
           })

--- a/packages/stateful/actions/core/treasury/ManageStaking/index.tsx
+++ b/packages/stateful/actions/core/treasury/ManageStaking/index.tsx
@@ -204,11 +204,13 @@ const InnerComponent: ActionComponent = (props) => {
     : {
         loading: false,
         data: coin(
-          balances.data.find(
-            ({ token: { chainId, denomOrAddress } }) =>
-              chainId === nativeToken.chainId &&
-              denomOrAddress === nativeToken.denomOrAddress
-          )?.balance ?? 0,
+          BigInt(
+            balances.data.find(
+              ({ token: { chainId, denomOrAddress } }) =>
+                chainId === nativeToken.chainId &&
+                denomOrAddress === nativeToken.denomOrAddress
+            )?.balance ?? 0
+          ).toString(),
           nativeToken.denomOrAddress
         ),
       }

--- a/packages/stateful/actions/core/treasury/Spend/index.tsx
+++ b/packages/stateful/actions/core/treasury/Spend/index.tsx
@@ -21,7 +21,7 @@ import {
   UseTransformToCosmos,
 } from '@dao-dao/types/actions'
 import {
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   decodePolytoneExecuteMsg,
   getChainForChainId,
@@ -155,9 +155,10 @@ const useTransformToCosmos: UseTransformToCosmos<SpendData> = () => {
         throw new Error(`Unknown token: ${denom}`)
       }
 
-      const amount = BigInt(
-        convertDenomToMicroDenomWithDecimals(_amount, token.decimals)
-      ).toString()
+      const amount = convertDenomToMicroDenomStringWithDecimals(
+        _amount,
+        token.decimals
+      )
 
       let msg: CosmosMsgForEmpty | undefined
       if (toChainId !== fromChainId) {

--- a/packages/stateful/actions/core/treasury/WyndSwap/index.tsx
+++ b/packages/stateful/actions/core/treasury/WyndSwap/index.tsx
@@ -41,6 +41,7 @@ import { ExecuteSwapOperationsMsg } from '@dao-dao/types/contracts/WyndexMultiHo
 import {
   DAO_DAO_DAO_ADDRESS,
   WYND_MULTI_HOP_CONTRACT,
+  convertDenomToMicroDenomStringWithDecimals,
   convertDenomToMicroDenomWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   encodeMessageAsBase64,
@@ -525,16 +526,16 @@ const useTransformToCosmos: UseTransformToCosmos<WyndSwapData> = () => {
         return
       }
 
-      const inAmount = convertDenomToMicroDenomWithDecimals(
+      const inAmount = convertDenomToMicroDenomStringWithDecimals(
         tokenInAmount,
         tokenIn.decimals
-      ).toString()
+      )
       const minOutAmount =
         _minOutAmount !== undefined
-          ? convertDenomToMicroDenomWithDecimals(
+          ? convertDenomToMicroDenomStringWithDecimals(
               _minOutAmount,
               tokenOut.decimals
-            ).toString()
+            )
           : undefined
 
       const msg: ExecuteSwapOperationsMsg = {

--- a/packages/stateful/actions/core/treasury/token_swap/PerformTokenSwap/index.tsx
+++ b/packages/stateful/actions/core/treasury/token_swap/PerformTokenSwap/index.tsx
@@ -18,7 +18,7 @@ import {
   UseTransformToCosmos,
 } from '@dao-dao/types/actions'
 import {
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   encodeMessageAsBase64,
   makeWasmMessage,
   objectMatchesStructure,
@@ -141,10 +141,10 @@ const useTransformToCosmos: UseTransformToCosmos<PerformTokenSwapData> = () => {
       }
 
       // Convert amount to micro amount.
-      const amount = convertDenomToMicroDenomWithDecimals(
+      const amount = convertDenomToMicroDenomStringWithDecimals(
         selfParty.amount,
         selfParty.decimals
-      ).toString()
+      )
 
       return selfParty.type === 'cw20'
         ? makeWasmMessage({

--- a/packages/stateful/components/SelfRelayExecuteModal.tsx
+++ b/packages/stateful/components/SelfRelayExecuteModal.tsx
@@ -403,7 +403,10 @@ export const SelfRelayExecuteModal = ({
                 {
                   bank: {
                     send: {
-                      amount: coins(fundsNeeded, relayer.feeToken.denom),
+                      amount: coins(
+                        BigInt(fundsNeeded).toString(),
+                        relayer.feeToken.denom
+                      ),
                       to_address: relayer.relayerAddress,
                     },
                   },
@@ -472,7 +475,10 @@ export const SelfRelayExecuteModal = ({
               grant: {
                 authorization: SendAuthorization.toProtoMsg(
                   SendAuthorization.fromPartial({
-                    spendLimit: coins(newBalance, relayer.feeToken.denom),
+                    spendLimit: coins(
+                      BigInt(newBalance).toString(),
+                      relayer.feeToken.denom
+                    ),
                   })
                 ),
                 expiration: {
@@ -837,7 +843,7 @@ export const SelfRelayExecuteModal = ({
         await client.sign.sendTokens(
           relayerAddress,
           wallet.address,
-          coins(remainingTokensAfterFee, feeDenom),
+          coins(BigInt(remainingTokensAfterFee).toString(), feeDenom),
           fee
         )
 

--- a/packages/stateful/components/WalletStakingModal.tsx
+++ b/packages/stateful/components/WalletStakingModal.tsx
@@ -19,7 +19,7 @@ import {
 } from '@dao-dao/stateless'
 import {
   CHAIN_GAS_MULTIPLIER,
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   cwMsgToEncodeObject,
   processError,
@@ -110,10 +110,10 @@ export const WalletStakingModal = (props: WalletStakingModalProps) => {
 
     setLoading(true)
     try {
-      const microAmount = convertDenomToMicroDenomWithDecimals(
+      const microAmount = convertDenomToMicroDenomStringWithDecimals(
         amount,
         nativeToken.decimals
-      ).toString()
+      )
 
       if (mode === StakingMode.Stake) {
         await signingCosmWasmClient.signAndBroadcast(

--- a/packages/stateful/components/dao/CreateDaoForm.tsx
+++ b/packages/stateful/components/dao/CreateDaoForm.tsx
@@ -333,7 +333,7 @@ export const InnerCreateDaoForm = ({
       automatically_add_cw721s: true,
       description,
       image_url: imageUrl ?? null,
-      name,
+      name: name.trim(),
       proposal_modules_instantiate_info: proposalModuleInstantiateInfos,
       // Placeholder. Should be replaced by creator's mutate function.
       voting_module_instantiate_info: {

--- a/packages/stateful/components/dao/DaoTokenDepositModal.tsx
+++ b/packages/stateful/components/dao/DaoTokenDepositModal.tsx
@@ -17,7 +17,7 @@ import {
 } from '@dao-dao/stateless'
 import {
   CHAIN_GAS_MULTIPLIER,
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   processError,
 } from '@dao-dao/utils'
@@ -101,10 +101,10 @@ export const DaoTokenDepositModal = ({
 
       setLoading(true)
       try {
-        const microAmount = convertDenomToMicroDenomWithDecimals(
+        const microAmount = convertDenomToMicroDenomStringWithDecimals(
           amount,
           token.decimals
-        ).toString()
+        )
 
         if (token.type === 'native') {
           await signingCosmWasmClient.sendTokens(

--- a/packages/stateful/components/gov/GovProposalStatusAndInfo.tsx
+++ b/packages/stateful/components/gov/GovProposalStatusAndInfo.tsx
@@ -46,7 +46,7 @@ import {
 } from '@dao-dao/types'
 import {
   CHAIN_GAS_MULTIPLIER,
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   formatPercentOf100,
   getGovPath,
@@ -297,7 +297,7 @@ const InnerProposalStatusAndInfo = ({
           proposalId: Long.fromString(proposalId.toString()),
           depositor: walletAddress,
           amount: coins(
-            convertDenomToMicroDenomWithDecimals(
+            convertDenomToMicroDenomStringWithDecimals(
               depositValue,
               depositToken.decimals
             ),

--- a/packages/stateful/creators/MembershipBased/mutate.ts
+++ b/packages/stateful/creators/MembershipBased/mutate.ts
@@ -50,7 +50,7 @@ export const mutate: DaoCreatorMutate<CreatorData> = (
   msg.voting_module_instantiate_info = {
     admin: { core_module: {} },
     code_id: codeIds.DaoVotingCw4,
-    label: `DAO_${name}_${MembershipBasedCreatorId}`,
+    label: `DAO_${name.trim()}_${MembershipBasedCreatorId}`,
     msg: Buffer.from(
       JSON.stringify(votingModuleAdapterInstantiateMsg),
       'utf8'

--- a/packages/stateful/creators/NftBased/mutate.ts
+++ b/packages/stateful/creators/NftBased/mutate.ts
@@ -40,7 +40,7 @@ export const mutate: DaoCreatorMutate<CreatorData> = (
   msg.voting_module_instantiate_info = {
     admin: { core_module: {} },
     code_id: codeIds.DaoVotingCw721Staked,
-    label: `DAO_${daoName}_${NftBasedCreatorId}`,
+    label: `DAO_${daoName.trim()}_${NftBasedCreatorId}`,
     msg: Buffer.from(
       JSON.stringify(votingModuleAdapterInstantiateMsg),
       'utf8'

--- a/packages/stateful/creators/TokenBased/mutate.ts
+++ b/packages/stateful/creators/TokenBased/mutate.ts
@@ -129,7 +129,7 @@ export const mutate: DaoCreatorMutate<CreatorData> = (
   msg.voting_module_instantiate_info = {
     admin: { core_module: {} },
     code_id: codeIds.DaoVotingTokenStaked,
-    label: `DAO_${daoName}_${TokenBasedCreatorId}`,
+    label: `DAO_${daoName.trim()}_${TokenBasedCreatorId}`,
     msg: Buffer.from(
       JSON.stringify(votingModuleAdapterInstantiateMsg),
       'utf8'

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/common/hooks/makeUsePublishProposal.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/common/hooks/makeUsePublishProposal.ts
@@ -291,7 +291,10 @@ export const makeUsePublishProposal =
         // Native token deposit if exists.
         const proposeFunds =
           requiredProposalDeposit && depositInfoNativeTokenDenom
-            ? coins(requiredProposalDeposit, depositInfoNativeTokenDenom)
+            ? coins(
+                BigInt(requiredProposalDeposit).toString(),
+                depositInfoNativeTokenDenom
+              )
             : undefined
 
         // Recreate form data with just the expected fields to remove any fields

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/daoCreation/getInstantiateInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/daoCreation/getInstantiateInfo.ts
@@ -87,7 +87,7 @@ export const getInstantiateInfo: DaoCreationGetInstantiateInfo = (
         info: {
           admin: { core_module: {} },
           code_id: codeIds.DaoPreProposeMultiple,
-          label: `DAO_${name}_pre-propose-${DaoProposalMultipleAdapterId}`,
+          label: `DAO_${name.trim()}_pre-propose-${DaoProposalMultipleAdapterId}`,
           msg: Buffer.from(
             JSON.stringify(preProposeMultipleInstantiateMsg),
             'utf8'
@@ -112,7 +112,7 @@ export const getInstantiateInfo: DaoCreationGetInstantiateInfo = (
   return {
     admin: { core_module: {} },
     code_id: codeIds.DaoProposalMultiple,
-    label: `DAO_${name}_${DaoProposalMultipleAdapterId}`,
+    label: `DAO_${name.trim()}_${DaoProposalMultipleAdapterId}`,
     msg: Buffer.from(JSON.stringify(msg), 'utf8').toString('base64'),
     // TODO(neutron-2.3.0): add back in here and in instantiate schema.
     ...(chainId !== ChainId.NeutronMainnet && {

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/hooks/makeUsePublishProposal.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/hooks/makeUsePublishProposal.ts
@@ -273,7 +273,10 @@ export const makeUsePublishProposal =
         // Native token deposit if exists.
         const proposeFunds =
           requiredProposalDeposit && depositInfoNativeTokenDenom
-            ? coins(requiredProposalDeposit, depositInfoNativeTokenDenom)
+            ? coins(
+                BigInt(requiredProposalDeposit).toString(),
+                depositInfoNativeTokenDenom
+              )
             : undefined
 
         // Recreate form data with just the expected fields to remove any fields

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/daoCreation/getInstantiateInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/daoCreation/getInstantiateInfo.ts
@@ -88,7 +88,7 @@ export const getInstantiateInfo: DaoCreationGetInstantiateInfo<
         info: {
           admin: { core_module: {} },
           code_id: codeIds.DaoPreProposeSingle,
-          label: `DAO_${name}_pre-propose-${DaoProposalSingleAdapterId}`,
+          label: `DAO_${name.trim()}_pre-propose-${DaoProposalSingleAdapterId}`,
           msg: Buffer.from(
             JSON.stringify(preProposeSingleInstantiateMsg),
             'utf8'
@@ -115,7 +115,7 @@ export const getInstantiateInfo: DaoCreationGetInstantiateInfo<
   return {
     admin: { core_module: {} },
     code_id: codeIds.DaoProposalSingle,
-    label: `DAO_${name}_${DaoProposalSingleAdapterId}`,
+    label: `DAO_${name.trim()}_${DaoProposalSingleAdapterId}`,
     msg: Buffer.from(JSON.stringify(msg), 'utf8').toString('base64'),
     // TODO(neutron-2.3.0): add back in here and in instantiate schema.
     ...(chainId !== ChainId.NeutronMainnet && {

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingNativeStaked/actions/Mint/index.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingNativeStaked/actions/Mint/index.tsx
@@ -12,7 +12,7 @@ import {
   UseTransformToCosmos,
 } from '@dao-dao/types/actions'
 import {
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   isDecodedStargateMsg,
   makeStargateMessage,
@@ -37,16 +37,18 @@ const useTransformToCosmos: UseTransformToCosmos<MintData> = () => {
 
   return useCallback(
     (data: MintData) => {
-      const amount = convertDenomToMicroDenomWithDecimals(
-        data.amount,
-        governanceTokenInfo.decimals
-      )
       return makeStargateMessage({
         stargate: {
           typeUrl: MsgMint.typeUrl,
           value: {
             sender: address,
-            amount: coin(amount, governanceTokenAddress),
+            amount: coin(
+              convertDenomToMicroDenomStringWithDecimals(
+                data.amount,
+                governanceTokenInfo.decimals
+              ),
+              governanceTokenAddress
+            ),
           } as MsgMint,
         },
       })

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingNativeStaked/components/StakingModal.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingNativeStaked/components/StakingModal.tsx
@@ -17,6 +17,7 @@ import {
 import { BaseStakingModalProps } from '@dao-dao/types'
 import {
   CHAIN_GAS_MULTIPLIER,
+  convertDenomToMicroDenomStringWithDecimals,
   convertDenomToMicroDenomWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   processError,
@@ -117,7 +118,7 @@ const InnerStakingModal = ({
             CHAIN_GAS_MULTIPLIER,
             undefined,
             coins(
-              convertDenomToMicroDenomWithDecimals(
+              convertDenomToMicroDenomStringWithDecimals(
                 amount,
                 governanceToken.decimals
               ),

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingTokenStaked/actions/Mint/index.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingTokenStaked/actions/Mint/index.tsx
@@ -18,7 +18,7 @@ import {
   UseTransformToCosmos,
 } from '@dao-dao/types/actions'
 import {
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   isDecodedStargateMsg,
   makeStargateMessage,
@@ -44,16 +44,18 @@ const useTransformToCosmos: UseTransformToCosmos<MintData> = () => {
 
   return useCallback(
     (data: MintData) => {
-      const amount = convertDenomToMicroDenomWithDecimals(
-        data.amount,
-        governanceTokenInfo.decimals
-      )
       return makeStargateMessage({
         stargate: {
           typeUrl: MsgMint.typeUrl,
           value: {
             sender: address,
-            amount: coin(amount, governanceTokenAddress),
+            amount: coin(
+              convertDenomToMicroDenomStringWithDecimals(
+                data.amount,
+                governanceTokenInfo.decimals
+              ),
+              governanceTokenAddress
+            ),
           } as MsgMint,
         },
       })

--- a/packages/stateful/voting-module-adapter/adapters/DaoVotingTokenStaked/components/StakingModal.tsx
+++ b/packages/stateful/voting-module-adapter/adapters/DaoVotingTokenStaked/components/StakingModal.tsx
@@ -17,6 +17,7 @@ import {
 import { BaseStakingModalProps } from '@dao-dao/types'
 import {
   CHAIN_GAS_MULTIPLIER,
+  convertDenomToMicroDenomStringWithDecimals,
   convertDenomToMicroDenomWithDecimals,
   convertMicroDenomToDenomWithDecimals,
   processError,
@@ -117,7 +118,7 @@ const InnerStakingModal = ({
             CHAIN_GAS_MULTIPLIER,
             undefined,
             coins(
-              convertDenomToMicroDenomWithDecimals(
+              convertDenomToMicroDenomStringWithDecimals(
                 amount,
                 governanceToken.decimals
               ),

--- a/packages/stateful/widgets/widgets/VestingPayments/actions/ManageVesting/index.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/actions/ManageVesting/index.tsx
@@ -35,7 +35,7 @@ import {
 } from '@dao-dao/types/contracts/CwPayrollFactory'
 import { InstantiateMsg as VestingInstantiateMsg } from '@dao-dao/types/contracts/CwVesting'
 import {
-  convertDenomToMicroDenomWithDecimals,
+  convertDenomToMicroDenomStringWithDecimals,
   convertDurationWithUnitsToSeconds,
   convertMicroDenomToDenomWithDecimals,
   convertSecondsToDurationWithUnits,
@@ -518,10 +518,10 @@ export const makeManageVestingActionMaker = ({
               throw new Error(`Unknown token: ${begin.denomOrAddress}`)
             }
 
-            const amount = convertDenomToMicroDenomWithDecimals(
+            const amount = convertDenomToMicroDenomStringWithDecimals(
               begin.amount,
               token.decimals
-            ).toString()
+            )
 
             const instantiateMsg: VestingInstantiateMsg = {
               denom:

--- a/packages/stateful/widgets/widgets/WyndDeposit/WyndDepositRenderer.tsx
+++ b/packages/stateful/widgets/widgets/WyndDeposit/WyndDepositRenderer.tsx
@@ -309,7 +309,7 @@ export const WyndDepositRenderer = ({
             msg,
             CHAIN_GAS_MULTIPLIER,
             undefined,
-            coins(requiredInput, token.denomOrAddress)
+            coins(BigInt(requiredInput).toString(), token.denomOrAddress)
           )
         } else {
           // Cw20

--- a/packages/stateless/pages/MeBalances.tsx
+++ b/packages/stateless/pages/MeBalances.tsx
@@ -127,7 +127,7 @@ export const MeBalances = <T extends TokenCardInfo, N extends NftCardInfo>({
             <div className="space-y-1">
               {visibleBalances.map((props, index) => (
                 <TokenLine
-                  key={props.token.denomOrAddress}
+                  key={props.token.denomOrAddress + index}
                   transparentBackground={index % 2 !== 0}
                   {...(props as T)}
                 />
@@ -159,7 +159,7 @@ export const MeBalances = <T extends TokenCardInfo, N extends NftCardInfo>({
             <div className={clsx('space-y-1', !showingHidden && 'hidden')}>
               {hiddenBalances.map((props, index) => (
                 <TokenLine
-                  key={props.token.denomOrAddress}
+                  key={props.token.denomOrAddress + index}
                   transparentBackground={index % 2 !== 0}
                   {...(props as T)}
                 />

--- a/packages/utils/conversion.ts
+++ b/packages/utils/conversion.ts
@@ -38,6 +38,12 @@ export function convertDenomToMicroDenomWithDecimals(
   return isNaN(amount) ? 0 : amount
 }
 
+// Using BigInt.toString() ensures the value is not abbreviated. The
+// Number.toString() function abbreviates large numbers like 1e20.
+export const convertDenomToMicroDenomStringWithDecimals = (
+  ...params: Parameters<typeof convertDenomToMicroDenomWithDecimals>
+) => BigInt(convertDenomToMicroDenomWithDecimals(...params)).toString()
+
 export function convertFromMicroDenom(denom: string) {
   return denom?.substring(1).toUpperCase()
 }


### PR DESCRIPTION
This fixes coin formatting when working with large numbers of decimals. Some coins have 18 decimals, which was causing problems when using the `coin` or `coins` function with raw numbers. They need to be encoded as strings instead.

This fixes the DAO name not being trimmed, which causes problems on some chains when a smart contract label has a trailing space.

This fixes the Me page crashing when tokens don't load from any one chain.