### PR TITLE
Support Neutron v0.2.1

### DIFF
--- a/packages/stateful/actions/core/dao_appearance/ManageWidgets/index.tsx
+++ b/packages/stateful/actions/core/dao_appearance/ManageWidgets/index.tsx
@@ -71,7 +71,8 @@ export const makeManageWidgetsAction: ActionMaker<ManageWidgetsData> = ({
   // V1 DAOs and V2-alpha DAOs use a value key of `addr`, the rest use `value`.
   const valueKey =
     context.info.coreVersion === ContractVersion.V1 ||
-    context.info.coreVersion === ContractVersion.V2Alpha
+    context.info.coreVersion === ContractVersion.V2Alpha ||
+    context.info.coreVersion === ContractVersion.NeutronV021
       ? 'addr'
       : 'value'
 

--- a/packages/stateful/actions/core/dao_governance/ManageStorageItems/index.tsx
+++ b/packages/stateful/actions/core/dao_governance/ManageStorageItems/index.tsx
@@ -63,7 +63,8 @@ export const makeManageStorageItemsAction: ActionMaker<
   // V1 DAOs and V2-alpha DAOs use a value key of `addr`, V2-beta uses `value`.
   const valueKey =
     context.info.coreVersion === ContractVersion.V1 ||
-    context.info.coreVersion === ContractVersion.V2Alpha
+    context.info.coreVersion === ContractVersion.V2Alpha ||
+    context.info.coreVersion === ContractVersion.NeutronV021
       ? 'addr'
       : 'value'
 

--- a/packages/stateful/actions/core/nfts/ManageCw721/index.tsx
+++ b/packages/stateful/actions/core/nfts/ManageCw721/index.tsx
@@ -191,7 +191,8 @@ export const makeManageCw721Action: ActionMaker<ManageCw721Data> = ({
   // V1 DAOs and V2-alpha DAOs use a value key of `addr`, V2-beta uses `value`.
   const storageItemValueKey =
     context.info.coreVersion === ContractVersion.V1 ||
-    context.info.coreVersion === ContractVersion.V2Alpha
+    context.info.coreVersion === ContractVersion.V2Alpha ||
+    context.info.coreVersion === ContractVersion.NeutronV021
       ? 'addr'
       : 'value'
 

--- a/packages/types/chain.ts
+++ b/packages/types/chain.ts
@@ -65,6 +65,10 @@ export enum ContractVersion {
   V210 = '2.1.0',
   // https://github.com/DA0-DA0/dao-contracts/releases/tag/v2.3.0
   V230 = '2.3.0',
+
+  // Neutron-specific versions.
+  // https://github.com/neutron-org/neutron-dao/releases/tag/v0.5.0
+  NeutronV021 = '0.2.1',
 }
 
 export enum ChainId {


### PR DESCRIPTION
Neutron DAO's recent upgrade broke UI support because they changed the version string. This PR adds the version so the UI recognizes and displays it.

<img width="611" alt="Screenshot 2023-11-08 at 23 30 14" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/3ea64c76-05bf-454b-8e46-f129afd18e2e">
<img width="495" alt="Screenshot 2023-11-08 at 23 30 41" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/3924f153-993b-4064-8f7b-b168334b2ad0">
