### PR TITLE
Fixed arrow position slightly off

### DIFF
--- a/packages/stateless/components/proposal/ProgressBar.tsx
+++ b/packages/stateless/components/proposal/ProgressBar.tsx
@@ -55,12 +55,13 @@ export const ProgressBar = ({
         </div>
       ))}
     </div>
+
     {caretPosition !== undefined && (
       <Tooltip title={caretTooltip}>
         <ArrowDropUp
           className="absolute bottom-[-0.825rem] z-10 !h-6 !w-6 text-icon-primary"
           style={{
-            left: `${caretPosition}%`,
+            left: `calc(${caretPosition}% - 0.75rem)`,
           }}
         />
       </Tooltip>


### PR DESCRIPTION
Resolves #1448 

This fixes the threshold and quorum setting indicator arrow off by a few pixels due to its width.