### PR TITLE
Fix legacy to support Tendermint 37

### DIFF
--- a/apps/dapp/package.json
+++ b/apps/dapp/package.json
@@ -15,10 +15,10 @@
     "ts:watch": "ts --watch"
   },
   "dependencies": {
-    "@cosmjs/cosmwasm-stargate": "^0.28.1",
-    "@cosmjs/encoding": "^0.28.1",
-    "@cosmjs/proto-signing": "^0.28.1",
-    "@cosmjs/stargate": "^0.28.1",
+    "@cosmjs/cosmwasm-stargate": "^0.31.3",
+    "@cosmjs/encoding": "^0.31.3",
+    "@cosmjs/proto-signing": "^0.31.3",
+    "@cosmjs/stargate": "^0.31.3",
     "@dao-dao/icons": "*",
     "@dao-dao/types": "^0.0.8",
     "@dao-dao/ui": "*",

--- a/apps/dapp/selectors/contracts.ts
+++ b/apps/dapp/selectors/contracts.ts
@@ -86,9 +86,9 @@ export const contractInstantiateTime = selectorFamily<Date | undefined, string>(
           return undefined
         }
 
-        const events = await client.searchTx({
-          tags: [{ key: 'instantiate._contract_address', value: address }],
-        })
+        const events = await client.searchTx([
+          { key: 'instantiate._contract_address', value: address },
+        ])
         if (events.length == 0) {
           // Failed to locate the instantiate transaction. This happens if the
           // RPC node doesn't have historical data this far back.

--- a/apps/dapp/selectors/proposals.ts
+++ b/apps/dapp/selectors/proposals.ts
@@ -113,13 +113,11 @@ export const proposalStartBlockSelector = selectorFamily<
         return 0
       }
 
-      const events = await client.searchTx({
-        tags: [
-          { key: 'wasm._contract_address', value: contractAddress },
-          { key: 'wasm.proposal_id', value: proposalId.toString() },
-          { key: 'wasm.action', value: 'propose' },
-        ],
-      })
+      const events = await client.searchTx([
+        { key: 'wasm._contract_address', value: contractAddress },
+        { key: 'wasm.proposal_id', value: proposalId.toString() },
+        { key: 'wasm.action', value: 'propose' },
+      ])
 
       if (events.length != 1) {
         return 0
@@ -172,13 +170,11 @@ export const proposalExecutionTXHashSelector = selectorFamily<
       // No TX Hash if proposal not yet executed.
       if (!client || proposal?.status !== 'executed') return null
 
-      const events = await client.searchTx({
-        tags: [
-          { key: 'wasm._contract_address', value: contractAddress },
-          { key: 'wasm.proposal_id', value: proposalId.toString() },
-          { key: 'wasm.action', value: 'execute' },
-        ],
-      })
+      const events = await client.searchTx([
+        { key: 'wasm._contract_address', value: contractAddress },
+        { key: 'wasm.proposal_id', value: proposalId.toString() },
+        { key: 'wasm.action', value: 'execute' },
+      ])
 
       if (events.length > 1) {
         console.error('More than one execution', events)

--- a/apps/dapp/selectors/treasury.ts
+++ b/apps/dapp/selectors/treasury.ts
@@ -97,9 +97,9 @@ export const transactions = selectorFamily({
     (address: string) =>
     async ({ get }) => {
       const client = get(cosmWasmClientSelector)
-      const response = (await client.searchTx({
-        sentFromOrTo: address,
-      })) as IndexedTx[]
+      const response = (await client.searchTx(
+        `message.module='bank' AND (transfer.sender='${address}' OR transfer.recipient='${address}')`
+      )) as IndexedTx[]
       return response
     },
 })

--- a/apps/sda/package.json
+++ b/apps/sda/package.json
@@ -15,10 +15,10 @@
     "ts:watch": "ts --watch"
   },
   "dependencies": {
-    "@cosmjs/cosmwasm-stargate": "^0.28.1",
-    "@cosmjs/encoding": "^0.28.1",
-    "@cosmjs/proto-signing": "^0.28.1",
-    "@cosmjs/stargate": "^0.28.1",
+    "@cosmjs/cosmwasm-stargate": "^0.31.3",
+    "@cosmjs/encoding": "^0.31.3",
+    "@cosmjs/proto-signing": "^0.31.3",
+    "@cosmjs/stargate": "^0.31.3",
     "@dao-dao/icons": "*",
     "@dao-dao/state": "*",
     "@dao-dao/types": "^0.0.8",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -10,7 +10,7 @@
     "@keplr-wallet/stores": "^0.10.3",
     "@walletconnect/browser-utils": "^1.7.8",
     "@walletconnect/client": "^1.7.8",
-    "cosmodal": "https://github.com/NoahSaso/cosmodal#7abc9d43f31693f56d3809dc7a87eeedce3c3ca2",
+    "cosmodal": "https://github.com/NoahSaso/cosmodal#a3db5393bedf755613f76c5adff0a3de126df09d",
     "react": "^18.1.0",
     "recoil": "^0.7.2"
   },

--- a/packages/state/recoil/selectors/proposal.ts
+++ b/packages/state/recoil/selectors/proposal.ts
@@ -20,13 +20,11 @@ export const proposalExecutionTXHashSelector = selectorFamily<
       // No TX Hash if proposal not yet executed.
       if (!client || proposal?.proposal.status !== Status.Executed) return
 
-      const events = await client.searchTx({
-        tags: [
-          { key: 'wasm._contract_address', value: contractAddress },
-          { key: 'wasm.proposal_id', value: proposalId.toString() },
-          { key: 'wasm.action', value: 'execute' },
-        ],
-      })
+      const events = await client.searchTx([
+        { key: 'wasm._contract_address', value: contractAddress },
+        { key: 'wasm.proposal_id', value: proposalId.toString() },
+        { key: 'wasm.action', value: 'execute' },
+      ])
 
       if (events.length > 1) {
         console.error('More than one execution', events)

--- a/packages/utils/messages.ts
+++ b/packages/utils/messages.ts
@@ -69,39 +69,31 @@ function isBinaryType(msgType?: WasmMsgType): boolean {
 export function decodeMessages(
   msgs: ProposalResponse['msgs']
 ): { [key: string]: any }[] {
-  const decodedMessageArray: any[] = []
-  const proposalMsgs = Object.values(msgs)
-  for (const msgObj of proposalMsgs) {
-    if (isWasmMsg(msgObj)) {
-      const msgType = getWasmMsgType(msgObj.wasm)
+  return msgs.map((msg) => {
+    if (isWasmMsg(msg)) {
+      const msgType = getWasmMsgType(msg.wasm)
       if (msgType && isBinaryType(msgType)) {
-        const base64Msg = (msgObj.wasm as any)[msgType]
-        if (base64Msg) {
-          const msg = parseEncodedMessage(base64Msg.msg)
-          if (msg) {
-            decodedMessageArray.push({
-              ...msgObj,
+        const base64MsgContainer = (msg.wasm as any)[msgType]
+        if (base64MsgContainer && 'msg' in base64MsgContainer) {
+          const parsedMsg = parseEncodedMessage(base64MsgContainer.msg)
+          if (parsedMsg) {
+            return {
+              ...msg,
               wasm: {
-                ...msgObj.wasm,
+                ...msg.wasm,
                 [msgType]: {
-                  ...base64Msg,
-                  msg,
+                  ...base64MsgContainer,
+                  msg: parsedMsg,
                 },
               },
-            })
+            }
           }
         }
       }
-    } else {
-      decodedMessageArray.push(msgObj)
     }
-  }
 
-  const decodedMessages = decodedMessageArray.length
-    ? decodedMessageArray
-    : proposalMsgs
-
-  return decodedMessages
+    return msg
+  })
 }
 
 export function decodedMessagesString(msgs: ProposalResponse['msgs']): string {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,6 +14,6 @@
   "prettier": "@dao-dao/config/prettier",
   "license": "MIT",
   "dependencies": {
-    "cosmodal": "https://github.com/NoahSaso/cosmodal#7abc9d43f31693f56d3809dc7a87eeedce3c3ca2"
+    "cosmodal": "https://github.com/NoahSaso/cosmodal#a3db5393bedf755613f76c5adff0a3de126df09d"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,16 +1288,6 @@
     "@cosmjs/math" "0.27.1"
     "@cosmjs/utils" "0.27.1"
 
-"@cosmjs/amino@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.28.2.tgz#a1bebd9d86c0da933873315a53e107440582141a"
-  integrity sha512-1VpbaigVVXYO84FkZxWmYzQDE4Va5JDxtnnaOZ2+dQ/y6+B+c8KRvn0cS429//8ngZCR2JhcPyNGSzNvljB/Hw==
-  dependencies:
-    "@cosmjs/crypto" "0.28.2"
-    "@cosmjs/encoding" "0.28.2"
-    "@cosmjs/math" "0.28.2"
-    "@cosmjs/utils" "0.28.2"
-
 "@cosmjs/amino@0.28.4":
   version "0.28.4"
   resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.28.4.tgz#9315f6876dba80148cf715ced44d1dc7a9b68b94"
@@ -1308,23 +1298,32 @@
     "@cosmjs/math" "0.28.4"
     "@cosmjs/utils" "0.28.4"
 
-"@cosmjs/cosmwasm-stargate@^0.28.1":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.28.2.tgz#df61ecc1d49a9ca342983c10398c72f448fc4dff"
-  integrity sha512-/SzBjS4PuX3WpKM2XdAvwrIYbSsUs6ehGKaJkObBZGx4ea+R7fis154MtJRV4lX+SZVnYszZEqR8zku8dHmw4g==
+"@cosmjs/amino@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/amino/-/amino-0.31.3.tgz#0f4aa6bd68331c71bd51b187fa64f00eb075db0a"
+  integrity sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==
   dependencies:
-    "@cosmjs/amino" "0.28.2"
-    "@cosmjs/crypto" "0.28.2"
-    "@cosmjs/encoding" "0.28.2"
-    "@cosmjs/math" "0.28.2"
-    "@cosmjs/proto-signing" "0.28.2"
-    "@cosmjs/stargate" "0.28.2"
-    "@cosmjs/tendermint-rpc" "0.28.2"
-    "@cosmjs/utils" "0.28.2"
-    cosmjs-types "^0.4.0"
+    "@cosmjs/crypto" "^0.31.3"
+    "@cosmjs/encoding" "^0.31.3"
+    "@cosmjs/math" "^0.31.3"
+    "@cosmjs/utils" "^0.31.3"
+
+"@cosmjs/cosmwasm-stargate@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.31.3.tgz#13066822f111832d57c2c5acc9e697ed389713f8"
+  integrity sha512-Uv9TmCn3650gdFeZm7SEfUZF3uX3lfJfFhXOk6I2ZLr/FrKximnlb+vwAfZaZnWYvlA7qrKtHIjeRNHvT23zcw==
+  dependencies:
+    "@cosmjs/amino" "^0.31.3"
+    "@cosmjs/crypto" "^0.31.3"
+    "@cosmjs/encoding" "^0.31.3"
+    "@cosmjs/math" "^0.31.3"
+    "@cosmjs/proto-signing" "^0.31.3"
+    "@cosmjs/stargate" "^0.31.3"
+    "@cosmjs/tendermint-rpc" "^0.31.3"
+    "@cosmjs/utils" "^0.31.3"
+    cosmjs-types "^0.8.0"
     long "^4.0.0"
     pako "^2.0.2"
-    protobufjs "~6.10.2"
 
 "@cosmjs/crypto@0.27.1":
   version "0.27.1"
@@ -1341,19 +1340,6 @@
     libsodium-wrappers "^0.7.6"
     ripemd160 "^2.0.2"
     sha.js "^2.4.11"
-
-"@cosmjs/crypto@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.28.2.tgz#a6d8cd1dc769499d1861e34efe5d8952d52eb550"
-  integrity sha512-paWuG1pgzG8fSvAPnJbQwPTAqpLuBDBGNFI5/2tkTEARxLtOivK2Iy6u0rFQX9GOPJ/EYu0JCKsUbtAPWuDu7Q==
-  dependencies:
-    "@cosmjs/encoding" "0.28.2"
-    "@cosmjs/math" "0.28.2"
-    "@cosmjs/utils" "0.28.2"
-    "@noble/hashes" "^1"
-    bn.js "^5.2.0"
-    elliptic "^6.5.3"
-    libsodium-wrappers "^0.7.6"
 
 "@cosmjs/crypto@0.28.4":
   version "0.28.4"
@@ -1386,19 +1372,23 @@
     sha.js "^2.4.11"
     unorm "^1.5.0"
 
+"@cosmjs/crypto@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/crypto/-/crypto-0.31.3.tgz#c752cb6d682fdc735dcb45a2519f89c56ba16c26"
+  integrity sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==
+  dependencies:
+    "@cosmjs/encoding" "^0.31.3"
+    "@cosmjs/math" "^0.31.3"
+    "@cosmjs/utils" "^0.31.3"
+    "@noble/hashes" "^1"
+    bn.js "^5.2.0"
+    elliptic "^6.5.4"
+    libsodium-wrappers-sumo "^0.7.11"
+
 "@cosmjs/encoding@0.27.1":
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.27.1.tgz#3cd5bc0af743485eb2578cdb08cfa84c86d610e1"
   integrity sha512-rayLsA0ojHeniaRfWWcqSsrE/T1rl1gl0OXVNtXlPwLJifKBeLEefGbOUiAQaT0wgJ8VNGBazVtAZBpJidfDhw==
-  dependencies:
-    base64-js "^1.3.0"
-    bech32 "^1.1.4"
-    readonly-date "^1.0.0"
-
-"@cosmjs/encoding@0.28.2", "@cosmjs/encoding@^0.28.1":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.28.2.tgz#1608c3fcc23cd1f7a309cfb71626177eea9b6bca"
-  integrity sha512-45kglsimqLtVjlu5tOHJlZYacwzLv0nnMKqG5/snPIbNER1YkmYhlQGQTXBQ/LGaXub/X45AK6OzWK9cUHgp8w==
   dependencies:
     base64-js "^1.3.0"
     bech32 "^1.1.4"
@@ -1431,13 +1421,14 @@
     bech32 "^1.1.4"
     readonly-date "^1.0.0"
 
-"@cosmjs/json-rpc@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/json-rpc/-/json-rpc-0.28.2.tgz#7cd5ab249c7634354d4d585503c7ec2f8c5738b3"
-  integrity sha512-6I8Kzc8QtTaazlybHwvHJ/RQtzerUgYfO29B/m8ntWZZMk2PFUAdKZlv0z2HTM6jTrIzrfVA0Po8+9I9q4W0Tg==
+"@cosmjs/encoding@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/encoding/-/encoding-0.31.3.tgz#2519d9c9ae48368424971f253775c4580b54c5aa"
+  integrity sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==
   dependencies:
-    "@cosmjs/stream" "0.28.2"
-    xstream "^11.14.0"
+    base64-js "^1.3.0"
+    bech32 "^1.1.4"
+    readonly-date "^1.0.0"
 
 "@cosmjs/json-rpc@^0.24.1":
   version "0.24.1"
@@ -1445,6 +1436,14 @@
   integrity sha512-kZ6473O81TRMyP1XomnvgIny3nBY//JngnpGJSDZyYjlIm6t5BhLqCuZJiuMOc937RyHKmqUQaOUtDA7X0TKYg==
   dependencies:
     "@cosmjs/stream" "^0.24.1"
+    xstream "^11.14.0"
+
+"@cosmjs/json-rpc@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/json-rpc/-/json-rpc-0.31.3.tgz#11e5cf0f6d9ab426dff470bb8d68d5d31cd6ab13"
+  integrity sha512-7LVYerXjnm69qqYR3uA6LGCrBW2EO5/F7lfJxAmY+iII2C7xO3a0vAjMSt5zBBh29PXrJVS6c2qRP22W1Le2Wg==
+  dependencies:
+    "@cosmjs/stream" "^0.31.3"
     xstream "^11.14.0"
 
 "@cosmjs/launchpad@^0.24.0-alpha.25", "@cosmjs/launchpad@^0.24.1":
@@ -1479,13 +1478,6 @@
   dependencies:
     bn.js "^5.2.0"
 
-"@cosmjs/math@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.28.2.tgz#319398afe1e7c6e65e17ef90d5647ebc35f96f96"
-  integrity sha512-u2X6g00HX5VdasI8PijgPb7md/v9outjND/PIuBpVadjf8HJxPKjrsYj346yfLdnA9gWBflsxw1nmu+0UU4Fng==
-  dependencies:
-    bn.js "^5.2.0"
-
 "@cosmjs/math@0.28.4":
   version "0.28.4"
   resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.28.4.tgz#ddc35b69fa1ffeaf5928f70d4c2faf9284627d84"
@@ -1507,19 +1499,12 @@
   dependencies:
     bn.js "^4.11.8"
 
-"@cosmjs/proto-signing@0.28.2", "@cosmjs/proto-signing@^0.28.1":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/proto-signing/-/proto-signing-0.28.2.tgz#ab750581e12fffe3f9d4f2e546578e6099336e05"
-  integrity sha512-/XnffkWeYIHsJJ3MrHKOxSN+g1PBcHcpZx7ddHF/r09Zg3A8lLeEuDWCBuZ1tvMGbtjKMoP3nbkIQdn+Os8iIg==
+"@cosmjs/math@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/math/-/math-0.31.3.tgz#767f7263d12ba1b9ed2f01f68d857597839fd957"
+  integrity sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==
   dependencies:
-    "@cosmjs/amino" "0.28.2"
-    "@cosmjs/crypto" "0.28.2"
-    "@cosmjs/encoding" "0.28.2"
-    "@cosmjs/math" "0.28.2"
-    "@cosmjs/utils" "0.28.2"
-    cosmjs-types "^0.4.0"
-    long "^4.0.0"
-    protobufjs "~6.10.2"
+    bn.js "^5.2.0"
 
 "@cosmjs/proto-signing@^0.24.0-alpha.25":
   version "0.24.1"
@@ -1544,15 +1529,18 @@
     long "^4.0.0"
     protobufjs "~6.10.2"
 
-"@cosmjs/socket@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/socket/-/socket-0.28.2.tgz#a55b7db886bfe54aa7af76498266955911e9f535"
-  integrity sha512-AGq58qFVWvufzb4hBiPb51ZrpT8yNb+at+m/tRwpLZ8u1prN9VQ7hogSXwQJsHPOzNxtyO80DVHlGGmd9wonXg==
+"@cosmjs/proto-signing@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/proto-signing/-/proto-signing-0.31.3.tgz#20440b7b96fb2cd924256a10e656fd8d4481cdcd"
+  integrity sha512-24+10/cGl6lLS4VCrGTCJeDRPQTn1K5JfknzXzDIHOx8THR31JxA7/HV5eWGHqWgAbudA7ccdSvEK08lEHHtLA==
   dependencies:
-    "@cosmjs/stream" "0.28.2"
-    isomorphic-ws "^4.0.1"
-    ws "^7"
-    xstream "^11.14.0"
+    "@cosmjs/amino" "^0.31.3"
+    "@cosmjs/crypto" "^0.31.3"
+    "@cosmjs/encoding" "^0.31.3"
+    "@cosmjs/math" "^0.31.3"
+    "@cosmjs/utils" "^0.31.3"
+    cosmjs-types "^0.8.0"
+    long "^4.0.0"
 
 "@cosmjs/socket@^0.24.1":
   version "0.24.1"
@@ -1564,29 +1552,32 @@
     ws "^6.2.0"
     xstream "^11.14.0"
 
-"@cosmjs/stargate@0.28.2", "@cosmjs/stargate@^0.28.1":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/stargate/-/stargate-0.28.2.tgz#fe531f7771b980f7b6696bf1cd45fc3dc19fdb7e"
-  integrity sha512-3c6Gu0OsocmvfKB6EC8DRD6To1IAVcgRYAQQ2kleSx/8dZAr5/x2vxwE2O1gqJhlwtEG+13+jzh39bX1uv8KwQ==
+"@cosmjs/socket@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/socket/-/socket-0.31.3.tgz#52086380f4de2fc3514b90b0484b4b1c4c50e39e"
+  integrity sha512-aqrDGGi7os/hsz5p++avI4L0ZushJ+ItnzbqA7C6hamFSCJwgOkXaOUs+K9hXZdX4rhY7rXO4PH9IH8q09JkTw==
   dependencies:
-    "@confio/ics23" "^0.6.8"
-    "@cosmjs/amino" "0.28.2"
-    "@cosmjs/encoding" "0.28.2"
-    "@cosmjs/math" "0.28.2"
-    "@cosmjs/proto-signing" "0.28.2"
-    "@cosmjs/stream" "0.28.2"
-    "@cosmjs/tendermint-rpc" "0.28.2"
-    "@cosmjs/utils" "0.28.2"
-    cosmjs-types "^0.4.0"
-    long "^4.0.0"
-    protobufjs "~6.10.2"
+    "@cosmjs/stream" "^0.31.3"
+    isomorphic-ws "^4.0.1"
+    ws "^7"
     xstream "^11.14.0"
 
-"@cosmjs/stream@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/stream/-/stream-0.28.2.tgz#3be1aaa33f71038d509a56fc8184b0e13c6b8734"
-  integrity sha512-qyIBOsWYqgEzcf3IujRvoz7/PWez1qMvj3spt3NGEMDlI+Eo7tpLHJBLdZHHFCXJUrii59SC297iz5isHIikpA==
+"@cosmjs/stargate@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/stargate/-/stargate-0.31.3.tgz#a2b38e398097a00f897dbd8f02d4d347d8fed818"
+  integrity sha512-53NxnzmB9FfXpG4KjOUAYAvWLYKdEmZKsutcat/u2BrDXNZ7BN8jim/ENcpwXfs9/Og0K24lEIdvA4gsq3JDQw==
   dependencies:
+    "@confio/ics23" "^0.6.8"
+    "@cosmjs/amino" "^0.31.3"
+    "@cosmjs/encoding" "^0.31.3"
+    "@cosmjs/math" "^0.31.3"
+    "@cosmjs/proto-signing" "^0.31.3"
+    "@cosmjs/stream" "^0.31.3"
+    "@cosmjs/tendermint-rpc" "^0.31.3"
+    "@cosmjs/utils" "^0.31.3"
+    cosmjs-types "^0.8.0"
+    long "^4.0.0"
+    protobufjs "~6.11.3"
     xstream "^11.14.0"
 
 "@cosmjs/stream@^0.24.1":
@@ -1596,20 +1587,11 @@
   dependencies:
     xstream "^11.14.0"
 
-"@cosmjs/tendermint-rpc@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.28.2.tgz#7f54b8dfde27f64ffee6378764d17149caaa6b3e"
-  integrity sha512-+EwuOZNr43g0UHjEARGmWOdUEvyqMsPOnFCtyE9I5tvXF6HmL9BuxZ2AJwWmctF50+6t/LUy+ubqfKpgZ3QC9A==
+"@cosmjs/stream@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/stream/-/stream-0.31.3.tgz#53428fd62487ec08fc3886a50a3feeb8b2af2e66"
+  integrity sha512-8keYyI7X0RjsLyVcZuBeNjSv5FA4IHwbFKx7H60NHFXszN8/MvXL6aZbNIvxtcIHHsW7K9QSQos26eoEWlAd+w==
   dependencies:
-    "@cosmjs/crypto" "0.28.2"
-    "@cosmjs/encoding" "0.28.2"
-    "@cosmjs/json-rpc" "0.28.2"
-    "@cosmjs/math" "0.28.2"
-    "@cosmjs/socket" "0.28.2"
-    "@cosmjs/stream" "0.28.2"
-    "@cosmjs/utils" "0.28.2"
-    axios "^0.21.2"
-    readonly-date "^1.0.0"
     xstream "^11.14.0"
 
 "@cosmjs/tendermint-rpc@^0.24.1":
@@ -1627,15 +1609,26 @@
     readonly-date "^1.0.0"
     xstream "^11.14.0"
 
+"@cosmjs/tendermint-rpc@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.3.tgz#d1a2bc5b3c98743631c9b55888589d352403c9b3"
+  integrity sha512-s3TiWkPCW4QceTQjpYqn4xttUJH36mTPqplMl+qyocdqk5+X5mergzExU/pHZRWQ4pbby8bnR7kMvG4OC1aZ8g==
+  dependencies:
+    "@cosmjs/crypto" "^0.31.3"
+    "@cosmjs/encoding" "^0.31.3"
+    "@cosmjs/json-rpc" "^0.31.3"
+    "@cosmjs/math" "^0.31.3"
+    "@cosmjs/socket" "^0.31.3"
+    "@cosmjs/stream" "^0.31.3"
+    "@cosmjs/utils" "^0.31.3"
+    axios "^0.21.2"
+    readonly-date "^1.0.0"
+    xstream "^11.14.0"
+
 "@cosmjs/utils@0.27.1":
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.27.1.tgz#1c8efde17256346ef142a3bd15158ee4055470e2"
   integrity sha512-VG7QPDiMUzVPxRdJahDV8PXxVdnuAHiIuG56hldV4yPnOz/si/DLNd7VAUUA5923b6jS1Hhev0Hr6AhEkcxBMg==
-
-"@cosmjs/utils@0.28.2":
-  version "0.28.2"
-  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.28.2.tgz#9da0fbb78ba649fc1dfaafdab0f5bb6e0f9a447b"
-  integrity sha512-2/1UeE4djz6tt4B0j3YQS+k7BYoMkblfRa3+t3lht9N5/yj05ZxVUiP7hD0lQtNmeCSQgFFmtX6zXWPes+aKQg==
 
 "@cosmjs/utils@0.28.4":
   version "0.28.4"
@@ -1651,6 +1644,11 @@
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.24.1.tgz#0adfefe63b7f17222bc2bc12f71296f35e7ad378"
   integrity sha512-VA3WFx1lMFb7esp9BqHWkDgMvHoA3D9w+uDRvWhVRpUpDc7RYHxMbWExASjz+gNblTCg556WJGzF64tXnf9tdQ==
+
+"@cosmjs/utils@^0.31.3":
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.31.3.tgz#f97bbfda35ad69e80cd5c7fe0a270cbda16db1ed"
+  integrity sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA==
 
 "@dao-dao/types@^0.0.8":
   version "0.0.8"
@@ -6799,6 +6797,14 @@ cosmjs-types@^0.4.0:
     long "^4.0.0"
     protobufjs "~6.11.2"
 
+cosmjs-types@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/cosmjs-types/-/cosmjs-types-0.8.0.tgz#2ed78f3e990f770229726f95f3ef5bf9e2b6859b"
+  integrity sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "~6.11.2"
+
 "cosmodal@https://github.com/NoahSaso/cosmodal#7abc9d43f31693f56d3809dc7a87eeedce3c3ca2":
   version "0.3.7"
   resolved "https://github.com/NoahSaso/cosmodal#7abc9d43f31693f56d3809dc7a87eeedce3c3ca2"
@@ -10701,6 +10707,18 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+libsodium-sumo@^0.7.13:
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz#533b97d2be44b1277e59c1f9f60805978ac5542d"
+  integrity sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ==
+
+libsodium-wrappers-sumo@^0.7.11:
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.13.tgz#a33aea845a0bb56db067548f04feba28c730ab8e"
+  integrity sha512-lz4YdplzDRh6AhnLGF2Dj2IUj94xRN6Bh8T0HLNwzYGwPehQJX6c7iYVrFUPZ3QqxE0bqC+K0IIqqZJYWumwSQ==
+  dependencies:
+    libsodium-sumo "^0.7.13"
+
 libsodium-wrappers@^0.7.6:
   version "0.7.10"
   resolved "https://registry.yarnpkg.com/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz#13ced44cacb0fc44d6ac9ce67d725956089ce733"
@@ -12847,6 +12865,25 @@ protobufjs@~6.10.2:
     "@protobufjs/utf8" "^1.1.0"
     "@types/long" "^4.0.1"
     "@types/node" "^13.7.0"
+    long "^4.0.0"
+
+protobufjs@~6.11.3:
+  version "6.11.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.4.tgz#29a412c38bf70d89e537b6d02d904a6f448173aa"
+  integrity sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
     long "^4.0.0"
 
 proxy-addr@~2.0.7:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6805,9 +6805,9 @@ cosmjs-types@^0.8.0:
     long "^4.0.0"
     protobufjs "~6.11.2"
 
-"cosmodal@https://github.com/NoahSaso/cosmodal#7abc9d43f31693f56d3809dc7a87eeedce3c3ca2":
+"cosmodal@https://github.com/NoahSaso/cosmodal#a3db5393bedf755613f76c5adff0a3de126df09d":
   version "0.3.7"
-  resolved "https://github.com/NoahSaso/cosmodal#7abc9d43f31693f56d3809dc7a87eeedce3c3ca2"
+  resolved "https://github.com/NoahSaso/cosmodal#a3db5393bedf755613f76c5adff0a3de126df09d"
   dependencies:
     "@cosmjs/launchpad" "^0.27.1"
     "@cosmjs/proto-signing" "^0.28.0"


### PR DESCRIPTION
Legacy is currently broken on chains that updated Tendermint to 37. This prevents legacy DAOs from upgrading.