### PR TITLE
Open DAO in the same tab by default

### DIFF
--- a/packages/stateful/components/EntityDisplay.tsx
+++ b/packages/stateful/components/EntityDisplay.tsx
@@ -1,10 +1,27 @@
+import { useRouter } from 'next/router'
+
 import { EntityDisplay as StatelessEntityDisplay } from '@dao-dao/stateless'
 import { StatefulEntityDisplayProps } from '@dao-dao/types'
 
 import { useEntity } from '../hooks'
 
-export const EntityDisplay = (props: StatefulEntityDisplayProps) => {
+export const EntityDisplay = ({
+  loadingEntity: _loadingEntity,
+  openInNewTab,
+  ...props
+}: StatefulEntityDisplayProps) => {
   const loadingEntity = useEntity(props.address)
 
-  return <StatelessEntityDisplay {...props} loadingEntity={loadingEntity} />
+  // If on proposal creation page, default to open in new tab to avoid
+  // accidentally redirecting away from the proposal while editing.
+  const { asPath } = useRouter()
+  openInNewTab ??= asPath.includes('/proposals/create') ? true : undefined
+
+  return (
+    <StatelessEntityDisplay
+      {...props}
+      loadingEntity={_loadingEntity || loadingEntity}
+      openInNewTab={openInNewTab}
+    />
+  )
 }

--- a/packages/stateful/widgets/widgets/RetroactiveCompensation/Renderer/components/stateful/ContributionForm.tsx
+++ b/packages/stateful/widgets/widgets/RetroactiveCompensation/Renderer/components/stateful/ContributionForm.tsx
@@ -5,7 +5,6 @@ import { useSetRecoilState, waitForAll } from 'recoil'
 
 import { genericTokenWithUsdPriceSelector } from '@dao-dao/state/recoil'
 import {
-  EntityDisplay,
   Loader,
   useCachedLoadable,
   useChain,
@@ -13,7 +12,11 @@ import {
 } from '@dao-dao/stateless'
 import { TokenType } from '@dao-dao/types'
 
-import { ConnectWallet, SuspenseLoader } from '../../../../../../components'
+import {
+  ConnectWallet,
+  EntityDisplay,
+  SuspenseLoader,
+} from '../../../../../../components'
 import { useEntity, useWallet } from '../../../../../../hooks'
 import { refreshStatusAtom } from '../../atoms'
 import { usePostRequest } from '../../hooks/usePostRequest'

--- a/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/VestingPaymentCard.stories.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/VestingPaymentCard.stories.tsx
@@ -6,6 +6,7 @@ import { CHAIN_ID } from '@dao-dao/storybook'
 import { DaoPageWrapperDecorator } from '@dao-dao/storybook/decorators/DaoPageWrapperDecorator'
 import { EntityType, TokenType } from '@dao-dao/types'
 
+import { EntityDisplay } from '../../../../../components/EntityDisplay'
 import { VestingPaymentCard } from './VestingPaymentCard'
 
 export default {
@@ -37,6 +38,7 @@ Default.args = {
   },
   recipientIsWallet: true,
   ButtonLink,
+  EntityDisplay,
   lazyInfo: makeTokenCardProps().lazyInfo,
   token: {
     chainId: CHAIN_ID,

--- a/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/VestingPaymentCard.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/VestingPaymentCard.tsx
@@ -15,7 +15,6 @@ import {
   ButtonPopup,
   ChartEmoji,
   DepositEmoji,
-  EntityDisplay,
   Loader,
   MarkdownRenderer,
   MoneyEmoji,
@@ -33,6 +32,7 @@ import {
   EntityType,
   GenericToken,
   LoadingData,
+  StatefulEntityDisplayProps,
   TokenCardLazyInfo,
   UnstakingTaskStatus,
 } from '@dao-dao/types'
@@ -49,6 +49,7 @@ export interface VestingPaymentCardProps {
   // If current wallet connected is the recipient.
   recipientIsWallet: boolean
 
+  EntityDisplay: ComponentType<StatefulEntityDisplayProps>
   ButtonLink: ComponentType<ButtonLinkProps>
   lazyInfo: LoadingData<TokenCardLazyInfo>
   token: GenericToken
@@ -81,6 +82,7 @@ export const VestingPaymentCard = ({
   recipient,
   recipientEntity,
   recipientIsWallet,
+  EntityDisplay,
   ButtonLink,
   lazyInfo,
   token,

--- a/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/index.tsx
+++ b/packages/stateful/widgets/widgets/VestingPayments/components/VestingPaymentCard/index.tsx
@@ -22,7 +22,7 @@ import {
   processError,
 } from '@dao-dao/utils'
 
-import { ButtonLink } from '../../../../../components/ButtonLink'
+import { ButtonLink, EntityDisplay } from '../../../../../components'
 import {
   useAwaitNextBlock,
   useEntity,
@@ -213,6 +213,7 @@ export const VestingPaymentCard = (vestingInfo: VestingInfo) => {
     <>
       <StatelessVestingPaymentCard
         ButtonLink={ButtonLink}
+        EntityDisplay={EntityDisplay}
         canClaimStakingRewards={
           !lazyInfoLoading.loading &&
           !!lazyInfoLoading.data.stakingInfo?.totalPendingRewards

--- a/packages/stateless/components/EntityDisplay.tsx
+++ b/packages/stateless/components/EntityDisplay.tsx
@@ -29,6 +29,7 @@ export const EntityDisplay = ({
   noUnderline,
   showFullAddress,
   noLink,
+  openInNewTab = false,
 }: EntityDisplayProps) => {
   const { t } = useTranslation()
   const { getDaoPath } = useDaoNavHelpers()
@@ -92,7 +93,7 @@ export const EntityDisplay = ({
           containerClassName="min-w-0"
           href={noLink ? undefined : href}
           onClick={(e) => !noLink && e.stopPropagation()}
-          openInNewTab
+          openInNewTab={openInNewTab}
           variant={noUnderline || noLink || !href ? 'none' : 'underline'}
         >
           {!hideImage && (

--- a/packages/stateless/components/EntityDisplay.tsx
+++ b/packages/stateless/components/EntityDisplay.tsx
@@ -29,7 +29,7 @@ export const EntityDisplay = ({
   noUnderline,
   showFullAddress,
   noLink,
-  openInNewTab = false,
+  openInNewTab,
 }: EntityDisplayProps) => {
   const { t } = useTranslation()
   const { getDaoPath } = useDaoNavHelpers()

--- a/packages/types/stateless/EntityDisplay.tsx
+++ b/packages/types/stateless/EntityDisplay.tsx
@@ -44,6 +44,7 @@ export type EntityDisplayProps = {
   noUnderline?: boolean
   showFullAddress?: boolean
   noLink?: boolean
+  openInNewTab?: boolean
 }
 
 export type StatefulEntityDisplayProps = Omit<

--- a/packages/types/stateless/EntityDisplay.tsx
+++ b/packages/types/stateless/EntityDisplay.tsx
@@ -50,4 +50,5 @@ export type EntityDisplayProps = {
 export type StatefulEntityDisplayProps = Omit<
   EntityDisplayProps,
   'loadingEntity'
->
+> &
+  Partial<Pick<EntityDisplayProps, 'loadingEntity'>>


### PR DESCRIPTION
[comment]: <> (don't forget to run `yarn format` from the root :D)

Fixes #1310 

- Currently, clicking on a DAO in an inline link will open the link a different tab. This PR will disable opening link in different tab by default but allow us to manually override it.
- This PR adds an optional openInNewTab flag to EntityDisplayProps in packages/types/stateless/EntityDisplay.tsx
- Default openInNewTab to false in the component
- Then just pass it through to the ButtonLink directly