### PR TITLE
Fix Enable Multiple Choice action for DAOs below v2.3.0

### DIFF
--- a/packages/stateful/actions/core/dao_governance/EnableMultipleChoice/index.tsx
+++ b/packages/stateful/actions/core/dao_governance/EnableMultipleChoice/index.tsx
@@ -24,6 +24,7 @@ import {
   getNativeTokenForChainId,
   makeWasmMessage,
   objectMatchesStructure,
+  versionBelowVersion,
 } from '@dao-dao/utils'
 
 import {
@@ -163,6 +164,12 @@ export const makeEnableMultipleChoiceAction: ActionMaker<
         name: context.info.name,
       },
       {
+        enableMultipleChoice: true,
+        // V2.3.0 introduced a funds field that is not supported by DAOs below.
+        omitFunds: versionBelowVersion(
+          context.info.coreVersion,
+          ContractVersion.V230
+        ),
         quorum: {
           majority: 'majority' in quorum,
           value: 'majority' in quorum ? 50 : Number(quorum.percent) * 100,

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/daoCreation/getInstantiateInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/daoCreation/getInstantiateInfo.ts
@@ -17,10 +17,13 @@ import {
 } from '@dao-dao/utils'
 import { makeValidateMsg } from '@dao-dao/utils/validation/makeValidateMsg'
 
+import { DaoCreationExtraVotingConfig } from '../types'
 import instantiateSchema from './instantiate_schema.json'
 import preProposeInstantiateSchema from './pre_propose_instantiate_schema.json'
 
-export const getInstantiateInfo: DaoCreationGetInstantiateInfo = (
+export const getInstantiateInfo: DaoCreationGetInstantiateInfo<
+  DaoCreationExtraVotingConfig
+> = (
   codeIds,
   {
     chainId,
@@ -33,7 +36,7 @@ export const getInstantiateInfo: DaoCreationGetInstantiateInfo = (
       allowRevoting,
     },
   },
-  _data,
+  { omitFunds },
   t
 ) => {
   const decimals = proposalDeposit.token?.decimals ?? 0
@@ -92,10 +95,11 @@ export const getInstantiateInfo: DaoCreationGetInstantiateInfo = (
             JSON.stringify(preProposeMultipleInstantiateMsg),
             'utf8'
           ).toString('base64'),
-          // TODO(neutron-2.3.0): add back in here and in instantiate schema.
-          ...(chainId !== ChainId.NeutronMainnet && {
-            funds: [],
-          }),
+          // TODO(neutron-2.3.0): add back in here
+          ...(chainId !== ChainId.NeutronMainnet &&
+            !omitFunds && {
+              funds: [],
+            }),
         },
       },
     },
@@ -114,10 +118,11 @@ export const getInstantiateInfo: DaoCreationGetInstantiateInfo = (
     code_id: codeIds.DaoProposalMultiple,
     label: `DAO_${name.trim()}_${DaoProposalMultipleAdapterId}`,
     msg: Buffer.from(JSON.stringify(msg), 'utf8').toString('base64'),
-    // TODO(neutron-2.3.0): add back in here and in instantiate schema.
-    ...(chainId !== ChainId.NeutronMainnet && {
-      funds: [],
-    }),
+    // TODO(neutron-2.3.0): add back in here
+    ...(chainId !== ChainId.NeutronMainnet &&
+      !omitFunds && {
+        funds: [],
+      }),
   }
 }
 

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/index.tsx
@@ -28,10 +28,10 @@ import {
   useLoadingWalletVoteInfo,
   useProposalRefreshers,
 } from './hooks'
-import { NewProposalForm } from './types'
+import { DaoCreationExtraVotingConfig, NewProposalForm } from './types'
 
 export const DaoProposalMultipleAdapter: ProposalModuleAdapter<
-  {},
+  DaoCreationExtraVotingConfig,
   MultipleChoiceVote,
   NewProposalForm
 > = {

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/types.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/types.ts
@@ -116,3 +116,10 @@ export type MultipleChoiceOptionData = {
   }[]
   voteOption: ProposalVoteOption<MultipleChoiceVote>
 }
+
+export type DaoCreationExtraVotingConfig = {
+  // If true, omit the funds field from the creation info objects. This is used
+  // when enabling multiple choice via the action for a DAO that is on a version
+  // below v2.3.0.
+  omitFunds?: boolean
+}

--- a/packages/types/dao.ts
+++ b/packages/types/dao.ts
@@ -211,7 +211,7 @@ export type DaoCreationGetInstantiateInfo<
   // Used within voting and proposal module adapters, so the data generic passed
   // in may not necessarily be the voting module adapter data. Must use `any`.
   newDao: NewDao<any>,
-  data: ModuleData,
+  data: DaoCreationVotingConfig & ModuleData,
   t: TFunction
 ) => ModuleInstantiateInfo
 

--- a/packages/utils/contracts.ts
+++ b/packages/utils/contracts.ts
@@ -1,6 +1,7 @@
 import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate'
 import { Coin, SigningStargateClient } from '@cosmjs/stargate'
 import { findAttribute, parseRawLog } from '@cosmjs/stargate/build/logs'
+import semverLt from 'semver/functions/lt'
 
 import { ContractVersion } from '@dao-dao/types'
 
@@ -76,3 +77,8 @@ export const instantiateSmartContract = async (
 
   return contractAddress
 }
+
+export const versionBelowVersion = (
+  version: ContractVersion,
+  below: ContractVersion
+): boolean => semverLt(version, below)

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,6 +25,7 @@
     "react-hot-toast": "^2.1.1",
     "react-i18next": "^11.0.0",
     "ripemd160": "^2.0.2",
+    "semver": "^7.5.4",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
@@ -37,6 +38,7 @@
     "@dao-dao/config": "2.2.0",
     "@dao-dao/types": "2.2.0",
     "@types/ripemd160": "^2.0.0",
+    "@types/semver": "^7.5.6",
     "jest": "^29.1.1",
     "next": "^13.3.0",
     "nft.storage": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9575,6 +9575,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver@^7.5.6":
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.6.tgz#c65b2bfce1bec346582c07724e3f8c1017a20339"
+  integrity sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
@@ -23095,7 +23100,7 @@ semver@^7.0.0, semver@^7.1.1:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.3.8, semver@^7.5.0:
+semver@^7.3.8, semver@^7.5.0, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
Resolves #1479 

This fixes the extraneous `funds` field when enabling multiple choice via an action on a DAO below v2.3.0.