### PR TITLE
Add utility function to `utils` README to log code IDs

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,3 +1,33 @@
 # @dao-dao/utils
 
 A collection of simple utility functions used across packages.
+
+## Miscellaneous
+
+### Log Code IDs
+
+To log the Code IDs from their config object in
+[`constants/chains.ts`](./constants/chains.ts) in a format to put into a
+[dao-contracts](https://github.com/DA0-DA0/dao-contracts/releases) tagged
+release:
+
+```js
+let output = (obj) =>
+  console.log(Object.entries(obj).map(([key, value]) => {
+    const convertedKey = [...Array(key.length)].map((_, idx) => {
+      const c = key.charAt(idx)
+      // Convert capital letter to lowercase with a hyphen before.
+      if (/[A-Z]/.test(c)) {
+        return `${idx > 0 ? '-' : ''}${c.toLowerCase()}`
+      }
+      return c
+    }).join('')
+    return `${convertedKey}: ${value}`
+  }).join('\n'))
+
+output({
+  ...
+  DaoCore: 1,
+  ...
+})
+```


### PR DESCRIPTION
This adds a helpful utility to the `@dao-dao/utils` package README for logging code IDs. No code changes are made.