### PR TITLE
Shrink Apps proposal creation modal to normal page width

### DIFF
--- a/packages/stateful/components/dao/tabs/AppsTab.tsx
+++ b/packages/stateful/components/dao/tabs/AppsTab.tsx
@@ -519,7 +519,7 @@ const ActionMatcherAndProposer = ({
   return (
     <Modal
       backdropClassName="!z-[39]"
-      containerClassName="sm:!max-w-[90dvw] !w-full"
+      containerClassName="sm:!max-w-[min(90dvw,64rem)] !w-full"
       footerContainerClassName="flex flex-row justify-between gap-8"
       footerContent={
         isWalletConnected ? (


### PR DESCRIPTION
This shrinks the max width of the Apps tab proposal creation modal to be the same as the normal proposal creation page.

<img width="2168" alt="Screenshot 2023-11-28 at 21 55 23" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/72e0254a-0708-48ae-bb49-a3038e65b598">
