### PR TITLE
Fix USDC default and don't show in treasury by default

### DIFF
--- a/packages/state/recoil/selectors/chain.ts
+++ b/packages/state/recoil/selectors/chain.ts
@@ -20,17 +20,14 @@ import {
   WithChainId,
 } from '@dao-dao/types'
 import {
-  MAINNET,
   addressIsModule,
   cosmWasmClientRouter,
   cosmosSdkVersionIs47OrHigher,
   cosmosValidatorToValidator,
   decodeGovProposal,
   getAllRpcResponse,
-  getNativeIbcUsdc,
   getNativeTokenForChainId,
   getRpcForChainId,
-  isNativeIbcUsdc,
   stargateClientRouter,
 } from '@dao-dao/utils'
 import { cosmos, ibc, juno, osmosis } from '@dao-dao/utils/protobuf'
@@ -225,18 +222,6 @@ export const nativeBalancesSelector = selectorFamily<
         balances.push({
           amount: '0',
           denom: nativeToken.denomOrAddress,
-        })
-      }
-      // Add USDC if not present and on mainnet.
-      const nativeIbcUsdcDenom = getNativeIbcUsdc(chainId)?.denomOrAddress
-      if (
-        MAINNET &&
-        nativeIbcUsdcDenom &&
-        !balances.some(({ denom }) => isNativeIbcUsdc(chainId, denom))
-      ) {
-        balances.push({
-          amount: '0',
-          denom: nativeIbcUsdcDenom,
         })
       }
 

--- a/packages/utils/assets.ts
+++ b/packages/utils/assets.ts
@@ -61,7 +61,9 @@ export const nativeTokenExists = (chainId: string, denom: string) =>
   getChainAssets(chainId).some(({ denomOrAddress }) => denomOrAddress === denom)
 
 export const getNativeIbcUsdc = (chainId: string) =>
-  getChainAssets(chainId).find(({ id }) => id === 'usdc')
+  getChainAssets(chainId).find(
+    ({ id, symbol }) => id === 'usdc' && symbol === 'USDC'
+  ) || getChainAssets(chainId).find(({ id }) => id === 'usdc')
 
 // Returns true if this denom is the IBC denom for USDC on the current chain.
 export const isNativeIbcUsdc = (chainId: string, ibcDenom: string): boolean =>


### PR DESCRIPTION
This hides USDC in the treasury by default since now there are multiple different USDCs and it's not very helpful. The deposit fiat buttons still show up in the treasury separately.

This also fixes the native USDC selected to prefer the pure USDC symbol (instead of USDC.axl).