### PR TITLE
Use v2.1.0 contracts if no funds field support for multiple choice

### DIFF
--- a/packages/stateful/actions/core/dao_governance/EnableMultipleChoice/index.tsx
+++ b/packages/stateful/actions/core/dao_governance/EnableMultipleChoice/index.tsx
@@ -86,9 +86,7 @@ export const makeEnableMultipleChoiceAction: ActionMaker<
   address,
   context,
   chain: { chain_id: chainId },
-  chainContext: {
-    config: { codeIds },
-  },
+  chainContext: { config: chainConfig },
 }) => {
   if (
     context.type !== ActionContextType.Dao ||
@@ -154,7 +152,7 @@ export const makeEnableMultipleChoiceAction: ActionMaker<
           }
 
     const info = DaoProposalMultipleAdapter.daoCreation.getInstantiateInfo(
-      codeIds,
+      chainConfig,
       {
         ...makeDefaultNewDao(chainId),
         // Only the name is used in this function to pick the contract label.
@@ -162,7 +160,7 @@ export const makeEnableMultipleChoiceAction: ActionMaker<
       },
       {
         enableMultipleChoice: true,
-        omitFunds:
+        moduleInstantiateFundsUnsupported:
           !context.info.supportedFeatures[Feature.ModuleInstantiateFunds],
         quorum: {
           majority: 'majority' in quorum,

--- a/packages/stateful/components/dao/CreateDaoForm.tsx
+++ b/packages/stateful/components/dao/CreateDaoForm.tsx
@@ -118,10 +118,11 @@ export const InnerCreateDaoForm = ({
 }: CreateDaoFormProps) => {
   const { t } = useTranslation()
 
+  const chainContext = useSupportedChainContext()
   const {
     chainId,
     config: { factoryContractAddress, codeIds },
-  } = useSupportedChainContext()
+  } = chainContext
 
   const { goToDao } = useDaoNavHelpers()
   const { setFollowing } = useFollowingDaos(chainId)
@@ -319,7 +320,7 @@ export const InnerCreateDaoForm = ({
     const proposalModuleInstantiateInfos =
       proposalModuleDaoCreationAdapters.map(({ getInstantiateInfo }, index) =>
         getInstantiateInfo(
-          codeIds,
+          chainContext.config,
           newDao,
           proposalModuleAdapters[index].data,
           t

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/types.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/types.ts
@@ -118,8 +118,9 @@ export type MultipleChoiceOptionData = {
 }
 
 export type DaoCreationExtraVotingConfig = {
-  // If true, omit the funds field from the creation info objects. This is used
-  // when enabling multiple choice via the action for a DAO that is on a version
-  // below v2.3.0.
-  omitFunds?: boolean
+  // If true, omits the funds field from the creation info objects and uses
+  // v2.1.0 contracts. This is used when enabling multiple choice via the action
+  // for a DAO that is on a version below v2.3.0, since there was a breaking
+  // change on the `funds` field.
+  moduleInstantiateFundsUnsupported?: boolean
 }

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/daoCreation/getInstantiateInfo.ts
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/daoCreation/getInstantiateInfo.ts
@@ -22,7 +22,7 @@ import preProposeInstantiateSchema from './pre_propose_instantiate_schema.json'
 export const getInstantiateInfo: DaoCreationGetInstantiateInfo<
   DaoCreationExtraVotingConfig
 > = (
-  codeIds,
+  { codeIds },
   {
     chainId,
     name,

--- a/packages/types/chain.ts
+++ b/packages/types/chain.ts
@@ -1,6 +1,7 @@
 import { Chain } from '@chain-registry/types'
 
 import { Coin } from './contracts'
+import { ContractVersion } from './features'
 import { GenericToken } from './token'
 import { CodeIdConfig, PolytoneConfig } from './utils'
 
@@ -82,6 +83,9 @@ export type SupportedChainConfig = {
     wallet: string
   }
   codeIds: CodeIdConfig
+  // Store code IDs for past versions of contracts, in case DAOs need a
+  // particular version of a contract.
+  historicalCodeIds?: Partial<Record<ContractVersion, Partial<CodeIdConfig>>>
   polytone?: PolytoneConfig
 }
 

--- a/packages/types/dao.ts
+++ b/packages/types/dao.ts
@@ -12,6 +12,7 @@ import {
   UseFormSetValue,
 } from 'react-hook-form'
 
+import { SupportedChainConfig } from './chain'
 import {
   ActiveThreshold,
   DepositRefundPolicy,
@@ -27,7 +28,6 @@ import {
 import { DaoCardProps, LoadingData, SuspenseLoaderProps } from './stateless'
 import { GenericToken, TokenCardInfo } from './token'
 import { DurationWithUnits } from './units'
-import { CodeIdConfig } from './utils'
 
 // Used in DaoInfoContext in @dao-dao/stateful/components/DaoPageWrapper
 export type DaoInfo = {
@@ -208,7 +208,7 @@ export type DaoCreationCommonVotingConfigItems = {
 export type DaoCreationGetInstantiateInfo<
   ModuleData extends FieldValues = any
 > = (
-  codeIds: CodeIdConfig,
+  chainConfig: SupportedChainConfig,
   // Used within voting and proposal module adapters, so the data generic passed
   // in may not necessarily be the voting module adapter data. Must use `any`.
   newDao: NewDao<any>,

--- a/packages/utils/constants/chains.ts
+++ b/packages/utils/constants/chains.ts
@@ -1,4 +1,9 @@
-import { ChainId, PolytoneConfig, SupportedChainConfig } from '@dao-dao/types'
+import {
+  ChainId,
+  ContractVersion,
+  PolytoneConfig,
+  SupportedChainConfig,
+} from '@dao-dao/types'
 
 // Chains which DAO DAO DAOs exist on.
 export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
@@ -48,6 +53,12 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
         // ContractVersion.V210
         Cw20Stake: 2444,
         DaoVotingCw20Staked: 2463,
+      },
+      historicalCodeIds: {
+        [ContractVersion.V210]: {
+          DaoPreProposeMultiple: 2458,
+          DaoProposalMultiple: 2461,
+        },
       },
       polytone: {
         [ChainId.OsmosisMainnet]: {
@@ -137,6 +148,12 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
         DaoVotingCw4: 251,
         DaoVotingCw721Staked: 253,
         DaoVotingTokenStaked: 252,
+      },
+      historicalCodeIds: {
+        [ContractVersion.V210]: {
+          DaoPreProposeMultiple: 118,
+          DaoProposalMultiple: 120,
+        },
       },
       polytone: {
         [ChainId.JunoMainnet]: {
@@ -260,6 +277,12 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
         DaoVotingTokenStaked: 121,
         CwTokenfactoryIssuer: 122,
       },
+      historicalCodeIds: {
+        [ContractVersion.V210]: {
+          DaoPreProposeMultiple: 89,
+          DaoProposalMultiple: 91,
+        },
+      },
       polytone: {
         [ChainId.OsmosisMainnet]: {
           // stargaze
@@ -350,6 +373,12 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
         Cw20Stake: 1247,
         DaoVotingCw20Staked: 1263,
       },
+      historicalCodeIds: {
+        [ContractVersion.V210]: {
+          DaoPreProposeMultiple: 1258,
+          DaoProposalMultiple: 1261,
+        },
+      },
     },
     [ChainId.OsmosisTestnet]: {
       name: 'osmosis',
@@ -391,6 +420,12 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
         DaoVotingCw721Staked: 4904,
         DaoVotingTokenStaked: 4905,
       },
+      historicalCodeIds: {
+        [ContractVersion.V210]: {
+          DaoPreProposeMultiple: 1319,
+          DaoProposalMultiple: 1322,
+        },
+      },
     },
     [ChainId.StargazeTestnet]: {
       name: 'stargaze',
@@ -428,6 +463,12 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
         DaoVotingCw4: 3235,
         DaoVotingCw721Staked: 3236,
         DaoVotingTokenStaked: 3237,
+      },
+      historicalCodeIds: {
+        [ContractVersion.V210]: {
+          DaoPreProposeMultiple: 224,
+          DaoProposalMultiple: 226,
+        },
       },
     },
   }


### PR DESCRIPTION
This fixes a bug where v2.1.0 DAOs would try and fail to add v2.3.0 multiple choice contract due to the `funds` breaking change. Now it will try to add the v2.1.0 contract.