### PR TITLE
Add missing Neutron historical code IDs

### DIFF
--- a/packages/utils/constants/chains.ts
+++ b/packages/utils/constants/chains.ts
@@ -240,6 +240,12 @@ export const SUPPORTED_CHAINS: Partial<Record<ChainId, SupportedChainConfig>> =
         DaoVotingCw721Staked: -1,
         DaoVotingTokenStaked: -1,
       },
+      historicalCodeIds: {
+        [ContractVersion.V210]: {
+          DaoPreProposeMultiple: 224,
+          DaoProposalMultiple: 226,
+        },
+      },
     },
     [ChainId.StargazeMainnet]: {
       name: 'stargaze',


### PR DESCRIPTION
This fills in missing v2.1.0 code IDs for Neutron. I realized it may be easy to forget this later once upgrading to v2.3.0 if not done now.

Part of #1504 