### PR TITLE
Remove token DAO creation fee when using existing token

### DIFF
--- a/packages/stateful/components/dao/CreateDaoForm.tsx
+++ b/packages/stateful/components/dao/CreateDaoForm.tsx
@@ -679,8 +679,9 @@ export const InnerCreateDaoForm = ({
         <div className="mb-14">
           <Page {...createDaoContext} />
 
-          {/* If funds are required, display. */}
-          {!!instantiateMsgFunds?.length &&
+          {/* If funds are required, display on last page. */}
+          {pageIndex === CreateDaoPages.length - 1 &&
+            !!instantiateMsgFunds?.length &&
             instantiateMsgFunds.some(({ amount }) => amount !== '0') && (
               <div className="mt-6 -mb-8 flex flex-row justify-end">
                 <div className="flex flex-col items-end gap-2">

--- a/packages/stateful/creators/TokenBased/GovernanceConfigurationInput.tsx
+++ b/packages/stateful/creators/TokenBased/GovernanceConfigurationInput.tsx
@@ -94,13 +94,19 @@ export const GovernanceConfigurationInput = ({
     undefined
   )
   useEffect(() => {
-    if (!tokenFactoryDenomCreationFeeLoading.loading) {
+    if (
+      data.tokenType === GovernanceTokenType.New &&
+      !tokenFactoryDenomCreationFeeLoading.loading
+    ) {
       setValue(
         'creator.data.tokenFactoryDenomCreationFee',
         tokenFactoryDenomCreationFeeLoading.data
       )
+    } else {
+      // No fee for using existing token.
+      setValue('creator.data.tokenFactoryDenomCreationFee', undefined)
     }
-  }, [setValue, tokenFactoryDenomCreationFeeLoading])
+  }, [data.tokenType, setValue, tokenFactoryDenomCreationFeeLoading])
 
   // Fill in default first tier info if tiers not yet edited.
   const [loadedPage, setLoadedPage] = useState(false)


### PR DESCRIPTION
This fixes a bug where it would charge the new token fee that some chains use (like Stargaze) on token-based DAO creation even when not creating a new token.