### PR TITLE
Fix v2 upgrade

### DIFF
--- a/packages/stateful/actions/core/dao_governance/UpgradeV1ToV2/index.tsx
+++ b/packages/stateful/actions/core/dao_governance/UpgradeV1ToV2/index.tsx
@@ -286,6 +286,7 @@ export const makeUpgradeV1ToV2Action: ActionMaker<UpgradeV1ToV2Data> = ({
                     label: `DAO_${name.trim()}_pre-propose-${
                       DaoProposalSingleAdapter.id
                     }`,
+                    funds: [],
                     msg: Buffer.from(
                       JSON.stringify({
                         deposit_info: depositInfo


### PR DESCRIPTION
The `funds` field was missing from the v2 upgrade action. This adds it in.