### PR TITLE
Hide instantiate2 action for DAOs that are too old

### DIFF
--- a/packages/stateful/actions/core/smart_contracting/Instantiate2/index.tsx
+++ b/packages/stateful/actions/core/smart_contracting/Instantiate2/index.tsx
@@ -13,7 +13,7 @@ import {
   ChainPickerInput,
   ChainProvider,
 } from '@dao-dao/stateless'
-import { TokenType } from '@dao-dao/types'
+import { Feature, TokenType } from '@dao-dao/types'
 import {
   ActionComponent,
   ActionContextType,
@@ -36,8 +36,6 @@ import {
 import { useTokenBalances } from '../../../hooks'
 import { useActionOptions } from '../../../react'
 import { Instantiate2Component as StatelessInstantiate2Component } from './Component'
-
-// TODO(instantiate2): fix pre-propose msg issue
 
 type Instantiate2Data = {
   chainId: string
@@ -134,7 +132,15 @@ export const makeInstantiate2Action: ActionMaker<Instantiate2Data> = ({
   t,
   address,
   chain: { chain_id: currentChainId },
+  context,
 }) => {
+  if (
+    context.type === ActionContextType.Dao &&
+    !context.info.supportedFeatures[Feature.Instantiate2]
+  ) {
+    return null
+  }
+
   const useDefaults: UseDefaults<Instantiate2Data> = () => ({
     chainId: currentChainId,
     admin: address,

--- a/packages/types/features.ts
+++ b/packages/types/features.ts
@@ -62,6 +62,11 @@ export enum Feature {
    * adding proposal modules).
    */
   ModuleInstantiateFunds,
+  /**
+   * The cosmwasm-std package was upgraded to v1.2.0 in the contracts which
+   * added support for Instantiate2 wasm messages.
+   */
+  Instantiate2,
 }
 
 /**

--- a/packages/utils/features.ts
+++ b/packages/utils/features.ts
@@ -24,6 +24,7 @@ export const isFeatureSupportedByVersion = (
     case Feature.VoteUntilExpiration:
       return versionGte(version, ContractVersion.V2Alpha)
     case Feature.ModuleInstantiateFunds:
+    case Feature.Instantiate2:
       return versionGte(version, ContractVersion.V230)
     default:
       return true


### PR DESCRIPTION
DAOs before v2.3.0 do not support `instantiate2`, so this hides the action.