### PR TITLE
Fix Polytone authz grant and simulation button stuck bug

### DIFF
--- a/packages/stateful/actions/core/authorizations/AuthzGrantRevoke/index.tsx
+++ b/packages/stateful/actions/core/authorizations/AuthzGrantRevoke/index.tsx
@@ -100,8 +100,9 @@ const Component: ActionComponent = (props) => {
 
 export const makeAuthzGrantRevokeAction: ActionMaker<AuthzGrantRevokeData> = ({
   t,
-  address,
+  address: mainAddress,
   chain: { chain_id: currentChainId },
+  context,
 }) => {
   const useDefaults: UseDefaults<AuthzGrantRevokeData> = () => ({
     chainId: currentChainId,
@@ -138,9 +139,7 @@ export const makeAuthzGrantRevokeAction: ActionMaker<AuthzGrantRevokeData> = ({
       !objectMatchesStructure(msg.stargate.value, {
         grantee: {},
         granter: {},
-      }) ||
-      // Make sure this address is the granter.
-      msg.stargate.value.granter !== address
+      })
     ) {
       return { match: false }
     }
@@ -403,7 +402,11 @@ export const makeAuthzGrantRevokeAction: ActionMaker<AuthzGrantRevokeData> = ({
                       msgTypeUrl,
                     }),
                 grantee,
-                granter: address,
+                granter:
+                  chainId === currentChainId ||
+                  context.type !== ActionContextType.Dao
+                    ? mainAddress
+                    : context.info.polytoneProxies[chainId],
               },
             },
           })

--- a/packages/stateless/components/proposal/NewProposal.tsx
+++ b/packages/stateless/components/proposal/NewProposal.tsx
@@ -111,16 +111,28 @@ export const NewProposal = <
   const [showSubmitErrorNote, setShowSubmitErrorNote] = useState(false)
   const [submitError, setSubmitError] = useState('')
 
-  const [holdingAltForSimulation, setHoldingAlt] = useState(false)
+  const [holdingAltForSimulation, setHoldingAltForSimulation] = useState(false)
+  // Unset holding alt after 3 seconds, in case it got stuck.
+  useEffect(() => {
+    if (!holdingAltForSimulation) {
+      return
+    }
+
+    const timeout = setTimeout(() => setHoldingAltForSimulation(false), 3000)
+
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [holdingAltForSimulation])
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Alt') {
-        setHoldingAlt(true)
+        setHoldingAltForSimulation(true)
       }
     }
     const handleKeyUp = (event: KeyboardEvent) => {
       if (event.key === 'Alt') {
-        setHoldingAlt(false)
+        setHoldingAltForSimulation(false)
       }
     }
 


### PR DESCRIPTION
Related to #1516 

This fixes authz not creating the correct grant message when executed cross-chain via polytone.

This also automatically disables the simulation button after 3 seconds in case it gets stuck thinking alt is held down.