### PR TITLE
Fix token-based DAO creation not accepting all native tokens

### DIFF
--- a/packages/utils/assets.ts
+++ b/packages/utils/assets.ts
@@ -2,7 +2,7 @@ import { asset_lists } from '@chain-registry/assets'
 
 import { GenericToken, TokenType } from '@dao-dao/types'
 
-import { getChainForChainId, getNativeTokenForChainId } from './chain'
+import { getChainForChainId } from './chain'
 import { concatAddressStartEnd } from './conversion'
 import { getFallbackImage } from './getFallbackImage'
 
@@ -61,10 +61,14 @@ export const getChainAssets = (chainId: string) => {
   return chainAssetsMap[chainId]!
 }
 
-// Native token exists if it is the native denom or any of the IBC assets.
-export const nativeTokenExists = (chainId: string, denom: string) =>
-  denom === getNativeTokenForChainId(chainId).denomOrAddress ||
-  getChainAssets(chainId).some(({ denomOrAddress }) => denomOrAddress === denom)
+/**
+ * Valid native denom if it follows cosmos SDK validation logic. Specifically,
+ * the regex string `[a-zA-Z][a-zA-Z0-9/:._-]{2,127}`.
+ *
+ * <https://github.com/cosmos/cosmos-sdk/blob/7728516abfab950dc7a9120caad4870f1f962df5/types/coin.go#L865-L867>
+ */
+export const isValidNativeTokenDenom = (denom: string) =>
+  /^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}$/.test(denom)
 
 export const getNativeIbcUsdc = (chainId: string) =>
   getChainAssets(chainId).find(

--- a/packages/utils/validation/index.ts
+++ b/packages/utils/validation/index.ts
@@ -7,8 +7,7 @@ import {
   isValidTokenFactoryDenom,
   isValidValidatorAddress,
 } from '../address'
-import { nativeTokenExists } from '../assets'
-import { getChainForChainId } from '../chain'
+import { isValidNativeTokenDenom } from '../assets'
 import cosmosMsgSchema from '../cosmos_msg.json'
 import { isValidUrl } from '../isValidUrl'
 import { makeValidateMsg } from './makeValidateMsg'
@@ -65,13 +64,6 @@ export const makeValidateDate =
     (v && !isNaN(Date.parse(v))) ||
     t(time ? 'error.invalidDateTime' : 'error.invalidDate')
 
-export const makeValidateNativeDenom =
-  (chainId: string) =>
-  (v: any, required = true) =>
-    (!required && !v) ||
-    (v && typeof v === 'string' && nativeTokenExists(chainId, v)) ||
-    'Invalid native denom. Ensure it is lower–cased.'
-
 export const makeValidateTokenFactoryDenom =
   (bech32Prefix: string, required = true) =>
   (v: any) =>
@@ -79,18 +71,9 @@ export const makeValidateTokenFactoryDenom =
     (v && typeof v === 'string' && isValidTokenFactoryDenom(v, bech32Prefix)) ||
     'Invalid token factory denom. Ensure it is lower–cased.'
 
-export const makeValidateNativeOrFactoryTokenDenom =
-  (chainId: string, required = true) =>
-  (v: any) =>
-    (!required && !v) ||
-    (v &&
-      typeof v === 'string' &&
-      (nativeTokenExists(chainId, v) ||
-        isValidTokenFactoryDenom(
-          v,
-          getChainForChainId(chainId).bech32_prefix
-        ))) ||
-    'Invalid native token denom. Ensure it is lower–cased.'
+export const validateNativeTokenDenom = (v: any) =>
+  (v && typeof v === 'string' && isValidNativeTokenDenom(v)) ||
+  'Invalid native token denom.'
 
 export const validateJSON = (v: string) => {
   try {


### PR DESCRIPTION
This fixes the token-based DAO creation denom validation. This changes it from checking against a hardcoded list of assets to validating the regex using the Cosmos SDK regex validation that our smart contracts use. It still queries the chain to find asset info to verify it exists, but the string validation was getting in the way.