### PR TITLE
Fix update proposal module actions clearing veto on usage

### DIFF
--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/common/actions/UpdateProposalConfig/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalMultiple/common/actions/UpdateProposalConfig/index.tsx
@@ -171,6 +171,9 @@ export const makeUpdateProposalConfigActionMaker =
               close_proposal_on_execution_failure:
                 proposalModuleConfig.data.close_proposal_on_execution_failure,
               min_voting_period: proposalModuleConfig.data.min_voting_period,
+              ...('veto' in proposalModuleConfig.data && {
+                veto: proposalModuleConfig.data.veto,
+              }),
             },
           }
 

--- a/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/actions/UpdateProposalConfigV2/index.tsx
+++ b/packages/stateful/proposal-module-adapter/adapters/DaoProposalSingle/common/actions/UpdateProposalConfigV2/index.tsx
@@ -221,6 +221,9 @@ export const makeUpdateProposalConfigV2ActionMaker =
               close_proposal_on_execution_failure:
                 proposalModuleConfig.data.close_proposal_on_execution_failure,
               min_voting_period: proposalModuleConfig.data.min_voting_period,
+              ...('veto' in proposalModuleConfig.data && {
+                veto: proposalModuleConfig.data.veto,
+              }),
             },
           }
 


### PR DESCRIPTION
This fixes a bug where the proposal module config update actions would clear veto settings.