### PR TITLE
Fix Create ICA action

### DIFF
--- a/packages/stateful/actions/core/advanced/CreateIca/Component.tsx
+++ b/packages/stateful/actions/core/advanced/CreateIca/Component.tsx
@@ -41,10 +41,12 @@ export const CreateIcaComponent: ActionComponent<CreateIcaOptions> = ({
   const { chain_id: sourceChainId } = useChain()
 
   const destinationChainId = watch((fieldNamePrefix + 'chainId') as 'chainId')
-  const imageUrl = getImageUrlForChainId(destinationChainId)
+  const imageUrl =
+    destinationChainId && getImageUrlForChainId(destinationChainId)
 
   const registerActionExists =
     isCreating &&
+    !!destinationChainId &&
     allActionsWithData.some(
       ({ actionKey, data }) =>
         actionKey === ActionKey.ManageIcas &&

--- a/packages/utils/chain.ts
+++ b/packages/utils/chain.ts
@@ -95,7 +95,7 @@ export const cosmosValidatorToValidator = ({
 
 export const getImageUrlForChainId = (chainId: string): string => {
   //Chain logo is sometimes larger and not square.
-  const { logo_URIs, images } = getChainForChainId(chainId)
+  const { logo_URIs, images } = maybeGetChainForChainId(chainId) ?? {}
   const chainImageUrl =
     logo_URIs?.png ??
     logo_URIs?.jpeg ??


### PR DESCRIPTION
The `Create ICA` action errors when the chain is unset, which is the default. This fixes it. I'm not sure what caused this because I'm pretty sure it worked when I first deployed it, but oh well. We really need some sanity tests...