### PR TITLE
Fix vesting payment error when input is cleared

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -454,6 +454,7 @@
     "txNotFound": "Transaction not found.",
     "unexpectedError": "An unexpected error occurred.",
     "unknownDenom": "Unknown denomination {{denom}}.",
+    "unknownError": "An unknown error occurred.",
     "unknownInboxType": "Unknown inbox item type.",
     "unsupportedApprovalFailedRender": "Failed to render approval proposal. Unsupported module."
   },

--- a/packages/stateful/actions/core/treasury/ManageVesting/BeginVesting.tsx
+++ b/packages/stateful/actions/core/treasury/ManageVesting/BeginVesting.tsx
@@ -152,8 +152,9 @@ export const BeginVesting: ActionComponent<BeginVestingOptions> = ({
   const stepPoints =
     startDate &&
     steps.reduce((acc, { percent, delay }, index): VestingStep[] => {
-      const delayMs =
-        delay.value && convertDurationWithUnitsToSeconds(delay) * 1000
+      const delayMs = delay.value
+        ? convertDurationWithUnitsToSeconds(delay) * 1000
+        : 0
 
       const lastMs =
         index === 0 ? startDate.getTime() : acc[acc.length - 1].timestamp

--- a/packages/stateless/components/inputs/InputErrorMessage.tsx
+++ b/packages/stateless/components/inputs/InputErrorMessage.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { FieldError } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 
 export interface InputErrorMessageProps {
   error?: FieldError | string | Error | unknown
@@ -10,6 +11,7 @@ export const InputErrorMessage = ({
   error,
   className,
 }: InputErrorMessageProps) => {
+  const { t } = useTranslation()
   const message =
     error &&
     (typeof error === 'string'
@@ -19,9 +21,9 @@ export const InputErrorMessage = ({
           'message' in error &&
           typeof (error as { message: string }).message === 'string')
       ? (error as { message: string }).message
-      : `${error}`)
+      : t('error.unknownError'))
 
-  return message && message !== '[object Object]' ? (
+  return message ? (
     <span
       className={clsx(
         'mt-1 ml-1 inline-block max-w-prose break-words text-xs text-text-interactive-error',


### PR DESCRIPTION
This fixes a bug with the begin vesting payment action that errors the whole action when the step delay value is deleted.