### PR TITLE
Enable multiple choice proposals by default

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -599,7 +599,7 @@
     "minterContract": "Minter contract",
     "minterContractMessage": "Minter contract message",
     "moreThanOneAccount": "More than one account",
-    "multipleChoiceDescription": "This allows proposals to contain multiple choices instead of just `Yes` and `No`.\n\n**CAUTION:** Using more features increases the risk to a DAO because there are more things that can go wrong. You can always enable this later.",
+    "multipleChoiceDescription": "This allows proposals to contain multiple choices instead of just `Yes` and `No`.",
     "multipleChoiceOptionDescriptionPlaceholder": "Give your choice a description... (supports Markdown format)",
     "multipleChoiceOptionTitlePlaceholder": "Give your choice a title",
     "multipleChoiceTitle": "Multiple choice proposals",

--- a/packages/stateful/components/dao/commonVotingConfig/index.ts
+++ b/packages/stateful/components/dao/commonVotingConfig/index.ts
@@ -14,10 +14,10 @@ export const loadCommonVotingConfigItems =
     items: [
       makeVotingDurationVotingConfigItem(),
       makeProposalDepositVotingConfigItem(),
+      makeMultipleChoiceVotingConfigItem(),
     ],
     advancedItems: [
       makeQuorumVotingConfigItem(),
-      makeMultipleChoiceVotingConfigItem(),
       makeAllowRevotingVotingConfigItem(),
       makeProposalSubmissionPolicyVotingConfigItem(),
       makeApproverVotingConfigItem(),

--- a/packages/stateful/recoil/atoms/newDao.ts
+++ b/packages/stateful/recoil/atoms/newDao.ts
@@ -64,7 +64,7 @@ export const makeDefaultNewDao = (chainId: string): NewDao => ({
     },
     anyoneCanPropose: false,
     allowRevoting: false,
-    enableMultipleChoice: false,
+    enableMultipleChoice: true,
     approver: {
       enabled: false,
       address: '',


### PR DESCRIPTION
When creating a DAO, enable multiple choice proposals by default. They have been used for quite some time now; I think it is safe to move them out of the advanced section and create DAOs with multiple choice setup automatically.

This moves the config card out of the advanced section so it is always visible.

<img width="1073" alt="Screenshot 2024-01-07 at 21 25 56" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/4894af52-a828-4b78-bc24-dacf650aae36">
