### PR TITLE
Fix infinite scroll

### DIFF
--- a/packages/stateless/components/proposal/ProposalList.tsx
+++ b/packages/stateless/components/proposal/ProposalList.tsx
@@ -6,7 +6,6 @@ import {
   DaoWithDropdownVetoableProposalList,
   LinkWrapperProps,
 } from '@dao-dao/types'
-import { getScrollableAncestor } from '@dao-dao/utils'
 
 import { useDaoInfoContext } from '../../hooks'
 import { Button } from '../buttons'
@@ -121,11 +120,6 @@ export const ProposalList = <T extends { proposalId: string }>({
       return
     }
 
-    const scrollContainer = getScrollableAncestor(container)
-    if (!scrollContainer) {
-      return
-    }
-
     let executedLoadingMore = false
     const onScroll = () => {
       if (executedLoadingMore) {
@@ -145,8 +139,10 @@ export const ProposalList = <T extends { proposalId: string }>({
 
     onScroll()
 
-    scrollContainer.addEventListener('scroll', onScroll)
-    return () => scrollContainer.removeEventListener('scroll', onScroll)
+    // Set third argument to `true` to capture all scroll events instead of
+    // waiting for them to bubble up.
+    window.addEventListener('scroll', onScroll, true)
+    return () => window.removeEventListener('scroll', onScroll, true)
   }, [loadingMore, canLoadMore, container, infiniteScrollFactor])
 
   return proposalsExist ? (


### PR DESCRIPTION
Sometimes infinite scroll does not work right away, and only starts working after the load more button is clicked one time. This is due to some intricacies of how DOM elements are loaded.

This fixes it by attaching the scroll handler to the window and capturing all scroll events instead of just trying to find the specific scrollable ancestor. Performance wise it should be basically the same.