### PR TITLE
Scroll to action when added and make library collapsible

### DIFF
--- a/packages/i18n/locales/en/translation.json
+++ b/packages/i18n/locales/en/translation.json
@@ -814,7 +814,7 @@
   "info": {
     "abstainVote": "Abstain",
     "accountPageDescription": "View tokens and NFTs for the account with address {{address}}.",
-    "actionLibraryDescription": "Choose an action from one of the categories below to add it.",
+    "actionLibraryDescription": "Choose one or more actions to perform upon execution.",
     "actionPageWarning": "There are {{actions}} actions across {{pages}} pages. Make sure you view all pages before voting.",
     "actionPaysTokenSwap_paid": "This action sent {{amount}} ${{tokenSymbol}} to the token swap contract below.",
     "actionPaysTokenSwap_unpaid": "This action sends {{amount}} ${{tokenSymbol}} to the token swap contract below.",

--- a/packages/stateless/components/Collapsible.tsx
+++ b/packages/stateless/components/Collapsible.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useState } from 'react'
+import { forwardRef, useState } from 'react'
 
 import { CollapsibleProps } from '@dao-dao/types/components/Collapsible'
 import { toAccessibleImageUrl } from '@dao-dao/utils'
@@ -7,99 +7,116 @@ import { toAccessibleImageUrl } from '@dao-dao/utils'
 import { DropdownIconButton } from './icon_buttons/DropdownIconButton'
 import { TooltipInfoIcon } from './tooltip'
 
-const titleClassName =
+const _titleClassName =
   'flex grow flex-row items-center gap-2 overflow-hidden py-2 transition-opacity hover:opacity-70 active:opacity-60 cursor-pointer'
 
-export const Collapsible = ({
-  label,
-  tooltip,
-  imageUrl,
-  link,
-  defaultCollapsed = false,
-  onExpand,
-  indentDropdownSize = 0,
-  noContentIndent = false,
-  children,
-  containerClassName,
-  headerClassName,
-  labelClassName,
-  contentContainerClassName,
-}: CollapsibleProps) => {
-  const [expanded, setExpanded] = useState(!defaultCollapsed)
-  const toggleExpanded = () => {
-    const newExpanded = !expanded
-    setExpanded(newExpanded)
-    onExpand?.(newExpanded)
-  }
+export const Collapsible = forwardRef<HTMLDivElement, CollapsibleProps>(
+  function Collapsible(
+    {
+      label,
+      tooltip,
+      imageUrl,
+      link,
+      defaultCollapsed = false,
+      onExpand,
+      indentDropdownSize = 0,
+      noContentIndent = false,
+      children,
+      containerClassName,
+      headerClassName,
+      labelClassName,
+      labelContainerClassName,
+      dropdownContainerClassName,
+      contentContainerClassName,
+    },
+    ref
+  ) {
+    const [expanded, setExpanded] = useState(!defaultCollapsed)
+    const toggleExpanded = () => {
+      const newExpanded = !expanded
+      setExpanded(newExpanded)
+      onExpand?.(newExpanded)
+    }
 
-  const titleContent = (
-    <>
-      {!!imageUrl && (
-        <div
-          className="h-6 w-6 overflow-hidden rounded-full bg-cover bg-center"
-          style={{
-            backgroundImage: `url(${toAccessibleImageUrl(imageUrl)})`,
-          }}
-        />
-      )}
+    const titleClassName = clsx(_titleClassName, labelContainerClassName)
 
-      <p className={clsx('link-text truncate', labelClassName)}>{label}</p>
-
-      {tooltip && <TooltipInfoIcon size="sm" title={tooltip} />}
-    </>
-  )
-
-  return (
-    <div className={clsx('flex flex-col gap-4', containerClassName)}>
-      <div className={clsx('flex flex-row items-stretch', headerClassName)}>
-        {[...Array(indentDropdownSize)].map((_, index) => (
+    const titleContent = (
+      <>
+        {!!imageUrl && (
           <div
-            key={index}
-            // The triangle `IconButton` is w-6 and offset by the container's
-            // ml-2, so to center this border beneath the arrow, we need to
-            // include the full offset (ml-2) and half the width (w-3), getting
-            // w-5.
-            className="w-5 shrink-0 border-r border-border-secondary"
-          ></div>
-        ))}
+            className="h-6 w-6 overflow-hidden rounded-full bg-cover bg-center"
+            style={{
+              backgroundImage: `url(${toAccessibleImageUrl(imageUrl)})`,
+            }}
+          />
+        )}
 
-        <div className="ml-2 flex grow flex-row items-center gap-2 overflow-hidden">
-          <div className="flex h-6 w-6 shrink-0 items-center justify-center">
-            {children ? (
-              <DropdownIconButton
-                className="text-icon-primary"
-                open={expanded}
-                toggle={toggleExpanded}
-              />
+        <p className={clsx('link-text truncate', labelClassName)}>{label}</p>
+
+        {tooltip && <TooltipInfoIcon size="sm" title={tooltip} />}
+      </>
+    )
+
+    return (
+      <div
+        className={clsx('flex flex-col gap-4', containerClassName)}
+        ref={ref}
+      >
+        <div className={clsx('flex flex-row items-stretch', headerClassName)}>
+          {[...Array(indentDropdownSize)].map((_, index) => (
+            <div
+              key={index}
+              // The triangle `IconButton` is w-6 and offset by the container's
+              // ml-2, so to center this border beneath the arrow, we need to
+              // include the full offset (ml-2) and half the width (w-3), getting
+              // w-5.
+              className="w-5 shrink-0 border-r border-border-secondary"
+            ></div>
+          ))}
+
+          <div
+            className={clsx(
+              'ml-2 flex grow flex-row items-center gap-2 overflow-hidden',
+              dropdownContainerClassName
+            )}
+          >
+            <div className="flex h-6 w-6 shrink-0 items-center justify-center">
+              {children ? (
+                <DropdownIconButton
+                  className="text-icon-primary"
+                  open={expanded}
+                  toggle={toggleExpanded}
+                />
+              ) : (
+                <div className="h-1 w-1 rounded-full bg-icon-interactive-disabled"></div>
+              )}
+            </div>
+
+            {link ? (
+              <link.LinkWrapper className={titleClassName} href={link.href}>
+                {titleContent}
+              </link.LinkWrapper>
             ) : (
-              <div className="h-1 w-1 rounded-full bg-icon-interactive-disabled"></div>
+              <div className={titleClassName} onClick={toggleExpanded}>
+                {titleContent}
+              </div>
             )}
           </div>
-
-          {link ? (
-            <link.LinkWrapper className={titleClassName} href={link.href}>
-              {titleContent}
-            </link.LinkWrapper>
-          ) : (
-            <div className={titleClassName} onClick={toggleExpanded}>
-              {titleContent}
-            </div>
-          )}
         </div>
+
+        {children && (
+          <div
+            className={clsx(
+              'animate-fade-in',
+              !expanded && 'hidden',
+              !noContentIndent && 'ml-10',
+              contentContainerClassName
+            )}
+          >
+            {children}
+          </div>
+        )}
       </div>
-
-      {children && (
-        <div
-          className={clsx(
-            'animate-fade-in',
-            !expanded && 'hidden',
-            !noContentIndent && 'ml-10',
-            contentContainerClassName
-          )}
-        >
-          {children}
-        </div>
-      )}
-    </div>
-  )
-}
+    )
+  }
+)

--- a/packages/stateless/components/actions/ActionLibrary.tsx
+++ b/packages/stateless/components/actions/ActionLibrary.tsx
@@ -18,6 +18,7 @@ import {
 
 import { useSearchFilter } from '../../hooks'
 import { Button } from '../buttons'
+import { Collapsible } from '../Collapsible'
 import { SearchBar } from '../inputs'
 import { Loader } from '../logo'
 import { TooltipInfoIcon } from '../tooltip'
@@ -233,26 +234,24 @@ export const ActionLibrary = ({
   )
 
   return (
-    <div
-      className="mt-2 flex flex-col gap-4 rounded-md border border-dashed border-border-primary p-4"
+    <Collapsible
+      containerClassName="mt-2 flex flex-col gap-4 rounded-md border border-dashed border-border-primary p-4 relative"
+      dropdownContainerClassName="!ml-0"
+      label={t('title.actionLibrary')}
+      labelClassName="!title-text"
+      labelContainerClassName="!py-0"
+      noContentIndent
       ref={actionLibraryRef}
+      tooltip={t('info.actionLibraryDescription')}
     >
-      <div className="flex flex-col items-stretch gap-y-2 gap-x-[calc(1.5rem+1px)] md:flex-row md:items-start md:justify-between">
-        <div className="flex flex-row gap-2 md:w-48">
-          <p className="title-text">{t('title.actionLibrary')}</p>
-          <TooltipInfoIcon
-            size="sm"
-            title={t('info.actionLibraryDescription')}
-          />
-        </div>
-
-        <SearchBar
-          {...searchBarProps}
-          containerClassName="md:w-[6rem] md:focus-within:w-full md:max-w-xs md:ring-[transparent] !duration-300 transition-all md:!ring-0 md:!p-0 md:!pb-1 overflow-hidden"
-          onIconClick={() => searchBarRef.current?.focus()}
-          ref={searchBarRef}
-        />
-      </div>
+      <SearchBar
+        {...searchBarProps}
+        className="text-sm"
+        containerClassName="mb-4 md:mb-0 md:absolute md:top-4 md:right-4 md:w-[6rem] md:focus-within:w-full md:max-w-xs md:ring-[transparent] !duration-300 transition-all md:!ring-0 md:!p-0 md:!pb-1 overflow-hidden"
+        iconClassName="md:!h-6 md:!w-6"
+        onIconClick={() => searchBarRef.current?.focus()}
+        ref={searchBarRef}
+      />
 
       <div className="flex flex-col gap-x-3 gap-y-1 md:flex-row md:items-start">
         <div className="no-scrollbar -mx-4 flex min-w-0 shrink-0 flex-row gap-y-0 overflow-x-auto px-4 pb-2 pt-1 md:w-56 md:flex-col md:pb-1">
@@ -335,7 +334,7 @@ export const ActionLibrary = ({
             ))}
         </div>
       </div>
-    </div>
+    </Collapsible>
   )
 }
 

--- a/packages/stateless/components/actions/ActionLibrary.tsx
+++ b/packages/stateless/components/actions/ActionLibrary.tsx
@@ -37,12 +37,17 @@ export type ActionLibraryProps = {
    * The react-hook-form field name that stores the action data.
    */
   actionDataFieldName: string
+  /**
+   * A callback when an action is selected.
+   */
+  onSelect?: (action: Action) => void
 }
 
 export const ActionLibrary = ({
   categories,
   loadedActions,
   actionDataFieldName,
+  onSelect,
 }: ActionLibraryProps) => {
   const { t } = useTranslation()
 
@@ -55,12 +60,16 @@ export const ActionLibrary = ({
   })
   const actionData = watch(actionDataFieldName as 'actionData') || []
 
+  const onSelectRef = useRef(onSelect)
+  onSelectRef.current = onSelect
   const onSelectAction = useCallback(
     (action: Action) => {
       const loadedAction = loadedActions[action.key]
       if (!loadedAction) {
         return
       }
+
+      onSelectRef.current?.(action)
 
       addAction({
         // See `ActionKeyAndData` comment in

--- a/packages/stateless/components/inputs/SearchBar.tsx
+++ b/packages/stateless/components/inputs/SearchBar.tsx
@@ -5,22 +5,24 @@ import { useTranslation } from 'react-i18next'
 
 export interface SearchBarProps
   extends Omit<ComponentPropsWithoutRef<'input'>, 'type' | 'variant'> {
-  containerClassName?: string
   hideIcon?: boolean
   variant?: 'sm' | 'lg'
   ghost?: boolean
   onIconClick?: () => void
+  iconClassName?: string
+  containerClassName?: string
 }
 
 export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
   function SearchBar(
     {
-      containerClassName,
       className,
       hideIcon,
       variant = 'lg',
       ghost,
       onIconClick,
+      iconClassName,
+      containerClassName,
       ...props
     },
     ref
@@ -46,7 +48,8 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           <Search
             className={clsx(
               '!h-5 !w-5 text-icon-tertiary transition group-focus-within:text-icon-primary',
-              onIconClick && 'cursor-pointer'
+              onIconClick && 'cursor-pointer',
+              iconClassName
             )}
             onClick={onIconClick}
           />

--- a/packages/types/components/Collapsible.ts
+++ b/packages/types/components/Collapsible.ts
@@ -19,5 +19,7 @@ export interface CollapsibleProps {
   containerClassName?: string
   headerClassName?: string
   labelClassName?: string
+  labelContainerClassName?: string
+  dropdownContainerClassName?: string
   contentContainerClassName?: string
 }


### PR DESCRIPTION
When a new action is added to a proposal, it should scroll into view. On mobile, the action library takes up the whole screen, and nothing happens when you click on an entry. Scrolling ensures the user knows something happened.

Also, make the action library collapsible.

<img width="1077" alt="Screenshot 2024-01-24 at 18 01 56" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/4db91aaf-4245-466a-be6d-d7b945be3883">
<img width="1078" alt="Screenshot 2024-01-24 at 18 02 04" src="https://github.com/DA0-DA0/dao-dao-ui/assets/6721426/7f6cc209-833c-4779-9504-8b33847c1d0c">
