### PR TITLE
Fix cw20 vesting creation by using a string amount

### DIFF
--- a/packages/stateful/actions/core/treasury/ManageVesting/index.tsx
+++ b/packages/stateful/actions/core/treasury/ManageVesting/index.tsx
@@ -701,7 +701,7 @@ export const makeManageVestingAction: ActionMaker<ManageVestingData> = (
                     funds: [],
                     msg: {
                       send: {
-                        amount: total,
+                        amount: total.toString(),
                         contract: vestingSource.factory,
                         msg: encodeMessageAsBase64({
                           instantiate_payroll_contract: msg,


### PR DESCRIPTION
![image](https://github.com/DA0-DA0/dao-dao-ui/assets/5104272/d44825a1-7d0c-48ab-849a-3ee7b0a90fed)

Fixes this error, because cw20 messages are sent as a number instead of as a string (Uint128)