### PR TITLE
Fix funds not being sent in prepropose.propose

### DIFF
--- a/packages/stateful/clients/proposal-module/SingleChoiceProposalModule.ts
+++ b/packages/stateful/clients/proposal-module/SingleChoiceProposalModule.ts
@@ -197,15 +197,20 @@ export class SingleChoiceProposalModule extends ProposalModuleBase<
         client,
         sender,
         this.prePropose.address
-      ).propose({
-        msg: {
-          // Type mismatch between Cosmos msgs and Secret Network Cosmos msgs.
-          // The contract execution will fail if the messages are invalid, so
-          // this is safe. The UI should ensure that the co rrect messages are
-          // used for the given chain anyways.
-          propose: data as any,
+      ).propose(
+        {
+          msg: {
+            // Type mismatch between Cosmos msgs and Secret Network Cosmos msgs.
+            // The contract execution will fail if the messages are invalid, so
+            // this is safe. The UI should ensure that the co rrect messages are
+            // used for the given chain anyways.
+            propose: data as any,
+          },
         },
-      })
+        undefined,
+        undefined,
+        funds
+      )
 
       isPreProposeApprovalProposal =
         this.prePropose.contractName === ContractName.PreProposeApprovalSingle


### PR DESCRIPTION
Native proposal deposits were erroring out due to the funds not being sent.

`Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: No funds sent: execute wasm contract failed`

[comment]: <> (don't forget to run `yarn format` from the root :D)
