### PR TITLE
New Feat: Dockerize apps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+package-lock.json
+.git
+.gitignore
+.vscode
+.next
+.turbo

--- a/README.md
+++ b/README.md
@@ -82,13 +82,31 @@ If something is misconfigured, check out the docs for
 | [`types`](./packages/types)         | Types used across packages.                                                                           |
 | [`utils`](./packages/utils)         | Utility functions used across packages.                                                               |
 
-## Docker 
-set the image name & tag. build the image:
 
+
+### Building Docker Images
+
+To create a dockerized image, simply run the following commands:
+
+#### For DAPP
 ```sh
-# Ensure BUILDPLATFORM is set to your machines platform, and TARGETPLATFORM is set for platform intended to run image:
-SDA_IMAGE=da0-da0/dao-app-sda:v0.0.2 DAPP_IMAGE=da0-da0/dao-app-dapp:v0.0.2 docker-compose build --build-arg BUILDPLATFORM=linux/arm64 --build-arg TARGETPLATFORM=linux/amd64
+docker-compose build dapp --build-arg BUILDPLATFORM=linux/arm64 --build-arg TARGETPLATFORM=linux/amd64
 ```
+
+#### For SDA
+```sh
+docker-compose build sda --build-arg BUILDPLATFORM=linux/arm64 --build-arg TARGETPLATFORM=linux/amd64
+```
+
+**Note:** Set the `DAPP_IMAGE` and `SDA_IMAGE` environment variables to your desired image names, e.g.:
+```bash
+DAPP_IMAGE=da0-da0/dao-app-dapp:v0.0.2
+SDA_IMAGE=da0-da0/dao-app-sda:v0.0.2
+```
+
+These commands will build the images for the specified platforms. Just replace `linux/arm64` and `linux/amd64` with your machine's platform and the intended platform for the image, respectively.
+
+***Important:** Please note that building images for cross-platform architectures can take a significant amount of time, as the build process needs to compile and package the image for the target platform. Be patient and let the build process complete. You can grab a cup of coffee or take a short break while you wait!*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -82,23 +82,24 @@ If something is misconfigured, check out the docs for
 | [`types`](./packages/types)         | Types used across packages.                                                                           |
 | [`utils`](./packages/utils)         | Utility functions used across packages.                                                               |
 
-
-
 ### Building Docker Images
 
 To create a dockerized image, simply run the following commands:
 
 #### For DAPP
+
 ```sh
 docker-compose build dapp --build-arg BUILDPLATFORM=linux/arm64 --build-arg TARGETPLATFORM=linux/amd64
 ```
 
 #### For SDA
+
 ```sh
 docker-compose build sda --build-arg BUILDPLATFORM=linux/arm64 --build-arg TARGETPLATFORM=linux/amd64
 ```
 
 **Note:** Set the `DAPP_IMAGE` and `SDA_IMAGE` environment variables to your desired image names, e.g.:
+
 ```bash
 DAPP_IMAGE=da0-da0/dao-app-dapp:v0.0.2
 SDA_IMAGE=da0-da0/dao-app-sda:v0.0.2
@@ -106,7 +107,7 @@ SDA_IMAGE=da0-da0/dao-app-sda:v0.0.2
 
 These commands will build the images for the specified platforms. Just replace `linux/arm64` and `linux/amd64` with your machine's platform and the intended platform for the image, respectively.
 
-***Important:** Please note that building images for cross-platform architectures can take a significant amount of time, as the build process needs to compile and package the image for the target platform. Be patient and let the build process complete. You can grab a cup of coffee or take a short break while you wait!*
+**\*Important:** Please note that building images for cross-platform architectures can take a significant amount of time, as the build process needs to compile and package the image for the target platform. Be patient and let the build process complete. You can grab a cup of coffee or take a short break while you wait!\*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ SDA_IMAGE=da0-da0/dao-app-sda:v0.0.2
 
 These commands will build the images for the specified platforms. Just replace `linux/arm64` and `linux/amd64` with your machine's platform and the intended platform for the image, respectively.
 
-**\*Important:** Please note that building images for cross-platform architectures can take a significant amount of time, as the build process needs to compile and package the image for the target platform. Be patient and let the build process complete. You can grab a cup of coffee or take a short break while you wait!\*
+**Important:** Please note that building images for cross-platform architectures can take a significant amount of time, as the build process needs to compile and package the image for the target platform. Be patient and let the build process complete. You can grab a cup of coffee or take a short break while you wait!
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ If something is misconfigured, check out the docs for
 | [`types`](./packages/types)         | Types used across packages.                                                                           |
 | [`utils`](./packages/utils)         | Utility functions used across packages.                                                               |
 
+## Docker 
+set the image name & tag. build the image:
+
+```sh
+# Ensure BUILDPLATFORM is set to your machines platform, and TARGETPLATFORM is set for platform intended to run image:
+SDA_IMAGE=da0-da0/dao-app-sda:v0.0.2 DAPP_IMAGE=da0-da0/dao-app-dapp:v0.0.2 docker-compose build --build-arg BUILDPLATFORM=linux/arm64 --build-arg TARGETPLATFORM=linux/amd64
+```
+
 ## Contributing
 
 Interested in contributing to DAO DAO? Check out

--- a/akash-deploy.sdl
+++ b/akash-deploy.sdl
@@ -1,0 +1,59 @@
+---
+version: "2.0"
+services:
+  dapp:
+    image: da0-da0/dao-app-dapp:v0.0.2
+    expose:
+      - port: 3000
+        as: 80
+        accept:
+          - daodao.zone
+          - www.daodao.zone
+        to:
+          - global: true
+  sda:
+    image: da0-da0/dao-app-sda:v0.0.2
+    expose:
+      - port: 3000
+        as: 80
+        accept:
+          - sda.daodao.zone
+          - www.sda.daodao.zone
+        to:
+          - global: true
+profiles:
+  compute:
+    dapp:
+      resources:
+        cpu:
+          units: 4
+        memory:
+          size: 16GB
+        storage:
+          - size: 120GB
+    sda:
+      resources:
+        cpu:
+          units: 4
+        memory:
+          size: 16GB
+        storage:
+          - size: 120GB
+  placement:
+    dcloud:
+      pricing:
+        dapp:
+          denom: uakt
+          amount: 10000
+        sda:
+          denom: uakt
+          amount: 10000
+deployment:
+  dapp:
+    dcloud:
+      profile: dapp
+      count: 1
+  sda:
+    dcloud:
+      profile: sda
+      count: 1

--- a/apps/dapp/.dockerignore
+++ b/apps/dapp/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+package-lock.json
+.git
+.gitignore
+.vscode
+.turbo

--- a/apps/dapp/Dockerfile
+++ b/apps/dapp/Dockerfile
@@ -1,0 +1,30 @@
+# Use the official Node.js image as the base
+FROM node:18
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy env variables
+COPY ./apps/dapp/.env.testnet .
+
+# Copy the package.json and yarn.lock files
+COPY package*.json yarn.lock ./
+
+# Install the workspace dependencies using yarn first
+RUN yarn install
+
+# Copy entire repo into the docker container
+COPY . .
+
+# Change to the apps/dapp directory
+WORKDIR /app/apps/dapp
+
+# Install the dependencies specifically for dapp
+RUN yarn install --network-timeout 900000
+
+# Build the SDA, make sure build doesnt crash 
+ENV NODE_OPTIONS=--max_old_space_size=8192
+
+# default
+RUN yarn build 
+EXPOSE 3000
+CMD ["yarn", "run", "start"]

--- a/apps/dapp/Dockerfile
+++ b/apps/dapp/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app/apps/dapp
 # Install the dependencies specifically for dapp
 RUN yarn install --network-timeout 900000
 
-# Build the SDA, make sure build doesnt crash 
+# Build the DAPP, make sure build doesnt crash 
 ENV NODE_OPTIONS=--max_old_space_size=8192
 
 # default

--- a/apps/sda/.dockerignore
+++ b/apps/sda/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+package-lock.json
+.git
+.gitignore
+.vscode
+.turbo

--- a/apps/sda/Dockerfile
+++ b/apps/sda/Dockerfile
@@ -1,0 +1,30 @@
+# Use the official Node.js image as the base
+FROM node:18
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy env variables
+COPY ./apps/sda/.env.testnet .
+
+# Copy the package.json and yarn.lock files
+COPY package*.json yarn.lock ./
+
+# Install the workspace dependencies using yarn first
+RUN yarn install
+
+# Copy entire repo into the docker container
+COPY . .
+
+# Change to the apps/sda directory
+WORKDIR /app/apps/sda
+
+# Install the dependencies specifically for sda
+RUN yarn install --network-timeout 900000
+
+# Build the SDA, make sure build doesnt crash 
+ENV NODE_OPTIONS=--max_old_space_size=8192
+
+# default
+RUN yarn build 
+EXPOSE 3000
+CMD ["yarn", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         - BUILDPLATFORM
         - TARGETPLATFORM
-    image: ${IMAGE_NAME}
+    image: ${SDA_IMAGE}
     platform: linux/amd64
   dapp:
     build:
@@ -15,5 +15,5 @@ services:
       args:
         - BUILDPLATFORM
         - TARGETPLATFORM
-    image: ${IMAGE_NAME}
+    image: ${DAPP_IMAGE}
     platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  sda:
+    build:
+      context: .
+      dockerfile: apps/sda/Dockerfile
+      args:
+        - BUILDPLATFORM
+        - TARGETPLATFORM
+    image: ${IMAGE_NAME}
+    platform: linux/amd64
+  dapp:
+    build:
+      context: .
+      dockerfile: apps/dapp/Dockerfile
+      args:
+        - BUILDPLATFORM
+        - TARGETPLATFORM
+    image: ${IMAGE_NAME}
+    platform: linux/amd64


### PR DESCRIPTION
Docker images can be built with:
- sda image: `SDA_IMAGE=da0-da0/dao-app-sda:v0.0.2`
- dapp image: `DAPP_IMAGE=da0-da0/dao-app-dapp:v0.0.2`

*Compiling the images seem to require at minimum 16GB RAM, & 50GB of storage.*

on ARM platform:
`docker-compose build --build-arg BUILDPLATFORM=linux/arm64 --build-arg TARGETPLATFORM=linux/amd64`

on AMD platform: 
`docker-compose build --build-arg BUILDPLATFORM=linux/amd64 --build-arg TARGETPLATFORM=linux/amd64`


## Akash SDL
There is also an example of an SDL file that can be referenced for deploying both app images (dapp & sda) on machines rented via the permissioneess compute market on Akash. 
