### PR TITLE
Add a contract_info query fallback for newer cw721 contract variants

### DIFF
--- a/packages/state/contracts/Cw721Base.ts
+++ b/packages/state/contracts/Cw721Base.ts
@@ -221,9 +221,19 @@ export class Cw721BaseQueryClient implements Cw721BaseReadOnlyInterface {
     })
   }
   contractInfo = async (): Promise<ContractInfoResponse> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      contract_info: {},
-    })
+    try {
+      return await this.client.queryContractSmart(this.contractAddress, {
+        contract_info: {},
+      })
+    } catch {
+      // Newer cw721 contracts deprecated contract_info in favor of
+      // get_collection_info_and_extension.
+      const response = await this.client.queryContractSmart(
+        this.contractAddress,
+        { get_collection_info_and_extension: {} }
+      )
+      return { name: response.name, symbol: response.symbol }
+    }
   }
   nftInfo = async ({
     tokenId,


### PR DESCRIPTION
A small change to add a fallback to cover new cw721 contract variants in case the initial `contract_info` query fails. 

Newer cw721 contracts created for migrating collections from Stargaze to Cosmos Hub do not support the `contract_info` query (marked as deprecated on cw721-base v0.19 and on) and replace it with a `get_collection_info_and_extension` query instead. The change results in an error when trying to create an NFT-based DAO. The `get_collection_info_and_extension` response extends the `contract_info` response and includes the `name` and `symbol` information needed by the DAODAO UI.