### PR TITLE
chore: update Thorchain/Rujira RPC and REST endpoints to Liquify gateway

### DIFF
--- a/packages/utils/constants/chains.ts
+++ b/packages/utils/constants/chains.ts
@@ -720,8 +720,8 @@ export const CHAIN_ENDPOINTS: Partial<
     rest: 'https://babylon-testnet-api.polkachu.com',
   },
   [ChainId.ThorchainMainnet]: {
-    rpc: 'https://rpc.ninerealms.com',
-    rest: 'https://thornode.ninerealms.com',
+    rpc: 'https://gateway.liquify.com/chain/thorchain_rpc',
+    rest: 'https://gateway.liquify.com/chain/thorchain_api',
   },
   [ChainId.ThorchainStagenet]: {
     rpc: 'https://stagenet-rpc.ninerealms.com',

--- a/packages/utils/constants/registry.ts
+++ b/packages/utils/constants/registry.ts
@@ -119,12 +119,12 @@ const thorchainMainnetChainRegistry = chains.find(
 thorchainMainnetChainRegistry.apis = {
   rpc: [
     {
-      address: 'https://thornode-mainnet-rpc.bryanlabs.net',
+      address: 'https://gateway.liquify.com/chain/thorchain_rpc',
     },
   ],
   rest: [
     {
-      address: 'https://thornode-mainnet-api.bryanlabs.net',
+      address: 'https://gateway.liquify.com/chain/thorchain_api',
     },
   ],
 }


### PR DESCRIPTION
Updates Thorchain mainnet RPC and REST endpoints to use Liquify gateway.

## Changes

**registry.ts** - Chain registry API endpoints:
- RPC: `https://gateway.liquify.com/chain/thorchain_rpc`
- REST: `https://gateway.liquify.com/chain/thorchain_api`

**chains.ts** - Preferred chain endpoints:
- RPC: `https://gateway.liquify.com/chain/thorchain_rpc`
- REST: `https://gateway.liquify.com/chain/thorchain_api`

Replaces the previous bryanlabs.net and ninerealms.com endpoints.