### PR TITLE
Add Solid Protocol to apps list (Terra)

### DIFF
--- a/packages/utils/constants/apps.ts
+++ b/packages/utils/constants/apps.ts
@@ -79,6 +79,14 @@ export const APPS: App[] = [
     },
   },
   {
+    name: 'Solid Protocol',
+    imageUrl: 'https://app.solidcapa.com/logo.svg',
+    url: 'https://app.solidcapa.com',
+    chainIdFilter: {
+      include: [ChainId.TerraMainnet],
+    },
+  },
+  {
     name: 'Calculated Finance',
     imageUrl: '/apps/calcfi.jpg',
     url: 'https://app.calculated.fi/?chain=osmosis-1',


### PR DESCRIPTION
## Summary

Adds [Solid Protocol](https://app.solidcapa.com) to the apps list for Terra Mainnet (ChainId.TerraMainnet).

Solid Protocol is a decentralized lending and stablecoin protocol on Terra Phoenix-1. Users deposit collateral (ampLUNA, CAPA, LP tokens, etc.) to borrow SOLID — a USD-pegged stablecoin — or stake CAPA in governance.

## Why add it

Terra DAOs using DAODAO can now use treasury funds to:
- 📥 Deposit collateral and borrow SOLID stablecoin
- 🏛️ Stake CAPA in protocol governance
- 💰 Use SOLID as a stablecoin treasury asset
- 🔮 Participate in the CAPA Crystals NFT ecosystem (currently minting)

This fills a gap — currently DAODAO has Mars Protocol, Astroport, and Stargaze for general Cosmos/Osmosis-centric chains, but the first lending + stablecoin option specifically for Terra DAOs.

## Change

Single entry added to `packages/utils/constants/apps.ts`:

```ts
{
  name: 'Solid Protocol',
  imageUrl: 'https://app.solidcapa.com/logo.svg',
  url: 'https://app.solidcapa.com',
  chainIdFilter: {
    include: [ChainId.TerraMainnet],
  },
},
```

## Links

- App: https://app.solidcapa.com
- Landing: https://solidcapa.com
- Twitter: https://twitter.com/solid_capa
- GitHub: https://github.com/solid-online

Happy to swap the image to a PNG/JPG if preferred — the current SVG logo is served from our production domain.

## Test plan

- [x] Verified app URL loads (https://app.solidcapa.com)
- [x] Verified logo URL returns HTTP 200
- [x] TypeScript compiles cleanly locally
- [x] ChainId.TerraMainnet exists in chain registry config