### PR TITLE
Add Atrium to apps list (Terra)

### DIFF
--- a/packages/utils/constants/apps.ts
+++ b/packages/utils/constants/apps.ts
@@ -87,6 +87,14 @@ export const APPS: App[] = [
     },
   },
   {
+    name: 'Atrium',
+    imageUrl: 'https://atrium.markets/img/atrium-favicon.svg',
+    url: 'https://atrium.markets',
+    chainIdFilter: {
+      include: [ChainId.TerraMainnet],
+    },
+  },
+  {
     name: 'Calculated Finance',
     imageUrl: '/apps/calcfi.jpg',
     url: 'https://app.calculated.fi/?chain=osmosis-1',


### PR DESCRIPTION
## Summary

Adds [Atrium](https://atrium.markets) to the apps list for Terra Mainnet (`ChainId.TerraMainnet`).

Atrium is an audit-first NFT marketplace on Terra Phoenix-1. 12-second atomic settlement, open-source contracts, 1.5% fee for holders, 0% for top-tier holders. Currently in curated-collection beta with CAPA Crystals, Scandalous Birds, and The Backroom · Quarters tradable; additional collections unlock as contracts complete independent audit.

## Why add it

Terra DAOs using DAODAO can now use treasury funds to:

- 🖼️ List, buy and sell NFTs from allowlisted Terra collections
- 💱 Settle in SOLID, LUNA, USDC, CAPA or ampCAPA via the multi-denom marketplace
- 🎁 Run on-chain raffles, giveaways and airdrops for community NFTs
- 🔒 Acquire TLA Locks (veLUNA escrow NFTs) directly on the open market

Pairs cleanly with the existing Solid Protocol entry — Solid handles the lending side of the Terra DAO toolkit, Atrium handles the NFT side.

## Change

Single entry added to `packages/utils/constants/apps.ts`, placed next to the existing Solid Protocol entry since both filter on `ChainId.TerraMainnet`:

\`\`\`ts
{
  name: 'Atrium',
  imageUrl: 'https://atrium.markets/img/atrium-favicon.svg',
  url: 'https://atrium.markets',
  chainIdFilter: {
    include: [ChainId.TerraMainnet],
  },
},
\`\`\`

## Links

- App: https://atrium.markets
- Twitter: https://twitter.com/solid_capa
- Sibling app already in the list: Solid Protocol (#1849)

Happy to swap the SVG icon for PNG/JPG if preferred — the current favicon is served from the production domain over HTTPS with permissive CORS.

## Test plan

- [x] Verified app URL loads (https://atrium.markets returns 200)
- [x] Verified icon URL returns HTTP 200 (https://atrium.markets/img/atrium-favicon.svg)
- [x] `ChainId.TerraMainnet` already exists in chain registry config (used by Solid Protocol entry directly above)
- [x] TypeScript compiles cleanly locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)