### PR TITLE
Add The Backroom · Quarters to apps list (Terra)

### DIFF
--- a/packages/utils/constants/apps.ts
+++ b/packages/utils/constants/apps.ts
@@ -87,6 +87,14 @@ export const APPS: App[] = [
     },
   },
   {
+    name: 'The Backroom · Quarters',
+    imageUrl: 'https://the-backroom.xyz/apple-touch-icon.svg',
+    url: 'https://the-backroom.xyz/marketplace',
+    chainIdFilter: {
+      include: [ChainId.TerraMainnet],
+    },
+  },
+  {
     name: 'Calculated Finance',
     imageUrl: '/apps/calcfi.jpg',
     url: 'https://app.calculated.fi/?chain=osmosis-1',


### PR DESCRIPTION
## Summary

Adds [The Backroom · Quarters](https://the-backroom.xyz) to the apps list for Terra Mainnet (`ChainId.TerraMainnet`).

The Backroom · Quarters is a 2,500-NFT collection of vintage arcade cabinets on Terra Phoenix-1. Mint opens **12 May 2026, 19:00 UTC** — 50 USDC per Quarter, weighted-random tier (Brass 2000 / Silver 400 / Gold 95 / **Phoenix 5**). Mint window stays open until sold out. CW721 v0.18 contract with the cw2981 royalty extension (5%) for secondary sales.

## Why add it

Terra DAOs using DAODAO can now use treasury funds to:

- 🕹️ Mint Quarters directly from the DAO during the active window (50 USDC each, payable via Noble USDC on Terra2)
- 🖼️ Browse the live floor and per-Quarter detail pages
- 🎮 Access the wallet-gated lounge where holders compete on per-game leaderboards (eight playable arcade games)

The marketplace surface at `/marketplace` is purpose-built for iframe embedding — no intro animation, full mint + browse UI, no Web3 dependencies beyond the wallet adapter (Keplr / Vultisig) already supported on Terra.

## Verification

- Live: <https://the-backroom.xyz>
- Marketplace surface (the app URL added here): <https://the-backroom.xyz/marketplace>
- CW721 contract: `terra16qk8sry8ej9xw98e0l37wrf9lsflgvgd0hqdw595m0hclzw8yvaqpk0zma`
- Minter contract: `terra1ja3zz20z6wc9at4radmnrnjjmryygq44760dsjqg9fcyhlvgeh3q5hnre7`
- Icon: <https://the-backroom.xyz/apple-touch-icon.svg> (180×180 SVG, dark theme)

Same submission pattern as #1849 (Solid Protocol, merged) and #1850 (Atrium, open).