### PR TITLE
Add Sundial to apps list (Terra)

### DIFF
--- a/packages/utils/constants/apps.ts
+++ b/packages/utils/constants/apps.ts
@@ -103,6 +103,14 @@ export const APPS: App[] = [
     },
   },
   {
+    name: 'Sundial',
+    imageUrl: 'https://sundial.markets/logo.svg',
+    url: 'https://sundial.markets',
+    chainIdFilter: {
+      include: [ChainId.TerraMainnet],
+    },
+  },
+  {
     name: 'Calculated Finance',
     imageUrl: '/apps/calcfi.jpg',
     url: 'https://app.calculated.fi/?chain=osmosis-1',


### PR DESCRIPTION
Add **Sundial** — Terra² identity service (`*.luna` names) — to the cross-chain apps list, filtered to Terra Mainnet.

Live at [sundial.markets](https://sundial.markets) on phoenix-1. Mirrors the pattern used for Solid Protocol (#1849), Atrium (#1850) and The Backroom (#1851).