### PR TITLE
Undo Neutron chain governance redirect

### DIFF
--- a/packages/utils/chains.test.ts
+++ b/packages/utils/chains.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+
+import { ChainId } from '@dao-dao/types'
+
+import { getSupportedChainConfig } from './chain'
+
+test('Neutron chains do not redirect chain governance to a DAO contract', () => {
+  expect(
+    getSupportedChainConfig(ChainId.NeutronMainnet)?.govContractAddress
+  ).toBeUndefined()
+  expect(
+    getSupportedChainConfig(ChainId.NeutronTestnet)?.govContractAddress
+  ).toBeUndefined()
+})

--- a/packages/utils/constants/chains.ts
+++ b/packages/utils/constants/chains.ts
@@ -16,7 +16,6 @@ import {
 import { NftBasedCreatorId } from './adapters'
 import _ALL_CODE_HASHES from './codeHashes.json'
 import _ALL_CODE_IDS from './codeIds.json'
-import { NEUTRON_GOVERNANCE_DAO } from './env'
 import { TEST_ENV } from './other'
 import _ALL_POLYTONE from './polytone.json'
 import { chains, convertChainRegistryChainToAnyChain } from './registry'
@@ -111,7 +110,6 @@ const BASE_SUPPORTED_CHAINS: Omit<
         accentColor: '#000000',
         factoryContractAddress:
           'neutron1asszs9mjglv2rzpeu8fzlsa0cy55th0jkv27hsw3ulddt7f74gpsrqhatg',
-        govContractAddress: NEUTRON_GOVERNANCE_DAO,
         subDaos: [
           'neutron1fuyxwxlsgjkfjmxfthq8427dm2am3ya3cwcdr8gls29l7jadtazsuyzwcc',
           'neutron1zjdv3u6svlazlydmje2qcp44yqkt0059chz8gmyl5yrklmgv6fzq9chelu',
@@ -399,7 +397,6 @@ const BASE_SUPPORTED_CHAINS: Omit<
         accentColor: '#000000',
         factoryContractAddress:
           'neutron1caflev8smuslum9uque5z2qhma8xxxmap5dafeynekl37s966k8sq034r4',
-        govContractAddress: NEUTRON_GOVERNANCE_DAO,
         explorerUrlTemplates: {
           tx: 'https://neutron.celat.one/pion-1/txs/REPLACE',
           wallet: 'https://neutron.celat.one/pion-1/accounts/REPLACE',


### PR DESCRIPTION
## Summary
- Removed the Neutron mainnet/testnet `govContractAddress` overrides so configured-chain governance falls through to the native x/gov DAO path.
- Preserved unrelated Neutron-specific configuration, including factory contracts, subDAOs, explorer URLs, deployment/polytone/account/action behavior, and actual Neutron governance DAO UI handling.
- Added a focused utils regression test asserting Neutron mainnet/testnet no longer configure a governance DAO redirect.

## Neutron usage review
- Chain governance redirect/special handling was the `govContractAddress: NEUTRON_GOVERNANCE_DAO` configuration for `ChainId.NeutronMainnet` and `ChainId.NeutronTestnet` in `packages/utils/constants/chains.ts`; both entries were removed.
- Remaining `ChainId.NeutronMainnet` / `ChainId.NeutronTestnet` and `NEUTRON_GOVERNANCE_DAO` usages were reviewed and are unrelated Neutron-specific behavior or UI handling for the actual DAO, so they were left intact.

## Validation
- `pnpm --filter @dao-dao/utils test -- chains.test.ts`
- `pnpm --filter @dao-dao/utils lint`
