### PR TITLE
Remove Neutron subDAO chain entries

### DIFF
--- a/packages/stateful/actions/core/actions/GovernanceProposal/index.tsx
+++ b/packages/stateful/actions/core/actions/GovernanceProposal/index.tsx
@@ -20,14 +20,12 @@ import {
   useCachedLoadingWithError,
 } from '@dao-dao/stateless'
 import {
-  AccountType,
   ActionComponent,
   ActionComponentProps,
   ActionContextType,
   ActionKey,
   ActionMatch,
   ActionOptions,
-  ChainId,
   GOVERNANCE_PROPOSAL_TYPES,
   GovProposalVersion,
   GovernanceProposalActionData,
@@ -281,19 +279,7 @@ export class GovernanceProposalAction extends ActionBase<GovernanceProposalActio
       description: options.t('info.submitGovernanceProposalDescription'),
     })
 
-    const defaultChainId =
-      // Neutron does not use the x/gov module. If this is a DAO on Neutron, see
-      // if it has polytone accounts on any other chain. If it does, default to
-      // one of them. Otherwise, hide the action since it cannot be used.
-      options.chain.chainId === ChainId.NeutronMainnet ||
-      options.chain.chainId === ChainId.NeutronTestnet
-        ? options.context.type === ActionContextType.Dao
-          ? options.context.dao.accounts.find(
-              (a) => a.type === AccountType.Polytone
-            )?.chainId
-          : undefined
-        : // If not on Neutron, default to current chain.
-          options.chain.chainId
+    const defaultChainId = options.chain.chainId
 
     if (!defaultChainId) {
       throw new Error('Could not find chain to vote on.')

--- a/packages/utils/chains.test.ts
+++ b/packages/utils/chains.test.ts
@@ -12,3 +12,12 @@ test('Neutron chains do not redirect chain governance to a DAO contract', () => 
     getSupportedChainConfig(ChainId.NeutronTestnet)?.govContractAddress
   ).toBeUndefined()
 })
+
+test('Neutron chains do not include subDAO entries', () => {
+  expect(
+    getSupportedChainConfig(ChainId.NeutronMainnet)?.subDaos
+  ).toBeUndefined()
+  expect(
+    getSupportedChainConfig(ChainId.NeutronTestnet)?.subDaos
+  ).toBeUndefined()
+})

--- a/packages/utils/constants/chains.ts
+++ b/packages/utils/constants/chains.ts
@@ -110,10 +110,6 @@ const BASE_SUPPORTED_CHAINS: Omit<
         accentColor: '#000000',
         factoryContractAddress:
           'neutron1asszs9mjglv2rzpeu8fzlsa0cy55th0jkv27hsw3ulddt7f74gpsrqhatg',
-        subDaos: [
-          'neutron1fuyxwxlsgjkfjmxfthq8427dm2am3ya3cwcdr8gls29l7jadtazsuyzwcc',
-          'neutron1zjdv3u6svlazlydmje2qcp44yqkt0059chz8gmyl5yrklmgv6fzq9chelu',
-        ],
         explorerUrlTemplates: {
           tx: 'https://neutron.celat.one/neutron-1/txs/REPLACE',
           wallet: 'https://neutron.celat.one/neutron-1/accounts/REPLACE',


### PR DESCRIPTION
## Summary
- Remove Neutron mainnet subDAO entries from the supported chain definition while leaving other Neutron config intact.
- Add a regression test that Neutron mainnet/testnet configs have no `subDaos` and retain no `govContractAddress` redirect.
- Default governance proposal actions to the current chain so Neutron continues using native x/gov after the redirect removal.

## Validation
- `pnpm test packages/utils/chains.test.ts --run`
- `pnpm utils lint`
- `pnpm stateful lint`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm stateful build`
