### PR TITLE
Re-enable Neutron governance staking action

### DIFF
--- a/packages/stateful/actions/core/actions/ManageStaking/index.test.ts
+++ b/packages/stateful/actions/core/actions/ManageStaking/index.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { ChainId } from '@dao-dao/types'
+
+import { isManageStakingAllowedInGovContext } from './utils'
+
+describe('isManageStakingAllowedInGovContext', () => {
+  it('allows Neutron mainnet and testnet chain governance to manage staking', () => {
+    expect(isManageStakingAllowedInGovContext(ChainId.NeutronMainnet)).toBe(
+      true
+    )
+    expect(isManageStakingAllowedInGovContext(ChainId.NeutronTestnet)).toBe(
+      true
+    )
+  })
+
+  it('keeps the existing chain governance staking guard for other chains', () => {
+    expect(isManageStakingAllowedInGovContext(ChainId.CosmosHubMainnet)).toBe(
+      false
+    )
+  })
+})

--- a/packages/stateful/actions/core/actions/ManageStaking/index.tsx
+++ b/packages/stateful/actions/core/actions/ManageStaking/index.tsx
@@ -65,6 +65,7 @@ import {
   ManageStakingComponent as StatelessManageStakingComponent,
   getStakeActions,
 } from './Component'
+import { isManageStakingAllowedInGovContext } from './utils'
 
 const InnerComponent: ActionComponent = (props) => {
   const { t } = useTranslation()
@@ -272,8 +273,13 @@ export class ManageStakingAction extends ActionBase<ManageStakingData> {
   public readonly Component = Component
 
   constructor(options: ActionOptions) {
-    // x/gov cannot stake.
-    if (options.context.type === ActionContextType.Gov) {
+    // Neutron now uses native x/gov for chain governance, and its governance
+    // module can execute staking messages. Keep the historical x/gov guard for
+    // other chains until they are explicitly verified.
+    if (
+      options.context.type === ActionContextType.Gov &&
+      !isManageStakingAllowedInGovContext(options.chain.chainId)
+    ) {
       throw new Error('Chain governance cannot stake assets')
     }
 

--- a/packages/stateful/actions/core/actions/ManageStaking/utils.ts
+++ b/packages/stateful/actions/core/actions/ManageStaking/utils.ts
@@ -1,0 +1,4 @@
+import { ChainId } from '@dao-dao/types'
+
+export const isManageStakingAllowedInGovContext = (chainId: string) =>
+  chainId === ChainId.NeutronMainnet || chainId === ChainId.NeutronTestnet


### PR DESCRIPTION
## Summary
- Re-enable Manage Staking for Neutron mainnet/testnet chain-governance action contexts by allowlisting Neutron through the existing x/gov constructor guard.
- Preserve the existing chain-governance staking guard for non-Neutron chains until those x/gov staking capabilities are separately verified.
- Add focused tests for the Neutron chain-governance allowlist helper.

## Neutron gates reviewed
- Manage Staking x/gov context guard: updated for Neutron mainnet/testnet.
- Community Pool Deposit x/distribution block: preserved because Neutron does not use the x/distribution community pool.
- Neutron SubDAO pause/overrule actions: preserved as Neutron-fork DAO behavior.
- Rebalancer actions and Spend Neutron transfer-fee handling: preserved as unrelated valid Neutron-specific behavior.
- GovActionsProvider ICA include: preserved for Valence account loading.

## Validation
- pnpm --filter @dao-dao/stateful test actions/core/actions/ManageStaking/index.test.ts --run
- pnpm --filter @dao-dao/stateful lint
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @dao-dao/stateful build
